### PR TITLE
Fixes an issue where the library reports `unknown` version of the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## Master
+
+### Bug Fixes
+
+* Fixes an issue where the package version is marked as "unknown".
+
+
 ## 2.4.0 (2016-01-18)
 
 ### Enhancements

--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -258,7 +258,7 @@ class Notification(object):
 
     def _payload(self):
         # Fetch the notifier version from the package
-        notifier_version = package_version("bugsnag_python") or "unknown"
+        notifier_version = package_version("bugsnag") or "unknown"
 
         # Construct the payload dictionary
         return {


### PR DESCRIPTION
Bugsnag searches for `bugsnag_python` as the package name while trying to determine it's own version.

Since the package is actually called `bugsnag`, the version cannot be determined and the library sends `unknown` as the version to the Bugsnag server.

```
>>> import pkg_resources

>>> pkg_resources.get_distribution('bugsnag').version
'2.4.0'

>>> pkg_resources.get_distribution('bugsnag_python')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/kyle/Projects/cocode/api.palaverapp.com/venv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 551, in get_distribution
    dist = get_provider(dist)
  File "/Users/kyle/Projects/cocode/api.palaverapp.com/venv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 431, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/Users/kyle/Projects/cocode/api.palaverapp.com/venv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 952, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/Users/kyle/Projects/cocode/api.palaverapp.com/venv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 839, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'bugsnag-python' distribution was not found and is required by the application
```