### PR TITLE
Update code-style to pass flake8 3.2

### DIFF
--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -47,8 +47,8 @@ def notify(exception, **options):
     """
     Notify bugsnag of an exception.
     """
-    if (isinstance(exception, (list, tuple)) and len(exception) == 3
-            and isinstance(exception[2], types.TracebackType)):
+    if (isinstance(exception, (list, tuple)) and len(exception) == 3 and
+            isinstance(exception[2], types.TracebackType)):
         default_client.notify_exc_info(*exception, **options)
     else:
         if not isinstance(exception, BaseException):

--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -45,7 +45,8 @@ class Notification(object):
         self.config = config
         self.request_config = request_config
 
-        def get_config(key): return options.pop(key, self.config.get(key))
+        def get_config(key):
+            return options.pop(key, self.config.get(key))
 
         self.release_stage = get_config("release_stage")
         self.app_version = get_config("app_version")
@@ -62,8 +63,8 @@ class Notification(object):
             self.user["id"] = options.pop("user_id")
 
         self.stacktrace = self._generate_stacktrace(
-                self.options.pop("traceback", sys.exc_info()[2]),
-                self.options.pop("source_func", None))
+            self.options.pop("traceback", sys.exc_info()[2]),
+            self.options.pop("source_func", None))
         self.grouping_hash = options.pop("grouping_hash", None)
         self.api_key = options.pop("api_key", get_config("api_key"))
 

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -14,10 +14,10 @@ def add_wsgi_request_data_to_notification(notification):
     notification.context = "%s %s" % (request.method, request_path(environ))
     notification.set_user(id=request.remote_addr)
     notification.add_tab("request", {
-                "url": request.path_url,
-                "headers": dict(request.headers),
-                "params": dict(request.params),
-            })
+        "url": request.path_url,
+        "headers": dict(request.headers),
+        "params": dict(request.params),
+    })
     notification.add_tab("environment", dict(request.environ))
 
 

--- a/tests/integrations/test_wsgi.py
+++ b/tests/integrations/test_wsgi.py
@@ -98,9 +98,11 @@ class TestWSGI(IntegrationTest):
 
         class CrashAfterSettingUserId(object):
             def __init__(self, environ, start_response):
-                bugsnag.configure_request(
-                        user={"id": "5", "email":
-                              "me@cirw.in", "name": "conrad"})
+                bugsnag.configure_request(user={
+                    "id": "5",
+                    "email": "me@cirw.in",
+                    "name": "conrad",
+                })
                 raise SentinelError("oops")
 
         app = TestApp(BugsnagMiddleware(CrashAfterSettingUserId))

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -229,8 +229,9 @@ class HandlersTest(IntegrationTest):
                         endpoint=self.server.address,
                         api_key='new news',
                         asynchronous=False)
-        handler = client.log_handler(
-                extra_fields={'fruit': ['grapes', 'pears']})
+        handler = client.log_handler(extra_fields={
+            'fruit': ['grapes', 'pears']
+        })
         logger = logging.getLogger(__name__)
         logger.addHandler(handler)
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -31,7 +31,7 @@ class TestBugsnag(IntegrationTest):
         while len(self.server.received) == 0:
             if time.time() > (start + 0.5):
                 raise Exception(
-                        'Timed out while waiting for asynchronous request.')
+                    'Timed out while waiting for asynchronous request.')
 
             time.sleep(0.001)
 
@@ -295,7 +295,7 @@ class TestBugsnag(IntegrationTest):
 
     def test_notify_metadata_complex_value(self):
         bugsnag.notify(ScaryException('unexpected failover'),
-                       value=(5+0j), value2=(13+3.4j))
+                       value=(5 + 0j), value2=(13 + 3.4j))
         json_body = self.server.received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('(5+0j)', event['metaData']['custom']['value'])
@@ -427,18 +427,17 @@ class TestBugsnag(IntegrationTest):
                   '-838b-a05aadc06a5\x00\x02uid\x00%\x00\x00\x001bab969f-7b30'
                   '-459a-adee-917b9e028eed\x00\x00'))
         self_class = 'tests.test_notify.TestBugsnag'
-        bugsnag.notify(Exception('free food'),
-                       meta_data={'payload': {
-                         'project': u('∆πåß∂ƒ'),
-                         'filename': u('DISPOSITIFS DE SÉCURITÉ.pdf'),
-                         u('♥♥i'): u('♥♥♥♥♥♥'),
-                         'src_name': u('☻☻☻☻☻ RDC DISPOSITIFS DE SÉCURTÉ.pdf'),
-                         u('accénted'): u('☘☘☘éééé@me.com'),
-                         'class': self.__class__,
-                         'another_class': dict,
-                         'self': self,
-                         'var': bins
-                       }})
+        bugsnag.notify(Exception('free food'), meta_data={'payload': {
+            'project': u('∆πåß∂ƒ'),
+            'filename': u('DISPOSITIFS DE SÉCURITÉ.pdf'),
+            u('♥♥i'): u('♥♥♥♥♥♥'),
+            'src_name': u('☻☻☻☻☻ RDC DISPOSITIFS DE SÉCURTÉ.pdf'),
+            u('accénted'): u('☘☘☘éééé@me.com'),
+            'class': self.__class__,
+            'another_class': dict,
+            'self': self,
+            'var': bins
+        }})
         json_body = self.server.received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual(u('∆πåß∂ƒ'), event['metaData']['payload']['project'])


### PR DESCRIPTION
After pulling down the repository I noticed that the tox/lint tests fail. Since the version of flake8 is not pinned an update to flake8 (3.2) now causes failures.

```shell
$ ./scripts/lint.sh 
bugsnag/legacy.py:51:13: W503 line break before binary operator
bugsnag/notification.py:48:9: E704 multiple statements on one line (def)
bugsnag/notification.py:65:17: E126 continuation line over-indented for hanging indent
bugsnag/wsgi/middleware.py:17:17: E126 continuation line over-indented for hanging indent
bugsnag/wsgi/middleware.py:20:13: E126 continuation line over-indented for hanging indent
tests/test_handlers.py:233:17: E126 continuation line over-indented for hanging indent
tests/test_notify.py:34:25: E126 continuation line over-indented for hanging indent
tests/test_notify.py:298:32: E226 missing whitespace around arithmetic operator
tests/test_notify.py:298:48: E226 missing whitespace around arithmetic operator
tests/test_notify.py:432:26: E121 continuation line under-indented for hanging indent
tests/integrations/test_wsgi.py:102:25: E126 continuation line over-indented for hanging indent
```