### PR TITLE
Improve test coverage, refactor notification with non-Exception objects

### DIFF
--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -293,6 +293,10 @@ class Notification(object):
         })
 
     def _send_to_bugsnag(self):
+        if self.api_key is None:
+            bugsnag.log("No API key configured, couldn't notify")
+            return
+
         # Generate the payload and make the request
         url = self.config.get_endpoint()
         async = self.config.asynchronous

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -174,6 +174,16 @@ class TestBugsnag(unittest.TestCase):
         event = json_body['events'][0]
         self.assertEqual('bar', event['metaData']['custom']['foo'])
 
+    def test_notify_before_notify_remove_api_key(self):
+
+        def callback(report):
+            report.api_key = None
+
+        bugsnag.before_notify(callback)
+        bugsnag.notify(ScaryException('unexpected failover'))
+        self.server.shutdown()
+        self.assertEqual(0, len(self.server.received))
+
     def test_notify_before_notify_modifying_api_key(self):
 
         def callback(report):


### PR DESCRIPTION
This changeset adds a number of tests for when a notification is sent to Bugsnag with 
objects which aren’t exceptions.

Additional behavior was added for the following cases:

1. When a callback/middleware set the `api_key` to `None`, the request was still sent. These requests are now cancelled and logged.
2. When a tuple was passed to `notify()` but did not contain a traceback at index `2`, an exception was thrown and logged. The index and value is now checked and only attached if it is a `TracebackType`
3. When a tuple was passed to notify and it had less than two values, an exception was thrown and logged. The value is now coerced into a `RuntimeError` and sent to Bugsnag
4. When an object which is not an Exception or tuple was passed to `notify()`, it was coerced into a string and the `errorClass` was set to the type of that object (like `int` or `str`). The value is now coerced into a `RuntimeError` and sent to Bugsnag