### PR TITLE
Create log handlers from clients

### DIFF
--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -5,6 +5,7 @@ from types import FunctionType
 
 from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.notification import Notification
+from bugsnag.handlers import BugsnagHandler
 
 import bugsnag
 
@@ -139,6 +140,9 @@ class Client(object):
             return False
 
         return True
+
+    def log_handler(self):
+        return BugsnagHandler(client=self)
 
 
 class ClientContext(object):

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -1,56 +1,128 @@
 from __future__ import division, print_function, absolute_import
 
 import logging
+import warnings
+
 import bugsnag
 
 
 class BugsnagHandler(logging.Handler, object):
-    def __init__(self, api_key=None, extra_fields={}):
+    def __init__(self, api_key=None, extra_fields=None, client=None):
+        """
+        Creates a new handler which sends records to Bugsnag
+        """
         super(BugsnagHandler, self).__init__()
-        self.api_key = api_key
-        self.extra_fields = extra_fields
+        self.client = client
+        self.callbacks = [self.extract_metadata, self.extract_severity]
+
+        if api_key is not None:
+            warnings.warn('api_key is deprecated in favor of using a client '
+                          'to set the correct API key '
+                          'and will be removed in a future release.',
+                          DeprecationWarning)
+
+            def add_api_key(record, options):
+                options['api_key'] = api_key
+
+            self.add_callback(add_api_key)
+
+        if extra_fields is not None:
+            warnings.warn('extra_fields is deprecated in favor of using a '
+                          'client and changing notification options using '
+                          'add_callback. '
+                          'extra_fields will be removed in a future release.',
+                          DeprecationWarning)
+
+            def add_extra_fields(record, options):
+                if 'meta_data' not in options:
+                    options['meta_data'] = {}
+
+                for section in extra_fields:
+                    if section not in options['meta_data']:
+                        options['meta_data'][section] = {}
+
+                    for field in extra_fields[section]:
+                        if hasattr(record, field):
+                            attr = getattr(record, field)
+                            options['meta_data'][section][field] = attr
+
+            self.add_callback(add_extra_fields)
 
     def emit(self, record):
-        # Severity is not a one-to-one mapping, as there are only
-        # a fixed number of severity levels available server side
-        if record.levelname.lower() in ['error', 'critical']:
-            severity = 'error'
-        elif record.levelname.lower() in ['warning', ]:
-            severity = 'warning'
-        else:
-            severity = 'info'
+        """
+        Outputs the record to Bugsnag
+        """
+        options = {}
 
-        # Only extract a few specific fields, as we don't want to
-        # repeat data already being sent over the wire (such as exc)
-        record_fields = ['asctime', 'created', 'levelname', 'levelno', 'msecs',
-                         'name', 'process', 'processName', 'relativeCreated',
-                         'thread', 'threadName', ]
+        for callback in self.callbacks:
+            try:
+                callback(record, options)
+            except Exception as e:
+                bugsnag.logger.error('Failed to run handler callback %s', e)
 
-        extra_data = {}
-        for field in record_fields:
-            if hasattr(record, field):
-                extra_data[field] = getattr(record, field)
-        metadata = {"extra data": extra_data}
-        for tab_name in self.extra_fields:
-            metadata[tab_name] = {}
-            for field_name in self.extra_fields[tab_name]:
-                if hasattr(record, field_name):
-                    metadata[tab_name][field_name] = getattr(record,
-                                                             field_name)
-
-        api_key = self.api_key or bugsnag.configuration.api_key
+        client = self.client or bugsnag.legacy.default_client
 
         if record.exc_info:
-            bugsnag.notify(record.exc_info, severity=severity,
-                           meta_data=metadata, api_key=api_key)
+            client.notify_exc_info(*record.exc_info, **options)
         else:
             # Create exception type dynamically, to prevent bugsnag.handlers
             # being prepended to the exception name due to class name
             # detection in utils. Because we are messing with the module
             # internals, we don't really want to expose this class anywhere
-            level_name = record.levelname if record.levelname else "Message"
-            exc_type = type('Log'+level_name, (Exception, ), {})
+            level_name = record.levelname or "Message"
+            exc_type = type('Log' + level_name, (Exception, ), {})
             exc = exc_type(record.getMessage())
-            exc.__module__ = '__main__'
+            exc.__module__ = None
 
