### PR TITLE
Group tests in a more standard structure, add code style linting

### DIFF
--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -39,11 +39,8 @@ def sanitize_object(obj, **kwargs):
         try:
             if six.PY3 and isinstance(obj, bytes):
                 string = six.text_type(obj, encoding='utf-8', errors='replace')
-            elif six.PY3 or hasattr(obj, '__unicode__'):
-                string = six.text_type(obj)
             else:
-                b = bytes(obj)
-                string = six.text_type(b, encoding='utf-8', errors='replace')
+                string = six.text_type(obj)
 
         except Exception:
             exc = traceback.format_exc()

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 LINT_TMP=`mktemp -t lint.XXXXXX`
-flake8 bugsnag > $LINT_TMP
+flake8 bugsnag tests > $LINT_TMP
 if [ -s $LINT_TMP ]; then
     cat $LINT_TMP
     exit 1

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 try:
     import sys; raise Exception("start")
 except Exception: start_of_file = sys.exc_info()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,8 +2,6 @@ import os
 import socket
 import unittest
 
-from nose.tools import eq_
-
 from bugsnag.configuration import Configuration
 
 
@@ -13,24 +11,24 @@ class TestConfiguration(unittest.TestCase):
         # Test default endpoint with ssl
         c = Configuration()
         c.use_ssl = True
-        eq_(c.get_endpoint(), "https://notify.bugsnag.com")
+        self.assertEqual(c.get_endpoint(), "https://notify.bugsnag.com")
 
         # Test default endpoint without ssl
         c = Configuration()
         c.use_ssl = False
-        eq_(c.get_endpoint(), "http://notify.bugsnag.com")
+        self.assertEqual(c.get_endpoint(), "http://notify.bugsnag.com")
 
         # Test custom endpoint
         c = Configuration()
         c.use_ssl = False
         c.endpoint = "localhost:1234"
