### PR TITLE
middleware,django/init: respect the context passed to #notify

### DIFF
--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -10,7 +10,7 @@ def add_django_request_to_notification(notification):
         return
 
     request = notification.request_config.django_request
-
+    context = notification.context
     notification.context = request.path
 
     if hasattr(request, 'user') and request.user.is_authenticated():
@@ -23,11 +23,14 @@ def add_django_request_to_notification(notification):
     else:
         notification.set_user(id=request.META['REMOTE_ADDR'])
 
-    route = resolve(request.path_info)
-    if route:
-        notification.context = route.url_name
+    if context:
+        notification.context = context
     else:
-        notification.context = "%s %s" % (request.method, request.path_info)
+        route = resolve(request.path_info)
+        if route:
+            notification.context = route.url_name
+        else:
+            notification.context = "%s %s" % (request.method, request.path_info)
 
     notification.add_tab("session", dict(request.session))
     notification.add_tab("request", {

--- a/bugsnag/middleware.py
+++ b/bugsnag/middleware.py
@@ -32,7 +32,9 @@ class DefaultMiddleware(object):
         notification.set_user(id=notification.request_config.user_id)
         notification.set_user(**notification.request_config.user)
         notification.grouping_hash = notification.request_config.get("grouping_hash")
-        notification.context = notification.request_config.get("context")
+
+        if not notification.context:
+            notification.context = notification.request_config.get("context")
 
         for name, dictionary in notification.request_config.meta_data.items():
             notification.add_tab(name, dictionary)
@@ -116,4 +118,3 @@ class MiddlewareStack(object):
             bugsnag.log("Error in exception middleware: %s" % exc)
             # still notify if middleware crashes before notification
             finish(notification)
-


### PR DESCRIPTION
The problem was that when you pass context to notify like this

```
bugsnag.notify(Exception("Something broke!"), context="myContext")
```

Then it's being overwrited by the value for the request_config.

Probably, grouping_hash has the similar issue.
