### PR TITLE
fixing NameError in bugsnag.notify exception when bugsnag.log is called

### DIFF
--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -45,7 +45,7 @@ def notify(exception, **options):
                         RequestConfiguration.get_instance(), **options).deliver()
     except Exception:
         try:
-            bugsnag.log("Notification failed")
+            log("Notification failed")
             print((traceback.format_exc()))
         except Exception:
             print(("[BUGSNAG] error in exception handler"))


### PR DESCRIPTION
Error squashes all other errors because bugsnag is not defined as a global here. log() is available after __init__.py fires by the time notify would be called.