### PR TITLE
Log exception stack traces in middleware

### DIFF
--- a/bugsnag/middleware.py
+++ b/bugsnag/middleware.py
@@ -1,3 +1,5 @@
+import traceback
+
 import bugsnag
 
 
@@ -120,6 +122,7 @@ class MiddlewareStack(object):
         try:
             to_call(notification)
         except Exception as exc:
-            bugsnag.log("Error in exception middleware: %s" % exc)
+            template = "Error in exception middleware: %s\n%s"
+            bugsnag.log(template % (exc, traceback.format_exc()))
             # still notify if middleware crashes before notification
             finish(notification)


### PR DESCRIPTION
Update middleware logging to include the stack trace in addition to the name and description of the exception. Alternately, we can fix this by reraising exception, but I have no context around the current behavior. Any thoughts?

Fixes #61