### PR TITLE
Return the value of a decorated function

### DIFF
--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -117,7 +117,7 @@ class ClientContext(object):
         @wraps(function)
         def decorate(*args, **kwargs):
             with self:
-                function(*args, **kwargs)
+                return function(*args, **kwargs)
 
         return decorate
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -115,6 +115,14 @@ class ClientTest(IntegrationTest):
 
         self.assertSentReportCount(1)
 
+    def test_capture_decorator_returns_value(self):
+
+        @self.client.capture
+        def foo():
+            return "300"
+
+        self.assertEqual(foo(), "300")
+
     def test_capture_decorator_raises(self):
 
         @self.client.capture


### PR DESCRIPTION
When using the `capture` decorator, return the value of the wrapped function. Other behavior can cause some confusion due to changing the visible behavior of a function.