### PR TITLE
Fix Issue #21 - Ignore HTTP 4xx on Tornado

### DIFF
--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -1,4 +1,5 @@
 from tornado.web import RequestHandler
+from tornado.web import HTTPError
 import bugsnag
 
 
@@ -15,11 +16,21 @@ class BugsnagRequestHandler(RequestHandler):
             },
         )
 
-        # Notify bugsnag
-        bugsnag.notify(exc)
+        # Notify bugsnag, unless it's an HTTPError that we specifically want to ignore
+        should_notify_bugsnag = True
+        if type(exc) == HTTPError:
+            ignore_status_codes = self.bugsnag_ignore_status_codes()
+            if ignore_status_codes and exc.status_code in ignore_status_codes:
+                should_notify_bugsnag = False
+        if should_notify_bugsnag:
+            bugsnag.notify(exc)
 
         # Call the parent handler
         RequestHandler._handle_request_exception(self, exc)
 
     def _get_context(self):
         return "%s %s" % (self.request.method, self.request.uri.split('?')[0])
+
+    def bugsnag_ignore_status_codes(self):
+        # Subclasses can override to add or remove codes
+        return [401, 403]


### PR DESCRIPTION
By default, don't notify about HTTPErrors with status code 401 or 403

BugsnagRequestHandler subclasses can override bugsnag_ignore_status_codes to modify the behavior