-            bugsnag.notify(exc, severity=severity, meta_data=metadata)
+            client.notify(exc, **options)
+
+    def add_callback(self, callback):
+        """
+        Add a new callback to be invoked after an log message is sent but
+        before it is sent to Bugsnag. Each callback is invoked with the
+        LogRecord and options to be sent to notify.
+        """
+        self.callbacks.append(callback)
+
+    def remove_callback(self, callback):
+        """
+        Remove a callback
+        """
+        self.callbacks.remove(callback)
+
+    def clear_callbacks(self):
+        """
+        Clear all callbacks
+        """
+        del self.callbacks[:]
+
+    def extract_severity(self, record, options):
+        """
+        Convert log record level into severity levels
+        """
+        levelno = record.levelno or logging.WARNING
+
+        if levelno >= logging.ERROR:
+            options['severity'] = 'error'
+        elif levelno >= logging.WARNING:
+            options['severity'] = 'warning'
+        else:
+            options['severity'] = 'info'
+
+    def extract_metadata(self, record, options):
+        """
+        Extract log record fields into error report metadata
+        """
+        record_fields = ('asctime', 'created', 'levelname', 'levelno', 'msecs',
+                         'name', 'process', 'processName', 'relativeCreated',
+                         'thread', 'threadName',)
+
+        extra_data = {}
+        for field in record_fields:
+            if hasattr(record, field):
+                extra_data[field] = getattr(record, field)
+
+        if 'meta_data' not in options:
+            options['meta_data'] = {}
+
+        options['meta_data']['extra data'] = extra_data

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,18 +1,37 @@
+from functools import wraps
 import logging
-import sys
 
 from six import u
 
 from bugsnag.handlers import BugsnagHandler
+from bugsnag import Client
 import bugsnag
 
-from tests.utils import IntegrationTest
+from tests.utils import IntegrationTest, ScaryException
 
 
-class HandlerTest(IntegrationTest):
+def use_client_logger(func):
+    @wraps(func)
+    def wrapped(obj):
+        client = Client(use_ssl=False,
+                        endpoint=obj.server.address,
+                        api_key='tomatoes',
+                        asynchronous=False)
+        handler = client.log_handler()
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+        try:
+            func(obj, handler, logger)
+        finally:
+            logger.removeHandler(handler)
+
+    return wrapped
+
+
+class HandlersTest(IntegrationTest):
 
     def setUp(self):
