### PR TITLE
Add test coverage for Django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ env:
   - TOXENV=py35-wsgi
   - TOXENV=py26-flask
   - TOXENV=py27-flask
+  - TOXENV=py27-django18-django
+  - TOXENV=py27-django19-django
+  - TOXENV=py27-django110-django
+  - TOXENV=py35-django18-django
+  - TOXENV=py35-django19-django
+  - TOXENV=py35-django110-django
   - TOXENV=py35-lint
 
 install: travis_retry pip install coveralls tox

--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -35,6 +35,7 @@ def add_django_request_to_notification(notification):
     if getattr(request, "session", None):
         notification.add_tab("session", dict(request.session))
     notification.add_tab("request", {
+        'method': request.method,
         'path': request.path,
         'encoding': request.encoding,
         'GET': dict(request.GET),

--- a/example/django/bugsnag_demo/settings.py
+++ b/example/django/bugsnag_demo/settings.py
@@ -24,7 +24,7 @@ DEBUG = True
 
 TEMPLATE_DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition
@@ -84,4 +84,6 @@ STATIC_URL = '/static/'
 
 BUGSNAG = {
     "api_key": "066f5ad3590596f9aa8d601ea89af845",
+    "endpoint": os.environ.get('BUGSNAG_API', 'https://notify.bugsnag.com'),
+    "asynchronous": False,
 }

--- a/example/django/demo/views.py
+++ b/example/django/demo/views.py
@@ -7,9 +7,11 @@ def index(request):
     with open('README.md') as fp:
         return HttpResponse(markdown.markdown(fp.read()))
 
+
 def crash(request):
     raise Exception("Bugsnag Django demo says: It crashed! Go check " +
                     "bugsnag.com for a new notification!")
+
 
 def callback(notification):
     if notification.context == "demo.views.crash_with_callback":
@@ -19,6 +21,7 @@ def callback(notification):
         }
         notification.add_tab("Diagnostics", tab)
 
+
 def crash_with_callback(request):
     bugsnag.before_notify(callback)
     raise Exception(
@@ -27,12 +30,14 @@ def crash_with_callback(request):
         "bugsnag.com for a new notification (see the Diagnostics tab)!"
     )
 
+
 def notify(request):
     msg = "Bugsnag Django demo says: False alarm, your application didn't crash"
-    bugsnag.notify(Exception(msg));
+    bugsnag.notify(Exception(msg))
     return HttpResponse(
         "Bugsnag Django demo says: It didn't crash! But still go check " +
         "<a href=\"bugsnag.com\">bugsnag.com</a> for a new notification.")
+
 
 def notify_meta(request):
     bugsnag.notify(
@@ -44,12 +49,14 @@ def notify_meta(request):
         " <a href=\"bugsnag.com\">bugsnag.com</a> for a new notification. " +
         "Check out the User tab for the meta data")
 
+
 def context(request):
     bugsnag.notify(
         Exception("Bugsnag Django demo says: Changed the context to backgroundJob"),
         context="backgroundJob")
     return HttpResponse(
         "Bugsnag Django demo says: The context of the error is \"backgroundJob\" now")
+
 
 def severity(request):
     bugsnag.notify(

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -26,6 +26,7 @@ class DjangoMiddlewareTests(IntegrationTest):
         payload = self.server.received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['metaData']['request'], {
+            'method': 'GET',
             'url': 'http://testserver/notify/',
             'path': '/notify/',
             'POST': {},
@@ -42,6 +43,7 @@ class DjangoMiddlewareTests(IntegrationTest):
         payload = self.server.received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['metaData']['request'], {
+            'method': 'GET',
             'url': 'http://testserver/crash/',
             'path': '/crash/',
             'POST': {},

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -1,0 +1,54 @@
+import sys
+import os
+from tests.utils import IntegrationTest
+
+import django
+from django.test import Client
+
+EXAMPLE_PATH = os.path.join(__file__, '..', '..', '..', 'example', 'django')
+sys.path.append(os.path.abspath(EXAMPLE_PATH))
+os.environ['DJANGO_SETTINGS_MODULE'] = 'bugsnag_demo.settings'
+
+
+class DjangoMiddlewareTests(IntegrationTest):
+    def setUp(self):
+        super(DjangoMiddlewareTests, self).setUp()
+
+        os.environ['BUGSNAG_API'] = self.server.url
+        django.setup()
+        self.client = Client()
+
+    def test_notify(self):
+        response = self.client.get('/notify/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(self.server.received), 1)
+
+        payload = self.server.received[0]['json_body']
+        event = payload['events'][0]
+        self.assertEqual(event['metaData']['request'], {
+            'url': 'http://testserver/notify/',
+            'path': '/notify/',
+            'POST': {},
+            'encoding': None,
+            'GET': {}
+        })
+
+    def test_unhandled_exception(self):
+        with self.assertRaises(Exception):
+            self.client.get('/crash/')
+
+        self.assertEqual(len(self.server.received), 1)
+
+        payload = self.server.received[0]['json_body']
+        event = payload['events'][0]
+        self.assertEqual(event['metaData']['request'], {
+            'url': 'http://testserver/crash/',
+            'path': '/crash/',
+            'POST': {},
+            'encoding': None,
+            'GET': {}
+        })
+
+    def test_ignores_http404(self):
+        self.client.get('/404')
+        self.assertEqual(len(self.server.received), 0)

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist=
     py{26,27,33,34,35}-{requests-,}test,
     py{26,27}-flask,
     py{26,27,33,34,35}-wsgi,
+    py{27,35}-django{18,19,110}-django
     py35-lint,
 
 [testenv]
@@ -21,9 +22,15 @@ deps=
     wsgi: webtest
     flask: flask
     flask: blinker
+    django: markdown
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
     lint: flake8
+
 commands =
     test: nosetests --tests=tests -sv --with-coverage --cover-package=bugsnag
     wsgi: nosetests integrations/test_wsgi.py -sv --with-coverage --cover-package=bugsnag
     flask: nosetests integrations/test_flask.py -sv --with-coverage --cover-package=bugsnag
+    django: nosetests integrations/test_django.py -sv --with-coverage --cover-package=bugsnag
     lint: {toxinidir}/scripts/lint.sh


### PR DESCRIPTION
This PR adds test coverage for the Django middleware and tests against Django 1.8, 1.9 and 1.10 on both Python 2.7 and Python 3.5.

I've also updated the Django integration to store the request method in the meta data for a request.