### PR TITLE
Extract source file/line when decorating functions

### DIFF
--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -154,8 +154,11 @@ class ClientContext(object):
     def __call__(self, function):
         @wraps(function)
         def decorate(*args, **kwargs):
-            with self:
+            try:
                 return function(*args, **kwargs)
+            except self.exception_types as e:
+                self.client.notify(e, source_func=function, **self.options)
+                raise
 
         return decorate
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -153,6 +153,20 @@ class ClientTest(IntegrationTest):
 
         self.assertSentReportCount(1)
 
+    def test_capture_decorator_mismatch(self):
+
+        @self.client.capture
+        def foo():
+            pass
+
+        self.assertRaises(TypeError, foo, 'bar')
+        self.assertSentReportCount(1)
+
+        payload = self.server.received[0]['json_body']
+        file = payload['events'][0]['exceptions'][0]['stacktrace'][0]['file']
+
+        self.assertEqual(file, "test_client.py")
+
     def test_capture_decorator_returns_value(self):
 
         @self.client.capture


### PR DESCRIPTION
When wrapping a function, if the function fails to invoke successfully,
the stacktrace would reflect that code inside of the Bugsnag library was
being called, which may obscure what needs to be fixed.

This changed passes along the source function being wrapped, extracting
the correct file and line number if available.