### PR TITLE
No longer register a global proxy opener

### DIFF
--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -10,10 +10,8 @@ import traceback
 import bugsnag
 from six.moves.urllib.request import (
     Request,
-    urlopen,
     ProxyHandler,
-    build_opener,
-    install_opener
+    build_opener
 )
 from bugsnag.utils import fully_qualified_class_name as class_name
 from bugsnag.utils import SanitizingJSONEncoder, package_version
@@ -26,14 +24,17 @@ def deliver(payload, url, async, proxy_host):
 
     def request():
         if proxy_host:
-            proxy = ProxyHandler({
+            proxies = ProxyHandler({
                 'https': proxy_host,
                 'http': proxy_host
             })
-            opener = build_opener(proxy)
-            install_opener(opener)
+
+            opener = build_opener(proxies)
+        else:
+            opener = build_opener()
+
         try:
-            resp = urlopen(req)
+            resp = opener.open(req)
             status = resp.getcode()
 
             if status != 200:

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -21,7 +21,7 @@ class TestFlask(unittest.TestCase):
     def setUp(self):
         self.server = FakeBugsnagServer(5435)
         bugsnag.configure(use_ssl=False,
-                          endpoint=self.server.url(),
+                          endpoint=self.server.address,
                           api_key='3874876376238728937',
                           notify_release_stages=['dev'],
                           release_stage='dev',

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -18,7 +18,7 @@ class TestBugsnag(unittest.TestCase):
         """
         self.server = FakeBugsnagServer()
         bugsnag.configure(use_ssl=False,
-                          endpoint=self.server.url(),
+                          endpoint=self.server.address,
                           api_key='tomatoes',
                           notify_release_stages=['dev'],
                           release_stage='dev',
@@ -359,3 +359,12 @@ class TestBugsnag(unittest.TestCase):
         self.assertEqual('    chain_2()', frames[2]['code']['2'])
         self.assertEqual('', frames[2]['code']['3'])
         self.assertEqual('', frames[2]['code']['4'])
+
+    def test_notify_proxy(self):
+        bugsnag.configure(proxy_host=self.server.url)
+        bugsnag.notify(ScaryException('unexpected failover'))
+        self.server.shutdown()
+
+        self.assertEqual(len(self.server.received), 1)
+        self.assertEqual(self.server.received[0]['method'], 'POST')
+        self.assertEqual(self.server.received[0]['path'], self.server.url)

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -18,7 +18,7 @@ class TestWSGI(unittest.TestCase):
     def setUp(self):
         self.server = FakeBugsnagServer(5858)
         bugsnag.configure(use_ssl=False,
-                          endpoint=self.server.url(),
+                          endpoint=self.server.address,
                           api_key='3874876376238728937',
                           notify_release_stages=['dev'],
                           release_stage='dev',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,8 +34,13 @@ class FakeBugsnagServer(object):
         self.thread.daemon = True
         self.thread.start()
 
-    def url(self):
+    @property
+    def address(self):
         return '%s:%d' % (self.host, self.port)
+
+    @property
+    def url(self):
+        return 'http://%s' % self.address
 
     def shutdown(self):
         self.server.shutdown()


### PR DESCRIPTION
Bugsnag should not affect the global urllib2 state and only register the proxy for the specific request.

This commit also adds test coverage for the proxy itself.