### PR TITLE
Skip sending reports to Bugsnag from lib internals

### DIFF
--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -33,6 +33,10 @@ class BugsnagHandler(logging.Handler, object):
         """
         Outputs the record to Bugsnag
         """
+        for path in bugsnag.__path__:
+            if path in record.pathname:
+                return
+
         options = {'meta_data': {}}
 
         for callback in self.callbacks:


### PR DESCRIPTION
In the case that Bugsnag is sending a log record, they are intended for
the user to see an internal issue or fix configuration problems.
In the specific case that the problem was a failure to send an error
report, there is a chance that this could cause a stack overflow if the
failure persists. This change avoids sending reports to Bugsnag from log
messages originating within the bugsnag library.

## Questions

There's a chance that this is too broad a fix for the potential issues here, and maybe a better approach would be to maintain some internal state about what errors have been sent? 🤔 