### PR TITLE
Separate integrations and test all pythons in tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,26 @@
 language: python
 
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
+env:
+  - TOXENV=py26-test
+  - TOXENV=py27-test
+  - TOXENV=py33-test
+  - TOXENV=py34-test
+  - TOXENV=py35-test
+  - TOXENV=py26-requests-test
+  - TOXENV=py27-requests-test
+  - TOXENV=py33-requests-test
+  - TOXENV=py34-requests-test
+  - TOXENV=py35-requests-test
+  - TOXENV=py26-wsgi
+  - TOXENV=py27-wsgi
+  - TOXENV=py33-wsgi
+  - TOXENV=py34-wsgi
+  - TOXENV=py35-wsgi
+  - TOXENV=py26-flask
+  - TOXENV=py27-flask
+  - TOXENV=py35-lint
 
-install: travis_retry pip install -r dev_requirements.txt
+install: travis_retry pip install coveralls tox
 
 script:
   - tox

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -1,14 +1,4 @@
-import sys
-
-from nose.plugins.skip import SkipTest
-if (3, 0) <= sys.version_info < (3, 3):  # noqa
-    raise SkipTest("Flask is incompatible with python3 3.0 - 3.2")
-
-try:
-    from flask import Flask
-except:
-    raise SkipTest("Flask is not installed")
-
+from flask import Flask
 from bugsnag.flask import handle_exceptions
 import bugsnag.notification
 from tests.utils import IntegrationTest

--- a/tox.ini
+++ b/tox.ini
@@ -1,34 +1,29 @@
 [tox]
-envlist=with_requests,without_requests,integrations,lint
+envlist=
+    py{26,27,33,34,35}-{requests-,}test,
+    py{26,27}-flask,
+    py{26,27,33,34,35}-wsgi,
+    py35-lint,
 
 [testenv]
+basepython =
+    py26: python2.6
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+    py35: python3.5
 whitelist_externals=
     {toxinidir}/scripts/lint.sh
 deps=
     .
     nose-cov
-
-[testenv:integrations]
-basepython=python
-deps=
-    flask
-    blinker
-    webtest
-    {[testenv]deps}
-commands=nosetests --tests=integrations -sv --with-coverage --cover-package=bugsnag
-
-[testenv:with_requests]
-basepython=python
-deps=
-    requests
-    {[testenv]deps}
-commands=nosetests --tests=tests -sv --with-coverage --cover-package=bugsnag
-
-[testenv:without_requests]
-basepython=python
-commands=nosetests --tests=tests -sv --with-coverage --cover-package=bugsnag
-
-[testenv:lint]
-basepython=python
-deps=flake8
-commands={toxinidir}/scripts/lint.sh
+    requests: requests
+    wsgi: webtest
+    flask: flask
+    flask: blinker
+    lint: flake8
+commands =
+    test: nosetests --tests=tests -sv --with-coverage --cover-package=bugsnag
+    wsgi: nosetests integrations/test_wsgi.py -sv --with-coverage --cover-package=bugsnag
+    flask: nosetests integrations/test_flask.py -sv --with-coverage --cover-package=bugsnag
+    lint: {toxinidir}/scripts/lint.sh


### PR DESCRIPTION
This PR revamps how tox testing in Bugsnag. Tox will now handle testing of each different python version instead of letting TravisCI handle switching Python versions. This makes it easier to test against multiple Python versions locally, and running the full test suite against all supported versions locally in the same way that it is done via CI.

The other thing I've done is broken the integration tests to run as separate tox environments, this is a step towards being able to test the integrations against multiple versions of dependencies. For example, to test the Django integration against multiple versions of Django.

I've also made some changes to the Flask test, I've removed the cases where tests are skipped when Flask is uninstalled. I find this could be problematic where the tests could become broken due to installation/configuration error where Flask isn't installed and the tests are silently skipped and seem to pass. I've just removed the skipping since now that the tests are run in separate tox environments there shouldn't be a case where you run the Flask tests unintentionally.

With the new tox config, I've also replicated each env into a TravisCI build matrix so TravisCI will run each tox environment separately and concurrently.

<img width="554" alt="screen shot 2016-11-19 at 23 30 24" src="https://cloud.githubusercontent.com/assets/44164/20459169/31862aea-aeb0-11e6-9325-4aa1968a6fb1.png">