### PR TITLE
Mute test logging, run sync

### DIFF
--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -45,11 +45,11 @@ def deliver(payload, url, async, proxy_host):
             bugsnag.logger.exception(
                 'Failed to send notification to %s' % url)
 
-    t = threading.Thread(target=request)
-    t.start()
-
-    if not async:
-        t.join()
+    if async:
+        t = threading.Thread(target=request)
+        t.start()
+    else:
+        request()
 
 
 class Notification(object):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import logging
+
+import bugsnag
+
+bugsnag.logger.setLevel(logging.CRITICAL)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,11 +30,9 @@ class FakeBugsnagServer(object):
     A server which accepts a single request, recording the JSON payload and
     other request information
     """
-    host = 'localhost'
 
-    def __init__(self, port=5555):
+    def __init__(self):
         self.received = []
-        self.port = port
 
         class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
 
@@ -50,8 +48,7 @@ class FakeBugsnagServer(object):
             def log_request(self, *args):
                 pass
 
-        self.server = BaseHTTPServer.HTTPServer((self.host, self.port),
-                                                Handler)
+        self.server = BaseHTTPServer.HTTPServer(('localhost', 0), Handler)
         self.server.timeout = 0.5
         self.thread = Thread(target=self.server.serve_forever, args=(0.1,))
         self.thread.daemon = True
@@ -59,7 +56,7 @@ class FakeBugsnagServer(object):
 
     @property
     def address(self):
-        return '%s:%d' % (self.host, self.port)
+        return '{0}:{1}'.format(*self.server.server_address)
 
     @property
     def url(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,6 +27,9 @@ class FakeBugsnagServer(object):
                                       'path': handler.path,
                                       'method': handler.command})
 
+            def log_request(self, *args):
+                pass
+
         self.server = BaseHTTPServer.HTTPServer((self.host, self.port),
                                                 Handler)
         self.server.timeout = 0.5

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,28 @@
 import json
+import unittest
 from threading import Thread
 
 from six.moves import BaseHTTPServer
+
+import bugsnag
+
+
+class IntegrationTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = FakeBugsnagServer()
+
+    def setUp(self):
+        self.server.received = []
+
+    def tearDown(self):
+        bugsnag.configuration = bugsnag.Configuration()
+        bugsnag.configuration.api_key = 'some key'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
 
 
 class FakeBugsnagServer(object):
@@ -10,7 +31,6 @@ class FakeBugsnagServer(object):
     other request information
     """
     host = 'localhost'
-    json_body = None
 
     def __init__(self, port=5555):
         self.received = []


### PR DESCRIPTION
Turn off non-critical logs during tests and alter the implementation of integration tests to run synchronously. 

* Fixes that one flaky test
* Removes unneeded noise
* Improves run consistency by reducing threads generated