### PR TITLE
Derive Django example views from imported list instead of strings

### DIFF
--- a/example/django/bugsnag_demo/urls.py
+++ b/example/django/bugsnag_demo/urls.py
@@ -1,11 +1,13 @@
 from django.conf.urls import patterns, include, url
+from demo.views import (index, crash, crash_with_callback, severity, notify,
+                        context, notify_meta)
 
 urlpatterns = patterns('',
-    url(r'^$', 'demo.views.index'),
-    url(r'^crash/$', 'demo.views.crash'),
-    url(r'^crash_with_callback/$', 'demo.views.crash_with_callback'),
-    url(r'^notify/$', 'demo.views.notify'),
-    url(r'^notify_meta/$', 'demo.views.notify_meta'),
-    url(r'^context/$', 'demo.views.context'),
-    url(r'^severity/$', 'demo.views.severity'),
+    url(r'^$', index),
+    url(r'^crash/$', crash),
+    url(r'^crash_with_callback/$', crash_with_callback),
+    url(r'^notify/$', notify),
+    url(r'^notify_meta/$', notify_meta),
+    url(r'^context/$', context),
+    url(r'^severity/$', severity),
 )

--- a/example/django/bugsnag_demo/urls.py
+++ b/example/django/bugsnag_demo/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import url
 from demo.views import (index, crash, crash_with_callback, severity, notify,
                         context, notify_meta)
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', index),
     url(r'^crash/$', crash),
     url(r'^crash_with_callback/$', crash_with_callback),
@@ -10,4 +10,4 @@ urlpatterns = patterns('',
     url(r'^notify_meta/$', notify_meta),
     url(r'^context/$', context),
     url(r'^severity/$', severity),
-)
+]

--- a/example/django/requirements.txt
+++ b/example/django/requirements.txt
@@ -1,3 +1,3 @@
-Django>=1.6
+Django>=1.8
 bugsnag>=2.2
 markdown>=2.4


### PR DESCRIPTION
Fixes some deprecation warnings regarding the use of a list of strings for view names