### PR TITLE
Add support for proxied connections to bugsnag

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,14 @@ import myapp.custom_logging
 bugsnag.configure(traceback_exclude_modules = [myapp.custom_logging])
 ```
 
+### proxy_host
+Proxies all communication with bugsnag.com via `proxy_host`.
+
+```python
+bugsnag.configure(proxy_host = 'http://proxy:3128')
+```
+
+
 Per-request Configuration
 -------------------------
 

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -58,6 +58,8 @@ class Configuration(_BaseConfiguration):
         self.middleware = MiddlewareStack()
         self.middleware.append(DefaultMiddleware)
 
+        self.proxy_host = None
+
         if not os.getenv("DYNO"):
             self.hostname = socket.gethostname()
         else:


### PR DESCRIPTION
Adds new option `proxy_host`

This uses the urllib ProxyHandler to set up proxied connections.