### PR TITLE
Use GET and POST in place of deprecated REQUEST

### DIFF
--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -31,7 +31,8 @@ def add_django_request_to_notification(notification):
     notification.add_tab("request", {
         'path': request.path,
         'encoding': request.encoding,
-        'params': dict(request.REQUEST),
+        'GET': dict(request.GET),
+        'POST': dict(request.POST),
         'url': request.build_absolute_uri(),
     })
     notification.add_tab("environment", dict(request.META))


### PR DESCRIPTION
Replaces the existing params element in the request tab with `GET` and `POST` properties. Exposes a potential shadowing bug where a property key existed in both the POST body and GET parameters but only one was shown.


Fixes #65