### PR TITLE
Print exception during failed handling

### DIFF
--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import traceback
 
 from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.notification import Notification


### PR DESCRIPTION
This fixes two issues.  One is that what was previousy line 48 (now 49) of `bugsnag/__init__.py` was calling traceback.format_exc(), but the traceback module was never imported.  The second is that if there is an error in the bugsnag exception handler, we definitely want to print a traceback for debugging.
