### PR TITLE
Add type checking with mypy and along with basic type hints

### DIFF
--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -8,9 +8,10 @@ from bugsnag.legacy import (configuration, configure, configure_request,
                             add_metadata_tab, clear_request_config, notify,
                             auto_notify, before_notify)
 
-__all__ = (Client, Notification, Configuration, RequestConfiguration,
-           configuration, configure, configure_request, add_metadata_tab,
-           clear_request_config, notify, auto_notify, before_notify)
+__all__ = ('Client', 'Notification', 'Configuration', 'RequestConfiguration',
+           'configuration', 'configure', 'configure_request',
+           'add_metadata_tab', 'clear_request_config', 'notify',
+           'auto_notify', 'before_notify')
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)

--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -109,10 +109,11 @@ class Client(object):
             sys.excepthook = self.sys_excepthook
             self.sys_excepthook = None
 
-    def deliver(self, notification):
+    def deliver(self, notification):  # type: (Notification) -> None
         """
         Deliver the exception notification to Bugsnag.
         """
+
         if not self.should_deliver(notification):
             return
 
@@ -130,7 +131,7 @@ class Client(object):
 
         self.configuration.middleware.run(notification, send_payload)
 
-    def should_deliver(self, notification):
+    def should_deliver(self, notification):  # type: (Notification) -> bool
         # Return early if we shouldn't notify for current release stage
         if not self.configuration.should_notify():
             return False

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -80,16 +80,16 @@ class Configuration(_BaseConfiguration):
         else:
             self.hostname = None
 
-    def should_notify(self):
+    def should_notify(self):  # type: () -> bool
         return self.notify_release_stages is None or \
             (isinstance(self.notify_release_stages, (tuple, list)) and
              self.release_stage in self.notify_release_stages)
 
-    def should_ignore(self, exception):
+    def should_ignore(self, exception):  # type: (Exception) -> bool
         return self.ignore_classes is not None and \
             fully_qualified_class_name(exception) in self.ignore_classes
 
-    def get_endpoint(self):
+    def get_endpoint(self):  # type: () -> str
         warnings.warn('get_endpoint and use_ssl are deprecated in favor '
                       'of including the protocol in the endpoint '
                       'configuration option and will be removed in a future '
@@ -113,7 +113,7 @@ class RequestConfiguration(_BaseConfiguration):
     """
 
     @classmethod
-    def get_instance(cls):
+    def get_instance(cls):  # type: () -> RequestConfiguration
         """
         Get this thread's instance of the RequestConfiguration.
         """

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps=
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     lint: flake8
+    lint: mypy
 
 commands =
     test: nosetests --tests=tests -sv --with-coverage --cover-package=bugsnag
@@ -34,3 +35,4 @@ commands =
     flask: nosetests integrations/test_flask.py -sv --with-coverage --cover-package=bugsnag
     django: nosetests integrations/test_django.py -sv --with-coverage --cover-package=bugsnag
     lint: {toxinidir}/scripts/lint.sh
+    lint: mypy -2 --ignore-missing-imports bugsnag


### PR DESCRIPTION
a9f4157422ee9014c0919170a9cd687c76b63d78 uses mypy during CI to run type checks. This picks out a problem with `__all__` in `__init__.py` because that wasn't a sequence of strings. This was fixed in same commit.

Then 455a5ea adds some basic type hints to some of the methods using comments so they are backwards compatible with Python 2 (https://docs.python.org/3/library/typing.html).

This can be demonstrated by returning a value that is not expected and then running the linting:

```diff
diff --git a/bugsnag/client.py b/bugsnag/client.py
index 4cea2a9..f376b6f 100644
--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -114,6 +114,8 @@ class Client(object):
         Deliver the exception notification to Bugsnag.
         """
 
+        return True
+
         if not self.should_deliver(notification):
             return
```

```shell
$ tox -e py35-lint
py35-lint runtests: commands[1] | mypy -2 --ignore-missing-imports bugsnag
bugsnag/client.py:117: error: No return value expected
```