### PR TITLE
FIX - Passing compiled modules to traceback_exclude_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,59 @@
 language: python
 
-env:
-  - TOXENV=py26-test
-  - TOXENV=py27-test
-  - TOXENV=py33-test
-  - TOXENV=py34-test
-  - TOXENV=py35-test
-  - TOXENV=py26-requests-test
-  - TOXENV=py27-requests-test
-  - TOXENV=py33-requests-test
-  - TOXENV=py34-requests-test
-  - TOXENV=py35-requests-test
-  - TOXENV=py26-wsgi
-  - TOXENV=py27-wsgi
-  - TOXENV=py33-wsgi
-  - TOXENV=py34-wsgi
-  - TOXENV=py35-wsgi
-  - TOXENV=py26-flask
-  - TOXENV=py27-flask
-  - TOXENV=py27-django18-django
-  - TOXENV=py27-django19-django
-  - TOXENV=py27-django110-django
-  - TOXENV=py35-django18-django
-  - TOXENV=py35-django19-django
-  - TOXENV=py35-django110-django
-  - TOXENV=py35-lint
+matrix:
+  include:
+  - python: 2.6
+    env: TOXENV=py26-test
+  - python: 2.6
+    env: TOXENV=py26-requests-test
+  - python: 2.6
+    env: TOXENV=py26-wsgi
+  - python: 2.6
+    env: TOXENV=py26-flask
+
+  - python: 2.7
+    env: TOXENV=py27-test
+  - python: 2.7
+    env: TOXENV=py27-requests-test
+  - python: 2.7
+    env: TOXENV=py27-wsgi
+  - python: 2.7
+    env: TOXENV=py27-flask
+  - python: 2.7
+    env: TOXENV=py27-django18-django
+  - python: 2.7
+    env: TOXENV=py27-django19-django
+  - python: 2.7
+    env: TOXENV=py27-django110-django
+
+  - python: 3.3
+    env: TOXENV=py33-test
+  - python: 3.3
+    env: TOXENV=py33-requests-test
+  - python: 3.3
+    env: TOXENV=py33-wsgi
+
+  - python: 3.4
+    env: TOXENV=py34-test
+  - python: 3.4
+    env: TOXENV=py34-requests-test
+  - python: 3.4
+    env: TOXENV=py34-wsgi
+
+  - python: 3.5
+    env: TOXENV=py35-test
+  - python: 3.5
+    env: TOXENV=py35-requests-test
+  - python: 3.5
+    env: TOXENV=py35-wsgi
+  - python: 3.5
+    env: TOXENV=py27-django18-django
+  - python: 3.5
+    env: TOXENV=py27-django19-django
+  - python: 3.5
+    env: TOXENV=py27-django110-django
+  - python: 3.5
+    env: TOXENV=py35-lint
 
 install: travis_retry pip install coveralls tox
 

--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -123,7 +123,10 @@ class Notification(object):
         user_exclude_modules = self.config.get("traceback_exclude_modules")
         for exclude_module in user_exclude_modules:
             try:
-                exclude_module_paths.append(exclude_module.__file__)
+                module_file = exclude_module.__file__
+                if module_file[-4:] == '.pyc':
+                    module_file = module_file[:-1]
+                exclude_module_paths.append(module_file)
             except:
                 bugsnag.logger.exception(
                     'Could not exclude module: %s' % repr(exclude_module))

--- a/tests/fixtures/helpers.py
+++ b/tests/fixtures/helpers.py
@@ -1,0 +1,4 @@
+def invoke_exception_on_other_file(config):
+    from bugsnag.notification import Notification
+
+    return Notification(Exception("another file!"), config, {})

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -6,6 +6,14 @@ from bugsnag.configuration import Configuration
 from bugsnag.notification import Notification
 from tests import fixtures
 
+try:
+    reload  # Python 2.x
+except NameError:
+    try:
+        from importlib import reload  # Python 3.4+
+    except ImportError:
+        from imp import reload  # Python 3.0 - 3.3
+
 
 class TestNotification(unittest.TestCase):
 

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import sys
 import unittest
 
 from bugsnag.configuration import Configuration
@@ -118,7 +119,12 @@ class TestNotification(unittest.TestCase):
 
         from tests.fixtures import helpers
         reload(helpers)  # The .py variation might be loaded from previous test.
-        self.assertTrue(helpers.__file__.endswith('.pyc'))
+
+        if sys.version_info < (3, 0):
+            # Python 2.6 & 2.7 returns the cached file on __file__,
+            # and hence we verify it returns .pyc for these versions
+            # and the code at _generate_stacktrace() handles that.
+            self.assertTrue(helpers.__file__.endswith('.pyc'))
 
         config = Configuration()
         config.traceback_exclude_modules = [helpers]

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -109,6 +109,7 @@ class TestNotification(unittest.TestCase):
         py_compile.compile('./fixtures/helpers.py')
 
         from tests.fixtures import helpers
+        reload(helpers)  # The .py variation might be loaded from previous test.
         self.assertTrue(helpers.__file__.endswith('.pyc'))
 
         config = Configuration()


### PR DESCRIPTION
`Configure.traceback_exclude_modules` receives a list of modules, and extracts the `__file__` of each, allowing to skip few modules from appearing in the stacktrace.
In Python 2.x, when a compiled module is loaded, it's `__file__` property displays the compiled `.pyc` path, while the running code will appear in the stacktrace with a `.py` suffix.

This fix replaces the _.pyc_ suffix with a _.py_, hence enabling the `traceback_exclude_modules` to work as it should.

I also added tests reproducing this scenario, and also tweaked _.travis.yml_ to support the new image they deployed recently (https://blog.travis-ci.com/2017-05-04-precise-image-updates).