### PR TITLE
Switch out flake8 for pycodestyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# Virtualenv
+venv/

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,4 @@
+pycodestyle==2.0.0
 twine
 wheel
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-LINT_TMP=`mktemp -t lint.XXXXXX`
-flake8 bugsnag tests > $LINT_TMP
-if [ -s $LINT_TMP ]; then
-    cat $LINT_TMP
+LINT_TMP="$(mktemp -t lint.XXXXXX)"
+pycodestyle --exclude=venv > "$LINT_TMP"
+if [ -s "$LINT_TMP" ]; then
+    cat "$LINT_TMP"
     exit 1
 else
     echo "No linting errors found."


### PR DESCRIPTION
* Add `pycodestyle` to `dev_requirements.txt`
* Switch `scripts/lint.sh` to run `pycodestyle` instead of `flake8`

Fixes #85

CC @kattrali 