### PR TITLE
Ensured context is preserved if set in flask

### DIFF
--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -8,8 +8,9 @@ def add_flask_request_to_notification(notification):
     if not request:
         return
 
-    notification.context = "%s %s" % (request.method,
-                                      request_path(request.environ))
+    if notification.context is None:
+        notification.context = "%s %s" % (request.method,
+                                          request_path(request.environ))
 
     if 'id' not in notification.user:
         notification.set_user(id=request.remote_addr)

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -153,3 +153,19 @@ class TestFlask(IntegrationTest):
                          'http://localhost/form')
         body = event['metaData']['request']['data']['body']
         self.assertTrue('_data' in body)
+
+    def test_bugsnag_notify_with_custom_context(self):
+        app = Flask("bugsnag")
+
+        @app.route("/hello")
+        def hello():
+            bugsnag.notify(SentinelError("oops"), context="custom_context_notification_testing")
+            return "OK"
+
+        handle_exceptions(app)
+        app.test_client().get('/hello')
+
+        self.assertEqual(1, len(self.server.received))
+        payload = self.server.received[0]['json_body']
+        self.assertEqual(payload['events'][0]['context'],
+                         'custom_context_notification_testing')

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -160,7 +160,7 @@ class TestFlask(IntegrationTest):
         @app.route("/hello")
         def hello():
             bugsnag.notify(SentinelError("oops"),
-                context="custom_context_notification_testing")
+                           context="custom_context_notification_testing")
             return "OK"
 
         handle_exceptions(app)

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -159,7 +159,8 @@ class TestFlask(IntegrationTest):
 
         @app.route("/hello")
         def hello():
-            bugsnag.notify(SentinelError("oops"), context="custom_context_notification_testing")
+            bugsnag.notify(SentinelError("oops"),
+                context="custom_context_notification_testing")
             return "OK"
 
         handle_exceptions(app)


### PR DESCRIPTION
Fix for: When changing or adding a custom context to a notification using the Flask library the context was being overridden by the default request parameters.