### PR TITLE
Replace logging with a proper logger

### DIFF
--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -1,8 +1,18 @@
 import types
 import sys
+import logging
 
 from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.notification import Notification
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler(sys.stderr)
+formatter = logging.Formatter(
+    '%(asctime)s - [%(name)s] %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 
 
 configuration = Configuration()
@@ -60,8 +70,8 @@ def notify(exception, **options):
         except:
             value = '[BADENCODING]'
 
-        warn(('Coercing invalid bugnsag.notify()'
-              'value to RuntimeError: %s') % value)
+        logger.warning('Coercing invalid bugnsag.notify()'
+                       ' value to RuntimeError: %s' % value)
         exception = RuntimeError(value)
 
     Notification(exception, configuration,
@@ -86,27 +96,12 @@ def before_notify(callback):
     configuration.middleware.before_notify(callback)
 
 
-def log(message):
-    """
-    Print a log message with a Bugsnag prefix.
-    """
-    print(("** [Bugsnag] %s" % message))
-
-
-def warn(message):
-    """
-    Print a warning message with a Bugsnag prefix.
-    """
-    sys.stderr.write("** [Bugsnag] WARNING: %s\n" % message)
-
-
 # Hook into all uncaught exceptions
 def __bugsnag_excepthook(exctype, exception, traceback):
     try:
         auto_notify(exception, traceback=traceback)
     except:
-        print(("[BUGSNAG] Error in excepthook, probably shutting down."))
-        pass
+        logger.exception('Error in excepthook, probably shutting down.')
 
     _old_excepthook(exctype, exception, traceback)
 

--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -27,8 +27,8 @@ def add_django_request_to_notification(notification):
             email = getattr(request.user, 'email', None)
             username = six.text_type(request.user.get_username())
             notification.set_user(id=username, email=email, name=name)
-        except Exception as e:
-            bugsnag.warn("could not get user data: %s" % e)
+        except Exception:
+            bugsnag.logger.exception('Could not get user data')
     else:
         notification.set_user(id=request.META['REMOTE_ADDR'])
 

--- a/bugsnag/django/middleware.py
+++ b/bugsnag/django/middleware.py
@@ -24,8 +24,8 @@ class BugsnagMiddleware(object):
         try:
             bugsnag.auto_notify(exception)
 
-        except Exception as exc:
-            bugsnag.log("Error in exception middleware: %s" % exc)
+        except Exception:
+            bugsnag.logger.exception('Error in exception middleware')
 
         bugsnag.clear_request_config()
 

--- a/bugsnag/middleware.py
+++ b/bugsnag/middleware.py
@@ -1,5 +1,3 @@
-import traceback
-
 import bugsnag
 
 
@@ -125,8 +123,7 @@ class MiddlewareStack(object):
 
         try:
             to_call(notification)
-        except Exception as exc:
-            template = "Error in exception middleware: %s\n%s"
-            bugsnag.log(template % (exc, traceback.format_exc()))
+        except Exception:
+            bugsnag.logger.exception('Error in exception middleware')
             # still notify if middleware crashes before notification
             finish(notification)

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -1,7 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
 import inspect
-import traceback
 import six
 from json import JSONEncoder
 
@@ -28,7 +27,6 @@ class SanitizingJSONEncoder(JSONEncoder):
 
     def __init__(self, keyword_filters=None, **kwargs):
         self.filters = list(map(str.lower, keyword_filters or []))
-        print(self.filters)
         self.ignored = []
         super(SanitizingJSONEncoder, self).__init__(**kwargs)
 
@@ -53,8 +51,7 @@ class SanitizingJSONEncoder(JSONEncoder):
                 return six.text_type(obj)
 
         except Exception:
-            exc = traceback.format_exc()
-            bugsnag.warn("Could not add object to payload: %s" % exc)
+            bugsnag.logger.exception('Could not add object to payload')
             return self.unencodeable_value
 
     def _sanitize(self, obj, trim_strings):


### PR DESCRIPTION
This pull request switches out the custom printing to a Python logger which will log everything to stderr. This simplifies and unifies the logging experience, handled exceptions are always logged consistently with the exception name and traceback. No more manually doing `traceback.format_exc()` etc.

This also gives users of the bugsnag library a way to customise or disable logging of certain information. For example, I could customise the logging level, to prevent the `INFO` logged events which happen every time a notification is sent.

```python
import logging
import bugsnag

bugsnag.logger.setLevel(logging.WARNING)
```

To demonstrate the behaviour and how the logger format works. Here's a short Python script:

```python
import bugsnag

bugsnag.notify('test')

bugsnag.configure(api_key='test', asynchronous=False)
bugsnag.notify('test')

bugsnag.configure(api_key='test', asynchronous=False, endpoint='invalid-example.com')
bugsnag.notify('test')
```

When ran, you can see the logged output:

```shell
$ python logging-test.py 
2016-08-20 15:06:38,284 - [bugsnag] WARNING - No API key configured, couldn't notify
2016-08-20 15:06:38,284 - [bugsnag] INFO - Notifying https://notify.bugsnag.com of exception
2016-08-20 15:06:38,890 - [bugsnag] INFO - Notifying https://invalid-example.com of exception
2016-08-20 15:06:38,942 - [bugsnag] ERROR - Failed to send notification to https://invalid-example.com
Traceback (most recent call last):
  File "/Users/kyle/Projects/bugsnag/bugsnag-python/bugsnag/notification.py", line 36, in request
    resp = urlopen(req)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 431, in open
    response = self._open(req, data)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 449, in _open
    '_open', req)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 1240, in https_open
    context=self._context)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 1197, in do_open
    raise URLError(err)
URLError: <urlopen error [Errno 8] nodename nor servname provided, or not known>
```