### PR TITLE
Improve payload sanitization

### DIFF
--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -16,12 +16,11 @@ from six.moves.urllib.request import (
     install_opener
 )
 from bugsnag.utils import fully_qualified_class_name as class_name
-from bugsnag.utils import json_encode, package_version, sanitize_object
+from bugsnag.utils import SanitizingJSONEncoder, package_version
 
 
 def deliver(payload, url, async, proxy_host):
-    payload = json_encode(payload)
-    req = Request(url, payload, {
+    req = Request(url, payload.encode('utf-8', 'replace'), {
         'Content-Type': 'application/json'
     })
 
@@ -171,8 +170,7 @@ class Notification(object):
         if name not in self.meta_data:
             self.meta_data[name] = {}
 
-        self.meta_data[name].update(sanitize_object(dictionary,
-                                    filters=self.config.params_filters))
+        self.meta_data[name].update(dictionary)
 
     def _generate_stacktrace(self, tb):
         """
@@ -260,38 +258,37 @@ class Notification(object):
         # Fetch the notifier version from the package
         notifier_version = package_version("bugsnag") or "unknown"
         # Construct the payload dictionary
-        return {
+        filters = self.config.params_filters
+        encoder = SanitizingJSONEncoder(separators=(',', ':'),
+                                        keyword_filters=filters)
+        return encoder.encode({
             "apiKey": self.api_key,
             "notifier": {
                 "name": self.NOTIFIER_NAME,
                 "url": self.NOTIFIER_URL,
                 "version": notifier_version,
             },
-            "events": [self._event_payload()]
-        }
-
-    def _event_payload(self):
-        event_dict = {
-            "payloadVersion": self.PAYLOAD_VERSION,
-            "severity": self.severity,
-            "releaseStage": self.release_stage,
-            "appVersion": self.app_version,
-            "context": self.context,
-            "groupingHash": self.grouping_hash,
-            "exceptions": [{
-                "errorClass": class_name(self.exception),
-                "message": self.exception,
-                "stacktrace": self.stacktrace,
-            }],
-            "metaData": self.meta_data,
-            "user": self.user,
-            "device": {
-                "hostname": self.hostname
-            },
-            "projectRoot": self.config.get("project_root"),
-            "libRoot": self.config.get("lib_root")
-        }
-        return sanitize_object(event_dict, filters=self.config.params_filters)
+            "events": [{
+                "payloadVersion": self.PAYLOAD_VERSION,
+                "severity": self.severity,
+                "releaseStage": self.release_stage,
+                "appVersion": self.app_version,
+                "context": self.context,
+                "groupingHash": self.grouping_hash,
+                "exceptions": [{
+                    "errorClass": class_name(self.exception),
+                    "message": self.exception,
+                    "stacktrace": self.stacktrace,
+                }],
+                "metaData": self.meta_data,
+                "user": self.user,
+                "device": {
+                    "hostname": self.hostname
+                },
+                "projectRoot": self.config.get("project_root"),
+                "libRoot": self.config.get("lib_root")
+            }]
+        })
 
     def _send_to_bugsnag(self):
         # Generate the payload and make the request

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -3,93 +3,91 @@ from __future__ import division, print_function, absolute_import
 import inspect
 import traceback
 import six
+from json import JSONEncoder
 
 import bugsnag
-
-try:
-    import json
-except ImportError:
-    import simplejson as json
 
 
 MAX_PAYLOAD_LENGTH = 128 * 1024
 MAX_STRING_LENGTH = 1024
 
 
-def sanitize_object(obj, **kwargs):
-    ignored = kwargs.get("ignored", [])
-    kwargs["ignored"] = ignored
+class SanitizingJSONEncoder(JSONEncoder):
+    """
+    A JSON encoder which handles filtering and conversion from JSON-
+    incompatible types to strings.
 
-    if id(obj) in ignored:
-        return "[RECURSIVE]"
-    if isinstance(obj, dict):
-        ignored.append(id(obj))
-        return _sanitize_dict(obj, **kwargs)
-    elif any(isinstance(obj, t) for t in (list, set, tuple)):
-        ignored.append(id(obj))
-        return [sanitize_object(x, **kwargs) for x in obj]
-    elif any(isinstance(obj, t) for t in (bool, float, int, long)):
-        return obj
-    elif obj is None:
-        return obj
-    else:
-        return _sanitize_as_string(obj)
+    >>> encoder = SanitizingJSONEncoder(filters=['bananas'])
+    >>> encoder.encode({'carrots': 4, 'bananas': 5})
+    "{'carrots': 4, 'bananas': '[FILTERED]'}"
+    """
 
+    filtered_value = '[FILTERED]'
+    recursive_value = '[RECURSIVE]'
+    unencodeable_value = '[BADENCODING]'
 
-def _sanitize_dict(obj, **kwargs):
-    filters = kwargs.get("filters", [])
-    clean_dict = {}
-    for k, v in six.iteritems(obj):
-        # Remove values for keys matching filters
-        is_string = isinstance(k, six.string_types)
-        if is_string and any(f.lower() in k.lower() for f in filters):
-            clean_dict[k] = "[FILTERED]"
+    def __init__(self, keyword_filters=None, **kwargs):
+        self.filters = list(map(str.lower, keyword_filters or []))
+        print(self.filters)
+        self.ignored = []
+        super(SanitizingJSONEncoder, self).__init__(**kwargs)
+
+    def encode(self, obj):
+        safe_obj = self._sanitize(obj, False)
+        payload = super(SanitizingJSONEncoder, self).encode(safe_obj)
+        if len(payload) > MAX_PAYLOAD_LENGTH:
+            safe_obj = self._sanitize(safe_obj, True)
+            return super(SanitizingJSONEncoder, self).encode(safe_obj)
         else:
-            clean_obj = sanitize_object(v, **kwargs)
-            if clean_obj is not None:
-                clean_dict[k] = clean_obj
+            return payload
 
-    return clean_dict
+    def default(self, obj):
+        """
+        Coerce values to strings if possible, otherwise replace with
+        '[BADENCODING]'
+        """
+        try:
+            if six.PY3 and isinstance(obj, bytes):
+                return six.text_type(obj, encoding='utf-8', errors='replace')
+            else:
+                return six.text_type(obj)
 
+        except Exception:
+            exc = traceback.format_exc()
+            bugsnag.warn("Could not add object to payload: %s" % exc)
+            return self.unencodeable_value
 
-def _sanitize_as_string(obj):
-    try:
-        if six.PY3 and isinstance(obj, bytes):
-            string = six.text_type(obj, encoding='utf-8', errors='replace')
+    def _sanitize(self, obj, trim_strings):
+        """
+        Replace recursive values and trim strings longer than
+        MAX_STRING_LENGTH
+        """
+        if id(obj) in self.ignored:
+            return self.recursive_value
+        elif isinstance(obj, dict):
+            self.ignored.append(id(obj))
+            return self._sanitize_dict(obj, trim_strings)
+        elif isinstance(obj, (set, tuple, list)):
+            self.ignored.append(id(obj))
+            return list(self._sanitize(value, trim_strings) for value in obj)
+        elif trim_strings and isinstance(obj, six.string_types):
+            return obj[:MAX_STRING_LENGTH]
         else:
-            string = six.text_type(obj)
+            return obj
 
-    except Exception:
-        exc = traceback.format_exc()
-        bugsnag.warn("Could not add object to metadata: %s" % exc)
-        string = "[BADENCODING]"
+    def _sanitize_dict(self, obj, trim_strings):
+        """
+        Remove any value from the dictionary which match the key filters
+        """
+        clean_dict = {}
+        for key, value in six.iteritems(obj):
+            is_string = isinstance(key, six.string_types)
+            if is_string and any(f in key.lower() for f in self.filters):
+                clean_dict[key] = self.filtered_value
+            else:
+                clean_dict[key] = self._sanitize(value, trim_strings)
 
-    return string
-
-
-def shrink_object(obj):
-    if isinstance(obj, six.string_types):
-        return obj[:MAX_STRING_LENGTH]
-
-    elif isinstance(obj, dict):
-        for k, v in six.iteritems(obj):
-            obj[k] = shrink_object(v)
-
-    elif any(isinstance(obj, t) for t in (list, set, tuple)):
-        return [shrink_object(x) for x in obj]
-
-    return obj
-
-
-def json_encode(obj):
-
-    payload = json.dumps(obj)
-
-    if len(payload) > MAX_PAYLOAD_LENGTH:
-        obj = shrink_object(json.loads(payload))
-        payload = json.dumps(obj)
-
-    return payload.encode('utf-8', 'replace')
+        return clean_dict
 
 
 def fully_qualified_class_name(obj):

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -23,7 +23,8 @@ def sanitize_object(obj, **kwargs):
         clean_dict = {}
         for k, v in six.iteritems(obj):
             # Remove values for keys matching filters
-            if any(f.lower() in k.lower() for f in filters):
+            is_string = isinstance(k, six.string_types)
+            if is_string and any(f.lower() in k.lower() for f in filters):
                 clean_dict[k] = "[FILTERED]"
             else:
                 clean_obj = sanitize_object(v, **kwargs)
@@ -34,6 +35,8 @@ def sanitize_object(obj, **kwargs):
     elif any(isinstance(obj, t) for t in (list, set, tuple)):
         return [sanitize_object(x, **kwargs) for x in obj]
     elif any(isinstance(obj, t) for t in (bool, float, int)):
+        return obj
+    elif obj is None:
         return obj
     else:
         try:

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -18,8 +18,13 @@ MAX_STRING_LENGTH = 1024
 
 def sanitize_object(obj, **kwargs):
     filters = kwargs.get("filters", [])
+    ignored = kwargs.get("ignored", [])
+    kwargs["ignored"] = ignored
 
+    if id(obj) in ignored:
+        return "[RECURSIVE]"
     if isinstance(obj, dict):
+        ignored.append(id(obj))
         clean_dict = {}
         for k, v in six.iteritems(obj):
             # Remove values for keys matching filters
@@ -33,6 +38,7 @@ def sanitize_object(obj, **kwargs):
 
         return clean_dict
     elif any(isinstance(obj, t) for t in (list, set, tuple)):
+        ignored.append(id(obj))
         return [sanitize_object(x, **kwargs) for x in obj]
     elif any(isinstance(obj, t) for t in (bool, float, int)):
         return obj

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -17,7 +17,6 @@ MAX_STRING_LENGTH = 1024
 
 
 def sanitize_object(obj, **kwargs):
-    filters = kwargs.get("filters", [])
     ignored = kwargs.get("ignored", [])
     kwargs["ignored"] = ignored
 
@@ -25,38 +24,47 @@ def sanitize_object(obj, **kwargs):
         return "[RECURSIVE]"
     if isinstance(obj, dict):
         ignored.append(id(obj))
-        clean_dict = {}
-        for k, v in six.iteritems(obj):
-            # Remove values for keys matching filters
-            is_string = isinstance(k, six.string_types)
-            if is_string and any(f.lower() in k.lower() for f in filters):
-                clean_dict[k] = "[FILTERED]"
-            else:
-                clean_obj = sanitize_object(v, **kwargs)
-                if clean_obj is not None:
-                    clean_dict[k] = clean_obj
-
-        return clean_dict
+        return _sanitize_dict(obj, **kwargs)
     elif any(isinstance(obj, t) for t in (list, set, tuple)):
         ignored.append(id(obj))
         return [sanitize_object(x, **kwargs) for x in obj]
-    elif any(isinstance(obj, t) for t in (bool, float, int)):
+    elif any(isinstance(obj, t) for t in (bool, float, int, long)):
         return obj
     elif obj is None:
         return obj
     else:
-        try:
-            if six.PY3 and isinstance(obj, bytes):
-                string = six.text_type(obj, encoding='utf-8', errors='replace')
-            else:
-                string = six.text_type(obj)
+        return _sanitize_as_string(obj)
 
-        except Exception:
-            exc = traceback.format_exc()
-            bugsnag.warn("Could not add object to metadata: %s" % exc)
-            string = "[BADENCODING]"
 
-        return string
+def _sanitize_dict(obj, **kwargs):
+    filters = kwargs.get("filters", [])
+    clean_dict = {}
+    for k, v in six.iteritems(obj):
+        # Remove values for keys matching filters
+        is_string = isinstance(k, six.string_types)
+        if is_string and any(f.lower() in k.lower() for f in filters):
+            clean_dict[k] = "[FILTERED]"
+        else:
+            clean_obj = sanitize_object(v, **kwargs)
+            if clean_obj is not None:
+                clean_dict[k] = clean_obj
+
+    return clean_dict
+
+
+def _sanitize_as_string(obj):
+    try:
+        if six.PY3 and isinstance(obj, bytes):
+            string = six.text_type(obj, encoding='utf-8', errors='replace')
+        else:
+            string = six.text_type(obj)
+
+    except Exception:
+        exc = traceback.format_exc()
+        bugsnag.warn("Could not add object to metadata: %s" % exc)
+        string = "[BADENCODING]"
+
+    return string
 
 
 def shrink_object(obj):

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -93,8 +93,9 @@ class TestFlask(unittest.TestCase):
             raise SentinelError("oops")
 
         handle_exceptions(app)
-        app.test_client().get('/hello')
-        app.test_client().get('/hello')
+        with app.test_client() as client:
+            client.get('/hello')
+            client.get('/hello')
         self.server.shutdown()
 
         payload = self.server.received[0]['json_body']

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import unittest
 
 from bugsnag.configuration import Configuration
@@ -18,7 +19,7 @@ class TestNotification(unittest.TestCase):
 
         notification.add_tab("request", {"arguments": {"password": "secret"}})
 
-        payload = notification._payload()
+        payload = json.loads(notification._payload())
         request = payload['events'][0]['metaData']['request']
         self.assertEqual(request['arguments']['password'], '[FILTERED]')
         self.assertEqual(request['params']['password'], '[FILTERED]')
@@ -31,20 +32,20 @@ class TestNotification(unittest.TestCase):
         line = inspect.currentframe().f_lineno + 1
         notification = Notification(Exception("oops"), config, {})
 
-        payload = notification._payload()
+        payload = json.loads(notification._payload())
 
         code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
         lvl = "        "
-        self.assertEqual(code[line - 3], lvl + "\"\"\"")
-        self.assertEqual(code[line - 2], lvl + "config = Configuration()")
-        self.assertEqual(code[line - 1],
+        self.assertEqual(code[str(line - 3)], lvl + "\"\"\"")
+        self.assertEqual(code[str(line - 2)], lvl + "config = Configuration()")
+        self.assertEqual(code[str(line - 1)],
                 lvl + "line = inspect.currentframe().f_lineno + 1")
-        self.assertEqual(code[line], lvl +
+        self.assertEqual(code[str(line)], lvl +
                 "notification = Notification(Exception(\"oops\"), config, {})")
-        self.assertEqual(code[line + 1], "")
-        self.assertEqual(code[line + 2],
-                lvl + "payload = notification._payload()")
-        self.assertEqual(code[line + 3], "")
+        self.assertEqual(code[str(line + 1)], "")
+        self.assertEqual(code[str(line + 2)],
+                lvl + "payload = json.loads(notification._payload())")
+        self.assertEqual(code[str(line + 3)], "")
 
     def test_code_at_start_of_file(self):
 
@@ -52,16 +53,16 @@ class TestNotification(unittest.TestCase):
         notification = Notification(fixtures.start_of_file[1], config, {},
                                     traceback=fixtures.start_of_file[2])
 
-        payload = notification._payload()
+        payload = json.loads(notification._payload())
 
         code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
-        self.assertEqual({1: '# flake8: noqa',
-             2: 'try:',
-             3: '    import sys; raise Exception("start")',
-             4: 'except Exception: start_of_file = sys.exc_info()',
-             5: '# 4',
-             6: '# 5',
-             7: '# 6'}, code)
+        self.assertEqual({'1': '# flake8: noqa',
+             '2': 'try:',
+             '3': '    import sys; raise Exception("start")',
+             '4': 'except Exception: start_of_file = sys.exc_info()',
+             '5': '# 4',
+             '6': '# 5',
+             '7': '# 6'}, code)
 
     def test_code_at_end_of_file(self):
 
@@ -69,16 +70,16 @@ class TestNotification(unittest.TestCase):
         notification = Notification(fixtures.end_of_file[1], config, {},
                                     traceback=fixtures.end_of_file[2])
 
-        payload = notification._payload()
+        payload = json.loads(notification._payload())
 
         code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
-        self.assertEqual({6:  '# 5',
-             7:  '# 6',
-             8:  '# 7',
-             9:  '# 8',
-             10: 'try:',
-             11: '    import sys; raise Exception("end")',
-             12: 'except Exception: end_of_file = sys.exc_info()'}, code)
+        self.assertEqual({'6':  '# 5',
+             '7':  '# 6',
+             '8':  '# 7',
+             '9':  '# 8',
+             '10': 'try:',
+             '11': '    import sys; raise Exception("end")',
+             '12': 'except Exception: end_of_file = sys.exc_info()'}, code)
 
     def test_code_turned_off(self):
         config = Configuration()
@@ -86,7 +87,7 @@ class TestNotification(unittest.TestCase):
         notification = Notification(Exception("oops"), config, {},
                                     traceback=fixtures.end_of_file[2])
 
-        payload = notification._payload()
+        payload = json.loads(notification._payload())
 
         code = payload['events'][0]['exceptions'][0]['stacktrace'][0]['code']
         self.assertEqual(code, None)

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -233,6 +233,54 @@ class TestBugsnag(unittest.TestCase):
         self.assertEqual(['foo', 'bar', '[RECURSIVE]'],
                          event['metaData']['a']['b'])
 
+    def test_notify_metadata_bool_value(self):
+        bugsnag.notify(ScaryException('unexpected failover'),
+                       value=True, value2=False)
+        self.server.shutdown()
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        self.assertEqual(True, event['metaData']['custom']['value'])
+        self.assertEqual(False, event['metaData']['custom']['value2'])
+
+    def test_notify_metadata_complex_value(self):
+        bugsnag.notify(ScaryException('unexpected failover'),
+                       value=(5+0j), value2=(13+3.4j))
+        self.server.shutdown()
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        self.assertEqual('(5+0j)', event['metaData']['custom']['value'])
+        self.assertEqual('(13+3.4j)', event['metaData']['custom']['value2'])
+
+    def test_notify_metadata_set_value(self):
+        bugsnag.notify(ScaryException('unexpected failover'),
+                       value=set([6, "cow", "gravy"]))
+        self.server.shutdown()
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        value = event['metaData']['custom']['value']
+        self.assertEqual(3, len(value))
+        self.assertTrue(6 in value)
+        self.assertTrue("cow" in value)
+        self.assertTrue("gravy" in value)
+
+    def test_notify_metadata_tuple_value(self):
+        bugsnag.notify(ScaryException('unexpected failover'),
+                       value=(3, "cow", "gravy"))
+        self.server.shutdown()
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        self.assertEqual([3, "cow", "gravy"],
+                         event['metaData']['custom']['value'])
+
+    def test_notify_metadata_integer_value(self):
+        bugsnag.notify(ScaryException('unexpected failover'),
+                       value=5, value2=-13)
+        self.server.shutdown()
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        self.assertEqual(5, event['metaData']['custom']['value'])
+        self.assertEqual(-13, event['metaData']['custom']['value2'])
+
     def test_notify_error_message(self):
         bugsnag.notify(ScaryException(u('unexpécted failover')))
         self.server.shutdown()

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -24,7 +24,7 @@ class TestBugsnag(unittest.TestCase):
                           release_stage='dev',
                           async=False)
 
-    def shutDown(self):
+    def tearDown(self):
         bugsnag.configuration = bugsnag.Configuration()
         bugsnag.configuration.api_key = 'some key'
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,17 @@
 import unittest
+import json
 
 from six import u
-from bugsnag.utils import json_encode, sanitize_object
+from bugsnag.utils import SanitizingJSONEncoder
 
 
 class TestUtils(unittest.TestCase):
 
-    def test_sanitize_filters(self):
+    def test_encode_filters(self):
         data = {"credit_card": "123213213123", "password": "456", "cake": True}
-        sane_data = sanitize_object(data, filters=["credit_card", "password"])
+        encoder = SanitizingJSONEncoder(keyword_filters=["credit_card",
+                                                         "password"])
+        sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data, {"credit_card": "[FILTERED]",
                                      "password": "[FILTERED]",
                                      "cake": True})
@@ -16,32 +19,39 @@ class TestUtils(unittest.TestCase):
     def test_sanitize_list(self):
         data = {"list": ["carrots", "apples", "peas"],
                 "passwords": ["abc", "def"]}
-        sane_data = sanitize_object(data, filters=["credit_card", "password"])
+        encoder = SanitizingJSONEncoder(keyword_filters=["credit_card",
+                                                         "passwords"])
+        sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data, {"list": ["carrots", "apples", "peas"],
                                      "passwords": "[FILTERED]"})
 
     def test_sanitize_valid_unicode_object(self):
         data = {"item": u('\U0001f62c')}
-        sane_data = sanitize_object(data, filters=[])
+        encoder = SanitizingJSONEncoder(keyword_filters=[])
+        sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data, data)
 
     def test_sanitize_nested_object_filters(self):
         data = {"metadata": {"another_password": "My password"}}
-        sane_data = sanitize_object(data, filters=["password"])
+        encoder = SanitizingJSONEncoder(keyword_filters=["password"])
+        sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data,
                          {"metadata": {"another_password": "[FILTERED]"}})
 
     def test_sanitize_bad_utf8_object(self):
         data = {"bad_utf8": u("test \xe9")}
-        sane_data = sanitize_object(data, filters=[])
+        encoder = SanitizingJSONEncoder(keyword_filters=[])
+        sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data, data)
 
     def test_sanitize_unencoded_object(self):
         data = {"exc": Exception()}
-        sane_data = sanitize_object(data, filters=[])
+        encoder = SanitizingJSONEncoder(keyword_filters=[])
+        sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data, {"exc": ""})
 
     def test_json_encode(self):
         payload = {"a": u("a") * 512 * 1024}
-        encoded = ('{"a": "' + 'a' * 1024 + '"}').encode('utf-8', 'replace')
-        self.assertEqual(json_encode(payload), encoded)
+        expected = {"a": u("a") * 1024}
+        encoder = SanitizingJSONEncoder(keyword_filters=[])
+        self.assertEqual(json.loads(encoder.encode(payload)), expected)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,4 @@
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 from threading import Thread
 
 from six.moves import BaseHTTPServer

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,7 +34,7 @@ class FakeBugsnagServer(object):
         self.server = BaseHTTPServer.HTTPServer((self.host, self.port),
                                                 Handler)
         self.server.timeout = 0.5
-        self.thread = Thread(target=self.server.serve_forever)
+        self.thread = Thread(target=self.server.serve_forever, args=(0.1,))
         self.thread.daemon = True
         self.thread.start()
 


### PR DESCRIPTION
This changeset increases the amount of payload sanitization while consolidating the sanitization and encoding logic into a `JSONEncoder`.

## Changes

* Handle recursive fields in payload
* Handle coercion to unicode strings in non-metadata fields
* Remove imports of `simplejson` as it is not applicable on Python 2.6+
* Improve test coverage