-        super(HandlerTest, self).setUp()
+        super(HandlersTest, self).setUp()
         bugsnag.configure(use_ssl=False,
                           endpoint=self.server.address,
                           api_key='tomatoes',
@@ -22,7 +41,7 @@ class HandlerTest(IntegrationTest):
         bugsnag.logger.setLevel(logging.INFO)
 
     def tearDown(self):
-        super(HandlerTest, self).tearDown()
+        super(HandlersTest, self).tearDown()
         bugsnag.logger.setLevel(logging.CRITICAL)
 
     def test_message(self):
@@ -118,21 +137,75 @@ class HandlerTest(IntegrationTest):
         self.assertEqual(u('INFO'),
                          event['metaData']['extra data']['levelname'])
 
+    def test_levelname_message(self):
+        handler = BugsnagHandler()
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+
+        class MessageFilter(logging.Filter):
+
+            def filter(self, record):
+                record.levelname = None
+                return True
+
+        handler.addFilter(MessageFilter())
+        logger.info('The system is down')
+        logger.removeHandler(handler)
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+        self.assertEqual('LogMessage', exception['errorClass'])
+
+    def test_custom_level(self):
+        handler = BugsnagHandler()
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+
+        logger.log(341, 'The system is down')
+        logger.removeHandler(handler)
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+        self.assertEqual('LogLevel 341', exception['errorClass'])
+
+    def test_custom_levelname(self):
+        handler = BugsnagHandler()
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+        logging.addLevelName(402, 'OMG')
+
+        logger.log(402, 'The system is down')
+        logger.removeHandler(handler)
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+        self.assertEqual('LogOMG', exception['errorClass'])
+        self.assertEqual('error', event['severity'])
+
     def test_exc_info_api_key(self):
         handler = BugsnagHandler(api_key='new news')
         logger = logging.getLogger(__name__)
         logger.addHandler(handler)
 
         try:
-            raise Exception('Oh no')
+            raise ScaryException('Oh no')
         except Exception:
-            logger.error('The system is down', exc_info=sys.exc_info)
+            logger.exception('The system is down')
 
         logger.removeHandler(handler)
 
         self.assertSentReportCount(1)
         json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
         self.assertEqual('new news', json_body['apiKey'])
+        self.assertEqual(exception['errorClass'], 'tests.utils.ScaryException')
 
     def test_extra_fields(self):
 
@@ -157,4 +230,160 @@ class HandlerTest(IntegrationTest):
         event = json_body['events'][0]
         self.assertEqual(event['metaData']['fruit'], {
             'grapes': 8, 'pears': 2
+        })
+
+    @use_client_logger
+    def test_client_message(self, handler, logger):
+        logger.critical('The system is down')
+        self.assertSentReportCount(1)
+
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+
+        self.assertEqual('The system is down', exception['message'])
+
+    @use_client_logger
+    def test_client_severity_critical(self, handler, logger):
+        logger.critical('The system is down')
+
+        self.assertSentReportCount(1)
+
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+
+        self.assertEqual('LogCRITICAL', exception['errorClass'])
+        self.assertEqual('error', event['severity'])
+        self.assertEqual(logging.CRITICAL,
+                         event['metaData']['extra data']['levelno'])
+        self.assertEqual(u('CRITICAL'),
+                         event['metaData']['extra data']['levelname'])
+
+    @use_client_logger
+    def test_client_severity_error(self, handler, logger):
+        logger.error('The system is down')
+
+        self.assertSentReportCount(1)
+
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+
+        self.assertEqual('LogERROR', exception['errorClass'])
+        self.assertEqual('error', event['severity'])
+        self.assertEqual(logging.ERROR,
+                         event['metaData']['extra data']['levelno'])
+        self.assertEqual(u('ERROR'),
+                         event['metaData']['extra data']['levelname'])
+
+    @use_client_logger
+    def test_client_severity_warning(self, handler, logger):
+        logger.warning('The system is down')
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+
+        self.assertEqual('LogWARNING', exception['errorClass'])
+        self.assertEqual('warning', event['severity'])
+        self.assertEqual(logging.WARNING,
+                         event['metaData']['extra data']['levelno'])
+        self.assertEqual(u('WARNING'),
+                         event['metaData']['extra data']['levelname'])
+
+    @use_client_logger
+    def test_client_severity_info(self, handler, logger):
+        logger.info('The system is down')
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+
+        self.assertEqual('LogINFO', exception['errorClass'])
+        self.assertEqual('info', event['severity'])
+        self.assertEqual(logging.INFO,
+                         event['metaData']['extra data']['levelno'])
+        self.assertEqual(u('INFO'),
+                         event['metaData']['extra data']['levelname'])
+
+    @use_client_logger
+    def test_client_add_callback(self, handler, logger):
+
+        def some_callback(record, options):
+            options['meta_data']['tab'] = {'key': 'value'}
+
+        handler.add_callback(some_callback)
+        logger.info('Everything is fine')
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        self.assertEqual(event['metaData']['tab'], {
+            'key': 'value'
+        })
+
+    @use_client_logger
+    def test_client_remove_callback(self, handler, logger):
+
+        def some_callback(record, options):
+            options['meta_data']['tab'] = {'key': 'value'}
+
+        def some_other_callback(record, options):
+            options['meta_data']['tab2'] = {'key': 'value'}
+
+        handler.add_callback(some_callback)
+        handler.add_callback(some_other_callback)
+        handler.remove_callback(some_callback)
+        logger.info('Everything is fine')
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        self.assertTrue('tab' not in event['metaData'])
+        self.assertEqual(event['metaData']['tab2'], {
+            'key': 'value'
+        })
+
+    @use_client_logger
+    def test_client_clear_callbacks(self, handler, logger):
+
+        def some_callback(record, options):
+            options['meta_data']['tab'] = {'key': 'value'}
+
+        def some_other_callback(record, options):
+            options['meta_data']['tab2'] = {'key': 'value'}
+
+        handler.add_callback(some_callback)
+        handler.add_callback(some_other_callback)
+        handler.clear_callbacks()
+        logger.info('Everything is fine')
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        self.assertTrue('tab' not in event['metaData'])
+        self.assertTrue('tab2' not in event['metaData'])
+
+    @use_client_logger
+    def test_client_crashing_callback(self, handler, logger):
+
+        def some_callback(record, options):
+            options['meta_data']['tab'] = {'key': 'value'}
+            raise ScaryException('Oh dear')
+
+        def some_other_callback(record, options):
+            options['meta_data']['tab']['key2'] = 'other value'
+
+        handler.add_callback(some_callback)
+        handler.add_callback(some_other_callback)
+        logger.info('Everything is fine')
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        self.assertEqual(event['metaData']['tab'], {
+            'key': 'value', 'key2': 'other value'
         })

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,160 @@
+import logging
+import sys
+
+from six import u
+
+from bugsnag.handlers import BugsnagHandler
+import bugsnag
+
+from tests.utils import IntegrationTest
+
+
+class HandlerTest(IntegrationTest):
+
+    def setUp(self):
+        super(HandlerTest, self).setUp()
+        bugsnag.configure(use_ssl=False,
+                          endpoint=self.server.address,
+                          api_key='tomatoes',
+                          notify_release_stages=['dev'],
+                          release_stage='dev',
+                          asynchronous=False)
+        bugsnag.logger.setLevel(logging.INFO)
+
+    def tearDown(self):
+        super(HandlerTest, self).tearDown()
+        bugsnag.logger.setLevel(logging.CRITICAL)
+
+    def test_message(self):
+        handler = BugsnagHandler()
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+
+        logger.critical('The system is down')
+        logger.removeHandler(handler)
+
+        self.assertSentReportCount(1)
+
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+        self.assertEqual('The system is down', exception['message'])
+
+    def test_severity_critical(self):
+        handler = BugsnagHandler()
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+
+        logger.critical('The system is down')
+        logger.removeHandler(handler)
+
+        self.assertSentReportCount(1)
+
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+        self.assertEqual('LogCRITICAL', exception['errorClass'])
+        self.assertEqual('error', event['severity'])
+        self.assertEqual(logging.CRITICAL,
+                         event['metaData']['extra data']['levelno'])
+        self.assertEqual(u('CRITICAL'),
+                         event['metaData']['extra data']['levelname'])
+
+    def test_severity_error(self):
+        handler = BugsnagHandler()
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+
+        logger.error('The system is down')
+        logger.removeHandler(handler)
+
+        self.assertSentReportCount(1)
+
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+        self.assertEqual('LogERROR', exception['errorClass'])
+        self.assertEqual('error', event['severity'])
+        self.assertEqual(logging.ERROR,
+                         event['metaData']['extra data']['levelno'])
+        self.assertEqual(u('ERROR'),
+                         event['metaData']['extra data']['levelname'])
+
+    def test_severity_warning(self):
+        handler = BugsnagHandler()
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+
+        logger.warning('The system is down')
+        logger.removeHandler(handler)
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+        self.assertEqual('LogWARNING', exception['errorClass'])
+        self.assertEqual('warning', event['severity'])
+        self.assertEqual(logging.WARNING,
+                         event['metaData']['extra data']['levelno'])
+        self.assertEqual(u('WARNING'),
+                         event['metaData']['extra data']['levelname'])
+
+    def test_severity_info(self):
+        handler = BugsnagHandler()
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+
+        logger.info('The system is down')
+        logger.removeHandler(handler)
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+        self.assertEqual('LogINFO', exception['errorClass'])
+        self.assertEqual('info', event['severity'])
+        self.assertEqual(logging.INFO,
+                         event['metaData']['extra data']['levelno'])
+        self.assertEqual(u('INFO'),
+                         event['metaData']['extra data']['levelname'])
+
+    def test_exc_info_api_key(self):
+        handler = BugsnagHandler(api_key='new news')
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+
+        try:
+            raise Exception('Oh no')
+        except Exception:
+            logger.error('The system is down', exc_info=sys.exc_info)
+
+        logger.removeHandler(handler)
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        self.assertEqual('new news', json_body['apiKey'])
+
+    def test_extra_fields(self):
+
+        class FruitFilter(logging.Filter):
+
+            def filter(self, record):
+                record.grapes = 8
+                record.pears = 2
+                record.apricots = 90
+                return True
+
+        handler = BugsnagHandler(api_key='new news',
+                                 extra_fields={'fruit': ['grapes', 'pears']})
+        logger = logging.getLogger(__name__)
+        logger.addHandler(handler)
+        logger.addFilter(FruitFilter())
+
+        logger.error('A wild tomato appeared')
+        logger.removeHandler(handler)
+
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        self.assertEqual(event['metaData']['fruit'], {
+            'grapes': 8, 'pears': 2
+        })


### PR DESCRIPTION
This changeset allows users to create log handlers using clients, and customize reports before they are sent to Bugsnag.

To create a client and handler:

```python
client = Client(api_key='...')
handler = client.log_handler()

logger.addHandler(handler)
```

To alter add or remove information from log records before a report is sent to Bugsnag, use callbacks:

```python
def add_custom_fields(record, options):
    if 'meta_data' not in options:
        options['meta_data'] = {}

    options['meta_data']['fruit'] ={'grape_count': len(record.grapes)}

handler.add_callback(add_custom_fields)
```

All records emitted by the logger are then sent to Bugsnag using the client.

To filter the logs sent, use `logging.Filter`:

```python
class MyFilter(logging.Filter):
    def filter(self, record):
        return record.account_id != 0

handler.addFilter(MyFilter())
```

The existing options to pass an `api_key` and `extra_fields` to `BugsnagHandler` have been deprecated in favor of client-based handling