-        eq_(c.get_endpoint(), "http://localhost:1234")
+        self.assertEqual(c.get_endpoint(), "http://localhost:1234")
 
     def test_reads_api_key_from_environ(self):
         os.environ['BUGSNAG_API_KEY'] = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         c = Configuration()
         self.assertEqual(c.api_key, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-        eq_(c.project_root, os.getcwd())
+        self.assertEqual(c.project_root, os.getcwd())
 
     def test_should_notify(self):
         # Test custom release_stage
@@ -62,7 +60,7 @@ class TestConfiguration(unittest.TestCase):
 
     def test_hostname(self):
         c = Configuration()
-        eq_(c.hostname, socket.gethostname())
+        self.assertEqual(c.hostname, socket.gethostname())
 
         os.environ["DYNO"] = "YES"
         c = Configuration()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,67 +1,69 @@
-from bugsnag.configuration import Configuration
 import os
 import socket
+import unittest
+
+from nose.tools import eq_
+
+from bugsnag.configuration import Configuration
 
 
-def test_get_endpoint():
-    # Test default endpoint with ssl
-    c = Configuration()
-    c.use_ssl = True
-    assert(c.get_endpoint() == "https://notify.bugsnag.com")
+class TestConfiguration(unittest.TestCase):
 
-    # Test default endpoint without ssl
-    c = Configuration()
-    c.use_ssl = False
-    assert(c.get_endpoint() == "http://notify.bugsnag.com")
+    def test_get_endpoint(self):
+        # Test default endpoint with ssl
+        c = Configuration()
+        c.use_ssl = True
+        eq_(c.get_endpoint(), "https://notify.bugsnag.com")
 
-    # Test custom endpoint
-    c = Configuration()
-    c.use_ssl = False
-    c.endpoint = "localhost:1234"
-    assert(c.get_endpoint() == "http://localhost:1234")
+        # Test default endpoint without ssl
+        c = Configuration()
+        c.use_ssl = False
+        eq_(c.get_endpoint(), "http://notify.bugsnag.com")
 
+        # Test custom endpoint
+        c = Configuration()
+        c.use_ssl = False
+        c.endpoint = "localhost:1234"
+        eq_(c.get_endpoint(), "http://localhost:1234")
 
-def test_environment_defaults():
-    os.environ['BUGSNAG_API_KEY'] = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    c = Configuration()
-    assert(c.api_key == 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
-    assert(c.project_root == os.getcwd())
+    def test_environment_defaults(self):
+        os.environ['BUGSNAG_API_KEY'] = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        c = Configuration()
+        self.assertEqual(c.api_key, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+        eq_(c.project_root, os.getcwd())
 
+    def test_should_notify(self):
+        # Test custom release_stage
+        c = Configuration()
+        c.release_stage = "anything"
+        self.assertTrue(c.should_notify())
 
-def test_should_notify():
-    # Test custom release_stage
-    c = Configuration()
-    c.release_stage = "anything"
-    assert(c.should_notify() == True)
+        # Test release_stage in notify_release_stages
+        c = Configuration()
+        c.notify_release_stages = ["production"]
+        c.release_stage = "development"
+        self.assertFalse(c.should_notify())
 
-    # Test release_stage in notify_release_stages
-    c = Configuration()
-    c.notify_release_stages = ["production"]
-    c.release_stage = "development"
-    assert(c.should_notify() == False)
+        # Test release_stage in notify_release_stages
+        c = Configuration()
+        c.notify_release_stages = ["custom"]
+        c.release_stage = "custom"
+        self.assertTrue(c.should_notify())
 
-    # Test release_stage in notify_release_stages
-    c = Configuration()
-    c.notify_release_stages = ["custom"]
-    c.release_stage = "custom"
-    assert(c.should_notify() == True)
+    def test_ignore_classes(self):
+        # Test ignoring a class works
+        c = Configuration()
+        c.ignore_classes.append("SystemError")
+        self.assertTrue(c.should_ignore(SystemError("Example")))
 
+        c = Configuration()
+        c.ignore_classes.append("SystemError")
+        self.assertFalse(c.should_ignore(Exception("Example")))
 
-def test_ignore_classes():
-    # Test ignoring a class works
-    c = Configuration()
-    c.ignore_classes.append("SystemError")
-    assert(c.should_ignore(SystemError("Example")) == True)
+    def test_hostname(self):
+        c = Configuration()
+        eq_(c.hostname, socket.gethostname())
 
-    c = Configuration()
-    c.ignore_classes.append("SystemError")
-    assert(c.should_ignore(Exception("Example")) == False)
-
-
-def test_hostname():
-    c = Configuration()
-    assert(c.hostname == socket.gethostname())
-
-    os.environ["DYNO"] = "YES"
-    c = Configuration()
-    assert(c.hostname == None)
+        os.environ["DYNO"] = "YES"
+        c = Configuration()
+        self.assertEqual(c.hostname, None)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -26,7 +26,7 @@ class TestConfiguration(unittest.TestCase):
         c.endpoint = "localhost:1234"
         eq_(c.get_endpoint(), "http://localhost:1234")
 
-    def test_environment_defaults(self):
+    def test_reads_api_key_from_environ(self):
         os.environ['BUGSNAG_API_KEY'] = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         c = Configuration()
         self.assertEqual(c.api_key, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -6,7 +6,6 @@ if (3, 0) <= sys.version_info < (3, 3):  # noqa
 
 import unittest
 
-from nose.tools import eq_, ok_
 from mock import patch
 from flask import Flask
 
@@ -34,9 +33,9 @@ class TestFlask(unittest.TestCase):
         handle_exceptions(app)
 
         resp = app.test_client().get('/hello')
-        eq_(resp.data, b'OK')
+        self.assertEqual(resp.data, b'OK')
 
-        eq_(deliver.call_count, 0)
+        self.assertEqual(deliver.call_count, 0)
 
     @patch('bugsnag.notification.deliver')
     def test_bugsnag_crash(self, deliver):
@@ -49,12 +48,12 @@ class TestFlask(unittest.TestCase):
         handle_exceptions(app)
         app.test_client().get('/hello')
 
-        eq_(deliver.call_count, 1)
+        self.assertEqual(deliver.call_count, 1)
         payload = deliver.call_args[0][0]
-        eq_(payload['events'][0]['exceptions'][0]['errorClass'],
-            'test_flask.SentinelError')
-        eq_(payload['events'][0]['metaData']['request']['url'],
-            'http://localhost/hello')
+        self.assertEqual(payload['events'][0]['exceptions'][0]['errorClass'],
+                         'test_flask.SentinelError')
+        self.assertEqual(payload['events'][0]['metaData']['request']['url'],
+                         'http://localhost/hello')
 
     @patch('bugsnag.notification.deliver')
     def test_bugsnag_notify(self, deliver):
@@ -68,10 +67,10 @@ class TestFlask(unittest.TestCase):
         handle_exceptions(app)
         app.test_client().get('/hello')
 
-        eq_(deliver.call_count, 1)
+        self.assertEqual(deliver.call_count, 1)
         payload = deliver.call_args[0][0]
-        eq_(payload['events'][0]['metaData']['request']['url'],
-            'http://localhost/hello')
+        self.assertEqual(payload['events'][0]['metaData']['request']['url'],
+                         'http://localhost/hello')
 
     @patch('bugsnag.notification.deliver')
     def test_bugsnag_custom_data(self, deliver):
@@ -89,15 +88,17 @@ class TestFlask(unittest.TestCase):
         app.test_client().get('/hello')
         app.test_client().get('/hello')
 
-        eq_(deliver.call_count, 2)
+        self.assertEqual(deliver.call_count, 2)
 
         payload = deliver.call_args_list[0][0][0]
-        eq_(payload['events'][0]['metaData'].get('hello'), None)
-        eq_(payload['events'][0]['metaData']['again']['hello'], 'world')
+        event = payload['events'][0]
+        self.assertEqual(event['metaData'].get('hello'), None)
+        self.assertEqual(event['metaData']['again']['hello'], 'world')
 
         payload = deliver.call_args_list[1][0][0]
-        eq_(payload['events'][0]['metaData']['hello']['world'], 'once')
-        eq_(payload['events'][0]['metaData'].get('again'), None)
+        event = payload['events'][0]
+        self.assertEqual(event['metaData']['hello']['world'], 'once')
+        self.assertEqual(event['metaData'].get('again'), None)
 
     @patch('bugsnag.notification.deliver')
     def test_bugsnag_includes_posted_json_data(self, deliver):
@@ -111,12 +112,15 @@ class TestFlask(unittest.TestCase):
         app.test_client().post(
             '/ajax', data='{"key": "value"}', content_type='application/json')
 
-        eq_(deliver.call_count, 1)
+        self.assertEqual(deliver.call_count, 1)
         payload = deliver.call_args[0][0]
         event = payload['events'][0]
-        eq_(event['exceptions'][0]['errorClass'], 'test_flask.SentinelError')
-        eq_(event['metaData']['request']['url'], 'http://localhost/ajax')
-        eq_(event['metaData']['request']['data'], dict(key='value'))
+        self.assertEqual(event['exceptions'][0]['errorClass'],
+                         'test_flask.SentinelError')
+        self.assertEqual(event['metaData']['request']['url'],
+                         'http://localhost/ajax')
+        self.assertEqual(event['metaData']['request']['data'],
+                         dict(key='value'))
 
     @patch('bugsnag.notification.deliver')
     def test_bugsnag_add_metadata_tab(self, deliver):
@@ -132,11 +136,11 @@ class TestFlask(unittest.TestCase):
         app.test_client().put(
             '/form', data='_data', content_type='application/octet-stream')
 
-        eq_(deliver.call_count, 1)
+        self.assertEqual(deliver.call_count, 1)
         payload = deliver.call_args[0][0]
-        eq_(payload['events'][0]['metaData']['account']['premium'], False)
-
-        eq_(payload['events'][0]['metaData']['account']['id'], 1)
+        event = payload['events'][0]
+        self.assertEqual(event['metaData']['account']['premium'], False)
+        self.assertEqual(event['metaData']['account']['id'], 1)
 
     @patch('bugsnag.notification.deliver')
     def test_bugsnag_includes_unknown_content_type_posted_data(self, deliver):
@@ -150,11 +154,12 @@ class TestFlask(unittest.TestCase):
         app.test_client().put(
             '/form', data='_data', content_type='application/octet-stream')
 
-        eq_(deliver.call_count, 1)
+        self.assertEqual(deliver.call_count, 1)
         payload = deliver.call_args[0][0]
         event = payload['events'][0]
-        eq_(event['exceptions'][0]['errorClass'],
-            'test_flask.SentinelError')
-        eq_(event['metaData']['request']['url'],
-            'http://localhost/form')
-        ok_('_data' in event['metaData']['request']['data']['body'])
+        self.assertEqual(event['exceptions'][0]['errorClass'],
+                         'test_flask.SentinelError')
+        self.assertEqual(event['metaData']['request']['url'],
+                         'http://localhost/form')
+        body = event['metaData']['request']['data']['body']
+        self.assertTrue('_data' in body)

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,11 +1,15 @@
 import sys
+
 from nose.plugins.skip import SkipTest
-if (3,0) <= sys.version_info < (3,3): raise SkipTest("Flask is incompatible with python3 3.0 - 3.2")
+if (3, 0) <= sys.version_info < (3, 3):  # noqa
+    raise SkipTest("Flask is incompatible with python3 3.0 - 3.2")
+
+import unittest
 
 from nose.tools import eq_, ok_
 from mock import patch
-
 from flask import Flask
+
 from bugsnag.flask import handle_exceptions
 import bugsnag.notification
 
@@ -17,139 +21,140 @@ class SentinalError(RuntimeError):
     pass
 
 
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_middleware_working(deliver):
-    app = Flask("bugsnag")
+class TestFlask(unittest.TestCase):
 
-    @app.route("/hello")
-    def hello():
-        return "OK"
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_middleware_working(self, deliver):
+        app = Flask("bugsnag")
 
-    handle_exceptions(app)
+        @app.route("/hello")
+        def hello():
+            return "OK"
 
-    resp = app.test_client().get('/hello')
-    eq_(resp.data, b'OK')
+        handle_exceptions(app)
 
-    eq_(deliver.call_count, 0)
+        resp = app.test_client().get('/hello')
+        eq_(resp.data, b'OK')
 
+        eq_(deliver.call_count, 0)
 
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_crash(deliver):
-    app = Flask("bugsnag")
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_crash(self, deliver):
+        app = Flask("bugsnag")
 
-    @app.route("/hello")
-    def hello():
-        raise SentinalError("oops")
+        @app.route("/hello")
+        def hello():
+            raise SentinalError("oops")
 
-    handle_exceptions(app)
-    app.test_client().get('/hello')
+        handle_exceptions(app)
+        app.test_client().get('/hello')
 
-    eq_(deliver.call_count, 1)
-    payload = deliver.call_args[0][0]
-    eq_(payload['events'][0]['exceptions'][0]['errorClass'], 'test_flask.SentinalError')
-    eq_(payload['events'][0]['metaData']['request']['url'], 'http://localhost/hello')
+        eq_(deliver.call_count, 1)
+        payload = deliver.call_args[0][0]
+        eq_(payload['events'][0]['exceptions'][0]['errorClass'],
+            'test_flask.SentinalError')
+        eq_(payload['events'][0]['metaData']['request']['url'],
+            'http://localhost/hello')
 
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_notify(self, deliver):
+        app = Flask("bugsnag")
 
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_notify(deliver):
-    app = Flask("bugsnag")
+        @app.route("/hello")
+        def hello():
+            bugsnag.notify(SentinalError("oops"))
+            return "OK"
 
-    @app.route("/hello")
-    def hello():
-        bugsnag.notify(SentinalError("oops"))
-        return "OK"
+        handle_exceptions(app)
+        app.test_client().get('/hello')
 
-    handle_exceptions(app)
-    app.test_client().get('/hello')
+        eq_(deliver.call_count, 1)
+        payload = deliver.call_args[0][0]
+        eq_(payload['events'][0]['metaData']['request']['url'],
+            'http://localhost/hello')
 
-    eq_(deliver.call_count, 1)
-    payload = deliver.call_args[0][0]
-    eq_(payload['events'][0]['metaData']['request']['url'], 'http://localhost/hello')
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_custom_data(self, deliver):
+        meta_data = [{"hello": {"world": "once"}},
+                     {"again": {"hello": "world"}}]
 
+        app = Flask("bugsnag")
 
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_custom_data(deliver):
-    meta_data = [{"hello": {"world": "once"}}, {"again": {"hello": "world"}}]
+        @app.route("/hello")
+        def hello():
+            bugsnag.configure_request(meta_data=meta_data.pop())
+            raise SentinalError("oops")
 
-    app = Flask("bugsnag")
+        handle_exceptions(app)
+        app.test_client().get('/hello')
+        app.test_client().get('/hello')
 
-    @app.route("/hello")
-    def hello():
-        bugsnag.configure_request(meta_data=meta_data.pop())
-        raise SentinalError("oops")
+        eq_(deliver.call_count, 2)
 
-    handle_exceptions(app)
-    app.test_client().get('/hello')
-    app.test_client().get('/hello')
+        payload = deliver.call_args_list[0][0][0]
+        eq_(payload['events'][0]['metaData'].get('hello'), None)
+        eq_(payload['events'][0]['metaData']['again']['hello'], 'world')
 
-    eq_(deliver.call_count, 2)
+        payload = deliver.call_args_list[1][0][0]
+        eq_(payload['events'][0]['metaData']['hello']['world'], 'once')
+        eq_(payload['events'][0]['metaData'].get('again'), None)
 
-    payload = deliver.call_args_list[0][0][0]
-    eq_(payload['events'][0]['metaData'].get('hello'), None)
-    eq_(payload['events'][0]['metaData']['again']['hello'], 'world')
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_includes_posted_json_data(self, deliver):
+        app = Flask("bugsnag")
 
-    payload = deliver.call_args_list[1][0][0]
-    eq_(payload['events'][0]['metaData']['hello']['world'], 'once')
-    eq_(payload['events'][0]['metaData'].get('again'), None)
+        @app.route("/ajax", methods=["POST"])
+        def hello():
+            raise SentinalError("oops")
 
+        handle_exceptions(app)
+        app.test_client().post(
+            '/ajax', data='{"key": "value"}', content_type='application/json')
 
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_includes_posted_json_data(deliver):
-    app = Flask("bugsnag")
+        eq_(deliver.call_count, 1)
+        payload = deliver.call_args[0][0]
+        event = payload['events'][0]
+        eq_(event['exceptions'][0]['errorClass'], 'test_flask.SentinalError')
+        eq_(event['metaData']['request']['url'], 'http://localhost/ajax')
+        eq_(event['metaData']['request']['data'], dict(key='value'))
 
-    @app.route("/ajax", methods=["POST"])
-    def hello():
-        raise SentinalError("oops")
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_add_metadata_tab(self, deliver):
+        app = Flask("bugsnag")
 
-    handle_exceptions(app)
-    app.test_client().post(
-        '/ajax', data='{"key": "value"}', content_type='application/json')
+        @app.route("/form", methods=["PUT"])
+        def hello():
+            bugsnag.add_metadata_tab("account", {"id": 1, "premium": True})
+            bugsnag.add_metadata_tab("account", {"premium": False})
+            raise SentinalError("oops")
 
-    eq_(deliver.call_count, 1)
-    payload = deliver.call_args[0][0]
-    eq_(payload['events'][0]['exceptions'][0]['errorClass'],
-        'test_flask.SentinalError')
-    eq_(payload['events'][0]['metaData']['request']['url'],
-        'http://localhost/ajax')
-    eq_(payload['events'][0]['metaData']['request']['data'], dict(key='value'))
+        handle_exceptions(app)
+        app.test_client().put(
+            '/form', data='_data', content_type='application/octet-stream')
 
+        eq_(deliver.call_count, 1)
+        payload = deliver.call_args[0][0]
+        eq_(payload['events'][0]['metaData']['account']['premium'], False)
 
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_add_metadata_tab(deliver):
-    app = Flask("bugsnag")
+        eq_(payload['events'][0]['metaData']['account']['id'], 1)
 
-    @app.route("/form", methods=["PUT"])
-    def hello():
-        bugsnag.add_metadata_tab("account", {"id": 1, "premium": True})
-        bugsnag.add_metadata_tab("account", {"premium": False})
-        raise SentinalError("oops")
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_includes_unknown_content_type_posted_data(self, deliver):
+        app = Flask("bugsnag")
 
-    handle_exceptions(app)
-    app.test_client().put(
-        '/form', data='_data', content_type='application/octet-stream')
+        @app.route("/form", methods=["PUT"])
+        def hello():
+            raise SentinalError("oops")
 
-    eq_(deliver.call_count, 1)
-    payload = deliver.call_args[0][0]
-    eq_(payload['events'][0]['metaData']['account']['premium'], False)
+        handle_exceptions(app)
+        app.test_client().put(
+            '/form', data='_data', content_type='application/octet-stream')
 
-    eq_(payload['events'][0]['metaData']['account']['id'], 1)
-
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_includes_unknown_content_type_posted_data(deliver):
-    app = Flask("bugsnag")
-
-    @app.route("/form", methods=["PUT"])
-    def hello():
-        raise SentinalError("oops")
-
-    handle_exceptions(app)
-    app.test_client().put(
-        '/form', data='_data', content_type='application/octet-stream')
-
-    eq_(deliver.call_count, 1)
-    payload = deliver.call_args[0][0]
-    eq_(payload['events'][0]['exceptions'][0]['errorClass'],
-        'test_flask.SentinalError')
-    eq_(payload['events'][0]['metaData']['request']['url'],
-        'http://localhost/form')
-    ok_('_data' in payload['events'][0]['metaData']['request']['data']['body'])
+        eq_(deliver.call_count, 1)
+        payload = deliver.call_args[0][0]
+        event = payload['events'][0]
+        eq_(event['exceptions'][0]['errorClass'],
+            'test_flask.SentinalError')
+        eq_(event['metaData']['request']['url'],
+            'http://localhost/form')
+        ok_('_data' in event['metaData']['request']['data']['body'])

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -17,7 +17,7 @@ import bugsnag.notification
 bugsnag.configuration.api_key = '066f5ad3590596f9aa8d601ea89af845'
 
 
-class SentinalError(RuntimeError):
+class SentinelError(RuntimeError):
     pass
 
 
@@ -44,7 +44,7 @@ class TestFlask(unittest.TestCase):
 
         @app.route("/hello")
         def hello():
-            raise SentinalError("oops")
+            raise SentinelError("oops")
 
         handle_exceptions(app)
         app.test_client().get('/hello')
@@ -52,7 +52,7 @@ class TestFlask(unittest.TestCase):
         eq_(deliver.call_count, 1)
         payload = deliver.call_args[0][0]
         eq_(payload['events'][0]['exceptions'][0]['errorClass'],
-            'test_flask.SentinalError')
+            'test_flask.SentinelError')
         eq_(payload['events'][0]['metaData']['request']['url'],
             'http://localhost/hello')
 
@@ -62,7 +62,7 @@ class TestFlask(unittest.TestCase):
 
         @app.route("/hello")
         def hello():
-            bugsnag.notify(SentinalError("oops"))
+            bugsnag.notify(SentinelError("oops"))
             return "OK"
 
         handle_exceptions(app)
@@ -83,7 +83,7 @@ class TestFlask(unittest.TestCase):
         @app.route("/hello")
         def hello():
             bugsnag.configure_request(meta_data=meta_data.pop())
-            raise SentinalError("oops")
+            raise SentinelError("oops")
 
         handle_exceptions(app)
         app.test_client().get('/hello')
@@ -105,7 +105,7 @@ class TestFlask(unittest.TestCase):
 
         @app.route("/ajax", methods=["POST"])
         def hello():
-            raise SentinalError("oops")
+            raise SentinelError("oops")
 
         handle_exceptions(app)
         app.test_client().post(
@@ -114,7 +114,7 @@ class TestFlask(unittest.TestCase):
         eq_(deliver.call_count, 1)
         payload = deliver.call_args[0][0]
         event = payload['events'][0]
-        eq_(event['exceptions'][0]['errorClass'], 'test_flask.SentinalError')
+        eq_(event['exceptions'][0]['errorClass'], 'test_flask.SentinelError')
         eq_(event['metaData']['request']['url'], 'http://localhost/ajax')
         eq_(event['metaData']['request']['data'], dict(key='value'))
 
@@ -126,7 +126,7 @@ class TestFlask(unittest.TestCase):
         def hello():
             bugsnag.add_metadata_tab("account", {"id": 1, "premium": True})
             bugsnag.add_metadata_tab("account", {"premium": False})
-            raise SentinalError("oops")
+            raise SentinelError("oops")
 
         handle_exceptions(app)
         app.test_client().put(
@@ -144,7 +144,7 @@ class TestFlask(unittest.TestCase):
 
         @app.route("/form", methods=["PUT"])
         def hello():
-            raise SentinalError("oops")
+            raise SentinelError("oops")
 
         handle_exceptions(app)
         app.test_client().put(
@@ -154,7 +154,7 @@ class TestFlask(unittest.TestCase):
         payload = deliver.call_args[0][0]
         event = payload['events'][0]
         eq_(event['exceptions'][0]['errorClass'],
-            'test_flask.SentinalError')
+            'test_flask.SentinelError')
         eq_(event['metaData']['request']['url'],
             'http://localhost/form')
         ok_('_data' in event['metaData']['request']['data']['body'])

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,7 +1,5 @@
 import unittest
 
-from nose.tools import eq_
-
 from bugsnag.middleware import MiddlewareStack
 
 
@@ -21,7 +19,7 @@ class TestMiddleware(unittest.TestCase):
 
         m.run(None, lambda: None)
 
-        eq_(a, [1, 2, 3, 4])
+        self.assertEqual(a, [1, 2, 3, 4])
 
     def test_before_notify_returning_false(self):
 
@@ -34,7 +32,7 @@ class TestMiddleware(unittest.TestCase):
 
         m.run(None, lambda: a.append(2))
 
-        eq_(a, [])
+        self.assertEqual(a, [])
 
     def test_before_exception_handling(self):
 
@@ -44,7 +42,7 @@ class TestMiddleware(unittest.TestCase):
         m.before_notify(lambda _: a.penned(1))
         m.run(None, lambda: a.append(2))
 
-        eq_(a, [2])
+        self.assertEqual(a, [2])
 
     def test_after_exception_handling(self):
         a = []
@@ -53,4 +51,4 @@ class TestMiddleware(unittest.TestCase):
         m.after_notify(lambda _: a.penned(1))
         m.run(None, lambda: a.append(2))
 
-        eq_(a, [2])
+        self.assertEqual(a, [2])

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,55 +1,56 @@
+import unittest
+
 from nose.tools import eq_
 
 from bugsnag.middleware import MiddlewareStack
 
 
-def test_order_of_middleware():
+class TestMiddleware(unittest.TestCase):
 
-    a = []
+    def test_order_of_middleware(self):
 
-    m = MiddlewareStack()
+        a = []
 
-    m.before_notify(lambda _: a.append(1))
-    m.before_notify(lambda _: a.append(2))
+        m = MiddlewareStack()
 
-    m.after_notify(lambda _: a.append(4))
-    m.after_notify(lambda _: a.append(3))
+        m.before_notify(lambda _: a.append(1))
+        m.before_notify(lambda _: a.append(2))
 
-    m.run(None, lambda: None)
+        m.after_notify(lambda _: a.append(4))
+        m.after_notify(lambda _: a.append(3))
 
-    eq_(a, [1, 2, 3, 4])
+        m.run(None, lambda: None)
 
+        eq_(a, [1, 2, 3, 4])
 
-def test_before_notify_returning_false():
+    def test_before_notify_returning_false(self):
 
-    a = []
+        a = []
 
-    m = MiddlewareStack()
+        m = MiddlewareStack()
 
-    m.before_notify(lambda _: False)
-    m.before_notify(lambda _: a.append(1))
+        m.before_notify(lambda _: False)
+        m.before_notify(lambda _: a.append(1))
 
-    m.run(None, lambda: a.append(2))
+        m.run(None, lambda: a.append(2))
 
-    eq_(a, [])
+        eq_(a, [])
 
+    def test_before_exception_handling(self):
 
-def test_before_exception_handling():
+        a = []
 
-    a = []
+        m = MiddlewareStack()
+        m.before_notify(lambda _: a.penned(1))
+        m.run(None, lambda: a.append(2))
 
-    m = MiddlewareStack()
-    m.before_notify(lambda _: a.penned(1))
-    m.run(None, lambda: a.append(2))
+        eq_(a, [2])
 
-    eq_(a, [2])
+    def test_after_exception_handling(self):
+        a = []
 
+        m = MiddlewareStack()
+        m.after_notify(lambda _: a.penned(1))
+        m.run(None, lambda: a.append(2))
 
-def test_after_exception_handling():
-    a = []
-
-    m = MiddlewareStack()
-    m.after_notify(lambda _: a.penned(1))
-    m.run(None, lambda: a.append(2))
-
-    eq_(a, [2])
+        eq_(a, [2])

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,8 +1,6 @@
 import inspect
 import unittest
 
-from nose.tools import eq_
-
 from bugsnag.configuration import Configuration
 from bugsnag.notification import Notification
 import fixtures
@@ -22,8 +20,8 @@ class TestNotification(unittest.TestCase):
 
         payload = notification._payload()
         request = payload['events'][0]['metaData']['request']
-        eq_(request['arguments']['password'], '[FILTERED]')
-        eq_(request['params']['password'], '[FILTERED]')
+        self.assertEqual(request['arguments']['password'], '[FILTERED]')
+        self.assertEqual(request['params']['password'], '[FILTERED]')
 
     def test_code(self):
         """
@@ -37,14 +35,16 @@ class TestNotification(unittest.TestCase):
 
         code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
         lvl = "        "
-        eq_(code[line - 3], lvl + "\"\"\"")
-        eq_(code[line - 2], lvl + "config = Configuration()")
-        eq_(code[line - 1], lvl + "line = inspect.currentframe().f_lineno + 1")
-        eq_(code[line], lvl +
-            "notification = Notification(Exception(\"oops\"), config, {})")
-        eq_(code[line + 1], "")
-        eq_(code[line + 2], lvl + "payload = notification._payload()")
-        eq_(code[line + 3], "")
+        self.assertEqual(code[line - 3], lvl + "\"\"\"")
+        self.assertEqual(code[line - 2], lvl + "config = Configuration()")
+        self.assertEqual(code[line - 1],
+                lvl + "line = inspect.currentframe().f_lineno + 1")
+        self.assertEqual(code[line], lvl +
+                "notification = Notification(Exception(\"oops\"), config, {})")
+        self.assertEqual(code[line + 1], "")
+        self.assertEqual(code[line + 2],
+                lvl + "payload = notification._payload()")
+        self.assertEqual(code[line + 3], "")
 
     def test_code_at_start_of_file(self):
 
@@ -55,7 +55,7 @@ class TestNotification(unittest.TestCase):
         payload = notification._payload()
 
         code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
-        eq_({1: '# flake8: noqa',
+        self.assertEqual({1: '# flake8: noqa',
              2: 'try:',
              3: '    import sys; raise Exception("start")',
              4: 'except Exception: start_of_file = sys.exc_info()',
@@ -72,7 +72,7 @@ class TestNotification(unittest.TestCase):
         payload = notification._payload()
 
         code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
-        eq_({6:  '# 5',
+        self.assertEqual({6:  '# 5',
              7:  '# 6',
              8:  '# 7',
              9:  '# 8',

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,85 +1,92 @@
 import inspect
+import unittest
+
+from nose.tools import eq_
 
 from bugsnag.configuration import Configuration
 from bugsnag.notification import Notification
 import fixtures
 
 
-def test_sanitize():
-    """
-        It should sanitize request data
-    """
-    config = Configuration()
-    notification = Notification(Exception("oops"), config, {},
-                                request={"params": {"password": "secret"}})
+class TestNotification(unittest.TestCase):
 
-    notification.add_tab("request", {"arguments": {"password": "secret"}})
+    def test_sanitize(self):
+        """
+            It should sanitize request data
+        """
+        config = Configuration()
+        notification = Notification(Exception("oops"), config, {},
+                                    request={"params": {"password": "secret"}})
 
-    payload = notification._payload()
-    request = payload['events'][0]['metaData']['request']
-    assert(request['arguments']['password'] == '[FILTERED]')
-    assert(request['params']['password'] == '[FILTERED]')
+        notification.add_tab("request", {"arguments": {"password": "secret"}})
 
+        payload = notification._payload()
+        request = payload['events'][0]['metaData']['request']
+        eq_(request['arguments']['password'], '[FILTERED]')
+        eq_(request['params']['password'], '[FILTERED]')
 
-def test_code():
-    """
-        It should include code
-    """
-    config = Configuration()
-    line = inspect.currentframe().f_lineno + 1
-    notification = Notification(Exception("oops"), config, {})
+    def test_code(self):
+        """
+            It should include code
+        """
+        config = Configuration()
+        line = inspect.currentframe().f_lineno + 1
+        notification = Notification(Exception("oops"), config, {})
 
-    payload = notification._payload()
+        payload = notification._payload()
 
-    code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
+        code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
+        lvl = "        "
+        eq_(code[line - 3], lvl + "\"\"\"")
+        eq_(code[line - 2], lvl + "config = Configuration()")
+        eq_(code[line - 1], lvl + "line = inspect.currentframe().f_lineno + 1")
+        eq_(code[line], lvl +
+            "notification = Notification(Exception(\"oops\"), config, {})")
+        eq_(code[line + 1], "")
+        eq_(code[line + 2], lvl + "payload = notification._payload()")
+        eq_(code[line + 3], "")
 
-    assert(code[line - 3] == "    \"\"\"")
-    assert(code[line - 2] == "    config = Configuration()")
-    assert(code[line - 1] == "    line = inspect.currentframe().f_lineno + 1")
-    error = "    notification = Notification(Exception(\"oops\"), config, {})"
-    assert(code[line] == error)
-    assert(code[line + 1] == "")
-    assert(code[line + 2] == "    payload = notification._payload()")
-    assert(code[line + 3] == "")
+    def test_code_at_start_of_file(self):
 
+        config = Configuration()
+        notification = Notification(fixtures.start_of_file[1], config, {},
+                                    traceback=fixtures.start_of_file[2])
 
-def test_code_at_start_of_file():
+        payload = notification._payload()
 
-    config = Configuration()
-    notification = Notification(fixtures.start_of_file[1], config, {},
-                                traceback=fixtures.start_of_file[2])
+        code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
+        eq_({1: '# flake8: noqa',
+             2: 'try:',
+             3: '    import sys; raise Exception("start")',
+             4: 'except Exception: start_of_file = sys.exc_info()',
+             5: '# 4',
+             6: '# 5',
+             7: '# 6'}, code)
 
-    payload = notification._payload()
+    def test_code_at_end_of_file(self):
 
-    code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
-    assert({1: 'try:',
-            2: '    import sys; raise Exception("start")',
-            3: 'except Exception: start_of_file = sys.exc_info()',
-            4: '# 4', 5: '# 5', 6: '# 6', 7: '# 7'} == code)
+        config = Configuration()
+        notification = Notification(fixtures.end_of_file[1], config, {},
+                                    traceback=fixtures.end_of_file[2])
 
+        payload = notification._payload()
 
-def test_code_at_end_of_file():
+        code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
+        eq_({6:  '# 5',
+             7:  '# 6',
+             8:  '# 7',
+             9:  '# 8',
+             10: 'try:',
+             11: '    import sys; raise Exception("end")',
+             12: 'except Exception: end_of_file = sys.exc_info()'}, code)
 
-    config = Configuration()
-    notification = Notification(fixtures.end_of_file[1], config, {},
-                                traceback=fixtures.end_of_file[2])
+    def test_code_turned_off(self):
+        config = Configuration()
+        config.send_code = False
+        notification = Notification(Exception("oops"), config, {},
+                                    traceback=fixtures.end_of_file[2])
 
-    payload = notification._payload()
+        payload = notification._payload()
 
-    code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
-    assert({5: '# 5',
-            6: '# 6', 7: '# 7', 8: '# 8', 9: 'try:',
-            10: '    import sys; raise Exception("end")',
-            11: 'except Exception: end_of_file = sys.exc_info()'} == code)
-
-
-def test_code_turned_off():
-    config = Configuration()
-    config.send_code = False
-    notification = Notification(Exception("oops"), config, {},
-                                traceback=fixtures.end_of_file[2])
-
-    payload = notification._payload()
-
-    code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
-    assert(None == code)  # flake8: noqa
+        code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
+        self.assertEqual(code, None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,29 +8,39 @@ from bugsnag.utils import json_encode, sanitize_object
 
 class TestUtils(unittest.TestCase):
 
-    def test_sanitize_object(self):
-        filters = ["password", "credit_card"]
-        crazy_dict = {
-            "password": "123456",
-            "metadata": {
-                "another_password": "123456",
-                "regular": "text"
-            },
-            "bad_utf8": "a test of \xe9 char",
-            "list": ["list", "of", "things"],
-            "unicode": u("string"),
-            "obj": Exception(),
-            "valid_unicode": u("\u2603"),
-        }
+    def test_sanitize_filters(self):
+        data = {"credit_card": "123213213123", "password": "456", "cake": True}
+        sane_data = sanitize_object(data, filters=["credit_card", "password"])
+        eq_(sane_data, {"credit_card": "[FILTERED]",
+                        "password": "[FILTERED]",
+                        "cake": True})
 
-        # Sanitize our object
-        sane_dict = sanitize_object(crazy_dict, filters=filters)
+    def test_sanitize_list(self):
+        data = {"list": ["carrots", "apples", "peas"],
+                "passwords": ["abc", "def"]}
+        sane_data = sanitize_object(data, filters=["credit_card", "password"])
+        eq_(sane_data, {"list": ["carrots", "apples", "peas"],
+                        "passwords": "[FILTERED]"})
 
-        # Check the values have been sanitized
-        eq_(sane_dict["password"], "[FILTERED]")
-        eq_(sane_dict["metadata"]["another_password"], "[FILTERED]")
-        eq_(sane_dict["metadata"]["regular"], "text")
-        self.assertTrue("things" in sane_dict["list"])
+    def test_sanitize_valid_unicode_object(self):
+        data = {"item": u('\U0001f62c')}
+        sane_data = sanitize_object(data, filters=[])
+        eq_(sane_data, data)
+
+    def test_sanitize_nested_object_filters(self):
+        data = {"metadata": {"another_password": "My password"}}
+        sane_data = sanitize_object(data, filters=["password"])
+        eq_(sane_data, {"metadata": {"another_password": "[FILTERED]"}})
+
+    def test_sanitize_bad_utf8_object(self):
+        data = {"bad_utf8": u("test \xe9")}
+        sane_data = sanitize_object(data, filters=[])
+        eq_(sane_data, data)
+
+    def test_sanitize_unencoded_object(self):
+        data = {"exc": Exception()}
+        sane_data = sanitize_object(data, filters=[])
+        eq_(sane_data, {"exc": ""})
 
     def test_json_encode(self):
         payload = {"a": u("a") * 512 * 1024}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,35 +1,38 @@
+import unittest
+
 from nose.tools import eq_
 
 from six import u
 from bugsnag.utils import json_encode, sanitize_object
 
 
-def test_sanitize_object():
-    filters = ["password", "credit_card"]
-    crazy_dict = {
-        "password": "123456",
-        "metadata": {
-            "another_password": "123456",
-            "regular": "text"
-        },
-        "bad_utf8": "a test of \xe9 char",
-        "list": ["list", "of", "things"],
-        "unicode": u("string"),
-        "obj": Exception(),
-        "valid_unicode": u("\u2603"),
-    }
+class TestUtils(unittest.TestCase):
 
-    # Sanitize our object
-    sane_dict = sanitize_object(crazy_dict, filters=filters)
+    def test_sanitize_object(self):
+        filters = ["password", "credit_card"]
+        crazy_dict = {
+            "password": "123456",
+            "metadata": {
+                "another_password": "123456",
+                "regular": "text"
+            },
+            "bad_utf8": "a test of \xe9 char",
+            "list": ["list", "of", "things"],
+            "unicode": u("string"),
+            "obj": Exception(),
+            "valid_unicode": u("\u2603"),
+        }
 
-    # Check the values have been sanitized
-    assert(sane_dict["password"] == "[FILTERED]")
-    assert(sane_dict["metadata"]["another_password"] == "[FILTERED]")
-    assert(sane_dict["metadata"]["regular"] == "text")
-    assert("things" in sane_dict["list"])
+        # Sanitize our object
+        sane_dict = sanitize_object(crazy_dict, filters=filters)
 
+        # Check the values have been sanitized
+        eq_(sane_dict["password"], "[FILTERED]")
+        eq_(sane_dict["metadata"]["another_password"], "[FILTERED]")
+        eq_(sane_dict["metadata"]["regular"], "text")
+        self.assertTrue("things" in sane_dict["list"])
 
-def test_json_encode():
-    payload = {"a": u("a") * 512 * 1024}
-    eq_(json_encode(payload),
-        ('{"a": "' + 'a' * 1024 + '"}').encode('utf-8', 'replace'))
+    def test_json_encode(self):
+        payload = {"a": u("a") * 512 * 1024}
+        eq_(json_encode(payload),
+            ('{"a": "' + 'a' * 1024 + '"}').encode('utf-8', 'replace'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,5 @@
 import unittest
 
-from nose.tools import eq_
-
 from six import u
 from bugsnag.utils import json_encode, sanitize_object
 
@@ -11,38 +9,39 @@ class TestUtils(unittest.TestCase):
     def test_sanitize_filters(self):
         data = {"credit_card": "123213213123", "password": "456", "cake": True}
         sane_data = sanitize_object(data, filters=["credit_card", "password"])
-        eq_(sane_data, {"credit_card": "[FILTERED]",
-                        "password": "[FILTERED]",
-                        "cake": True})
+        self.assertEqual(sane_data, {"credit_card": "[FILTERED]",
+                                     "password": "[FILTERED]",
+                                     "cake": True})
 
     def test_sanitize_list(self):
         data = {"list": ["carrots", "apples", "peas"],
                 "passwords": ["abc", "def"]}
         sane_data = sanitize_object(data, filters=["credit_card", "password"])
-        eq_(sane_data, {"list": ["carrots", "apples", "peas"],
-                        "passwords": "[FILTERED]"})
+        self.assertEqual(sane_data, {"list": ["carrots", "apples", "peas"],
+                                     "passwords": "[FILTERED]"})
 
     def test_sanitize_valid_unicode_object(self):
         data = {"item": u('\U0001f62c')}
         sane_data = sanitize_object(data, filters=[])
-        eq_(sane_data, data)
+        self.assertEqual(sane_data, data)
 
     def test_sanitize_nested_object_filters(self):
         data = {"metadata": {"another_password": "My password"}}
         sane_data = sanitize_object(data, filters=["password"])
-        eq_(sane_data, {"metadata": {"another_password": "[FILTERED]"}})
+        self.assertEqual(sane_data,
+                         {"metadata": {"another_password": "[FILTERED]"}})
 
     def test_sanitize_bad_utf8_object(self):
         data = {"bad_utf8": u("test \xe9")}
         sane_data = sanitize_object(data, filters=[])
-        eq_(sane_data, data)
+        self.assertEqual(sane_data, data)
 
     def test_sanitize_unencoded_object(self):
         data = {"exc": Exception()}
         sane_data = sanitize_object(data, filters=[])
-        eq_(sane_data, {"exc": ""})
+        self.assertEqual(sane_data, {"exc": ""})
 
     def test_json_encode(self):
         payload = {"a": u("a") * 512 * 1024}
-        eq_(json_encode(payload),
-            ('{"a": "' + 'a' * 1024 + '"}').encode('utf-8', 'replace'))
+        encoded = ('{"a": "' + 'a' * 1024 + '"}').encode('utf-8', 'replace')
+        self.assertEqual(json_encode(payload), encoded)

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,3 +1,5 @@
+import unittest
+
 from webtest import TestApp
 from nose.tools import eq_, assert_raises
 from mock import patch
@@ -14,138 +16,141 @@ class SentinalError(RuntimeError):
     pass
 
 
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_middleware_working(deliver):
-    def BasicWorkingApp(environ, start_response):
-        start_response("200 OK",
-                       [('Content-Type', 'text/plain; charset=utf-8')])
-        return iter([b'OK'])
+class TestWSGI(unittest.TestCase):
 
-    app = TestApp(BugsnagMiddleware(BasicWorkingApp))
-
-    resp = app.get('/', status=200)
-    eq_(resp.body, b'OK')
-
-    eq_(deliver.call_count, 0)
-
-
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_middleware_crash_on_start(deliver):
-
-    class CrashOnStartApp(object):
-        def __init__(self, environ, start_response):
-            raise SentinalError("oops")
-
-    app = TestApp(BugsnagMiddleware(CrashOnStartApp))
-
-    assert_raises(SentinalError, lambda: app.get('/beans'))
-
-    eq_(deliver.call_count, 1)
-    payload = deliver.call_args[0][0]
-    eq_(payload['events'][0]['context'], 'GET /beans')
-    eq_(payload['events'][0]['metaData']['environment']['PATH_INFO'], '/beans')
-
-
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_middleware_crash_on_iter(deliver):
-    class CrashOnIterApp(Iterator):
-        def __init__(self, environ, start_response):
-            pass
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            raise SentinalError("oops")
-    app = TestApp(BugsnagMiddleware(CrashOnIterApp))
-
-    assert_raises(SentinalError, lambda: app.get('/beans'))
-
-    eq_(deliver.call_count, 1)
-    payload = deliver.call_args[0][0]
-    eq_(payload['events'][0]['metaData']['environment']['PATH_INFO'], '/beans')
-
-
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_middleware_crash_on_close(deliver):
-    class CrashOnCloseApp(Iterator):
-        def __init__(self, environ, start_response):
-            pass
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            raise StopIteration()
-
-        def close(self):
-            raise SentinalError("oops")
-
-    app = TestApp(BugsnagMiddleware(CrashOnCloseApp))
-
-    assert_raises(SentinalError, lambda: app.get('/beans'))
-
-    eq_(deliver.call_count, 1)
-    payload = deliver.call_args[0][0]
-    eq_(payload['events'][0]['metaData']['environment']['PATH_INFO'], '/beans')
-
-
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_middleware_respects_user_id(deliver):
-
-    class CrashAfterSettingUserId(object):
-        def __init__(self, environ, start_response):
-            bugsnag.configure_request(user={"id": "5", "email":
-                                            "me@cirw.in", "name": "conrad"})
-            raise SentinalError("oops")
-
-    app = TestApp(BugsnagMiddleware(CrashAfterSettingUserId))
-
-    assert_raises(SentinalError, lambda: app.get('/beans'))
-
-    eq_(deliver.call_count, 1)
-    payload = deliver.call_args[0][0]
-    eq_(payload['events'][0]['user']['id'], '5')
-
-
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_middleware_respects_meta_data(deliver):
-
-    class CrashAfterSettingMetaData(object):
-        def __init__(self, environ, start_response):
-            bugsnag.configure_request(meta_data={"account": {"paying": True}})
-
-        def __iter__(self):
-            raise SentinalError("oops")
-
-    app = TestApp(BugsnagMiddleware(CrashAfterSettingMetaData))
-
-    assert_raises(SentinalError, lambda: app.get('/beans'))
-
-    eq_(deliver.call_count, 1)
-    payload = deliver.call_args[0][0]
-    eq_(payload['events'][0]['metaData']['account'], {"paying": True})
-
-
-@patch('bugsnag.notification.deliver')
-def test_bugsnag_middleware_closes_iterables(deliver):
-
-    class CrashOnCloseIterable(object):
-
-        def __init__(self, environ, start_response):
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_middleware_working(self, deliver):
+        def BasicWorkingApp(environ, start_response):
             start_response("200 OK",
                            [('Content-Type', 'text/plain; charset=utf-8')])
+            return iter([b'OK'])
 
-        def __iter__(self):
-            yield 'OK'
+        app = TestApp(BugsnagMiddleware(BasicWorkingApp))
 
-        def close(self):
-            raise SentinalError("oops")
+        resp = app.get('/', status=200)
+        eq_(resp.body, b'OK')
 
-    app = TestApp(BugsnagMiddleware(CrashOnCloseIterable))
+        eq_(deliver.call_count, 0)
 
-    assert_raises(SentinalError, lambda: app.get('/beans'))
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_middleware_crash_on_start(self, deliver):
 
-    eq_(deliver.call_count, 1)
-    payload = deliver.call_args[0][0]
-    eq_(payload['events'][0]['metaData']['environment']['PATH_INFO'], '/beans')
+        class CrashOnStartApp(object):
+            def __init__(self, environ, start_response):
+                raise SentinalError("oops")
+
+        app = TestApp(BugsnagMiddleware(CrashOnStartApp))
+
+        assert_raises(SentinalError, lambda: app.get('/beans'))
+
+        eq_(deliver.call_count, 1)
+        payload = deliver.call_args[0][0]
+        eq_(payload['events'][0]['context'], 'GET /beans')
+        eq_(payload['events'][0]['metaData']['environment']['PATH_INFO'],
+            '/beans')
+
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_middleware_crash_on_iter(self, deliver):
+        class CrashOnIterApp(Iterator):
+            def __init__(self, environ, start_response):
+                pass
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                raise SentinalError("oops")
+        app = TestApp(BugsnagMiddleware(CrashOnIterApp))
+
+        with self.assertRaises(SentinalError):
+            app.get('/beans')
+
+        eq_(deliver.call_count, 1)
+        payload = deliver.call_args[0][0]
+        eq_(payload['events'][0]['metaData']['environment']['PATH_INFO'],
+            '/beans')
+
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_middleware_crash_on_close(self, deliver):
+        class CrashOnCloseApp(Iterator):
+            def __init__(self, environ, start_response):
+                pass
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                raise StopIteration()
+
+            def close(self):
+                raise SentinalError("oops")
+
+        app = TestApp(BugsnagMiddleware(CrashOnCloseApp))
+
+        assert_raises(SentinalError, lambda: app.get('/beans'))
+
+        eq_(deliver.call_count, 1)
+        payload = deliver.call_args[0][0]
+        eq_(payload['events'][0]['metaData']['environment']['PATH_INFO'],
+            '/beans')
+
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_middleware_respects_user_id(self, deliver):
+
+        class CrashAfterSettingUserId(object):
+            def __init__(self, environ, start_response):
+                bugsnag.configure_request(
+                        user={"id": "5", "email":
+                              "me@cirw.in", "name": "conrad"})
+                raise SentinalError("oops")
+
+        app = TestApp(BugsnagMiddleware(CrashAfterSettingUserId))
+
+        assert_raises(SentinalError, lambda: app.get('/beans'))
+
+        eq_(deliver.call_count, 1)
+        payload = deliver.call_args[0][0]
+        eq_(payload['events'][0]['user']['id'], '5')
+
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_middleware_respects_meta_data(self, deliver):
+
+        class CrashAfterSettingMetaData(object):
+            def __init__(self, environ, start_response):
+                bugsnag.configure_request(meta_data={"account":
+                                                     {"paying": True}})
+
+            def __iter__(self):
+                raise SentinalError("oops")
+
+        app = TestApp(BugsnagMiddleware(CrashAfterSettingMetaData))
+
+        assert_raises(SentinalError, lambda: app.get('/beans'))
+
+        eq_(deliver.call_count, 1)
+        payload = deliver.call_args[0][0]
+        eq_(payload['events'][0]['metaData']['account'], {"paying": True})
+
+    @patch('bugsnag.notification.deliver')
+    def test_bugsnag_middleware_closes_iterables(self, deliver):
+
+        class CrashOnCloseIterable(object):
+
+            def __init__(self, environ, start_response):
+                start_response("200 OK",
+                               [('Content-Type', 'text/plain; charset=utf-8')])
+
+            def __iter__(self):
+                yield 'OK'
+
+            def close(self):
+                raise SentinalError("oops")
+
+        app = TestApp(BugsnagMiddleware(CrashOnCloseIterable))
+
+        assert_raises(SentinalError, lambda: app.get('/beans'))
+
+        eq_(deliver.call_count, 1)
+        payload = deliver.call_args[0][0]
+        eq_(payload['events'][0]['metaData']['environment']['PATH_INFO'],
+            '/beans')

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -12,7 +12,7 @@ import bugsnag.notification
 bugsnag.configuration.api_key = '066f5ad3590596f9aa8d601ea89af845'
 
 
-class SentinalError(RuntimeError):
+class SentinelError(RuntimeError):
     pass
 
 
@@ -37,11 +37,11 @@ class TestWSGI(unittest.TestCase):
 
         class CrashOnStartApp(object):
             def __init__(self, environ, start_response):
-                raise SentinalError("oops")
+                raise SentinelError("oops")
 
         app = TestApp(BugsnagMiddleware(CrashOnStartApp))
 
-        assert_raises(SentinalError, lambda: app.get('/beans'))
+        assert_raises(SentinelError, lambda: app.get('/beans'))
 
         eq_(deliver.call_count, 1)
         payload = deliver.call_args[0][0]
@@ -59,10 +59,10 @@ class TestWSGI(unittest.TestCase):
                 return self
 
             def __next__(self):
-                raise SentinalError("oops")
+                raise SentinelError("oops")
         app = TestApp(BugsnagMiddleware(CrashOnIterApp))
 
-        with self.assertRaises(SentinalError):
+        with self.assertRaises(SentinelError):
             app.get('/beans')
 
         eq_(deliver.call_count, 1)
@@ -83,11 +83,11 @@ class TestWSGI(unittest.TestCase):
                 raise StopIteration()
 
             def close(self):
-                raise SentinalError("oops")
+                raise SentinelError("oops")
 
         app = TestApp(BugsnagMiddleware(CrashOnCloseApp))
 
-        assert_raises(SentinalError, lambda: app.get('/beans'))
+        assert_raises(SentinelError, lambda: app.get('/beans'))
 
         eq_(deliver.call_count, 1)
         payload = deliver.call_args[0][0]
@@ -102,11 +102,11 @@ class TestWSGI(unittest.TestCase):
                 bugsnag.configure_request(
                         user={"id": "5", "email":
                               "me@cirw.in", "name": "conrad"})
-                raise SentinalError("oops")
+                raise SentinelError("oops")
 
         app = TestApp(BugsnagMiddleware(CrashAfterSettingUserId))
 
-        assert_raises(SentinalError, lambda: app.get('/beans'))
+        assert_raises(SentinelError, lambda: app.get('/beans'))
 
         eq_(deliver.call_count, 1)
         payload = deliver.call_args[0][0]
@@ -121,11 +121,11 @@ class TestWSGI(unittest.TestCase):
                                                      {"paying": True}})
 
             def __iter__(self):
-                raise SentinalError("oops")
+                raise SentinelError("oops")
 
         app = TestApp(BugsnagMiddleware(CrashAfterSettingMetaData))
 
-        assert_raises(SentinalError, lambda: app.get('/beans'))
+        assert_raises(SentinelError, lambda: app.get('/beans'))
 
         eq_(deliver.call_count, 1)
         payload = deliver.call_args[0][0]
@@ -144,11 +144,11 @@ class TestWSGI(unittest.TestCase):
                 yield 'OK'
 
             def close(self):
-                raise SentinalError("oops")
+                raise SentinelError("oops")
 
         app = TestApp(BugsnagMiddleware(CrashOnCloseIterable))
 
-        assert_raises(SentinalError, lambda: app.get('/beans'))
+        assert_raises(SentinelError, lambda: app.get('/beans'))
 
         eq_(deliver.call_count, 1)
         payload = deliver.call_args[0][0]


### PR DESCRIPTION
* Reformat tests as `unittest` cases
* Split up sanitization tests to more easily check for breakage
* Simplify string sanitization
* Lint test code