### PR TITLE
Adding Handled/Unhandled payload properties

### DIFF
--- a/bugsnag/celery/__init__.py
+++ b/bugsnag/celery/__init__.py
@@ -14,7 +14,14 @@ def failure_handler(sender, task_id, exception, args, kwargs, traceback, einfo,
 
     bugsnag.auto_notify(exception, traceback=traceback,
                         context=sender.name,
-                        extra_data=task)
+                        extra_data=task,
+                        unhandled=True,
+                        severity_reason={
+                            'type':'middleware_handler',
+                            'attributes': {
+                                'name': 'celery'
+                            }
+                        })
 
 
 def connect_failure_handler():

--- a/bugsnag/celery/__init__.py
+++ b/bugsnag/celery/__init__.py
@@ -16,9 +16,9 @@ def failure_handler(sender, task_id, exception, args, kwargs, traceback, einfo,
                         context=sender.name,
                         extra_data=task,
                         severity_reason={
-                            'type': 'middleware_handler',
+                            'type': 'unhandledExceptionMiddleware',
                             'attributes': {
-                                'name': 'celery'
+                                'framework': 'Celery'
                             }
                         })
 

--- a/bugsnag/celery/__init__.py
+++ b/bugsnag/celery/__init__.py
@@ -17,7 +17,7 @@ def failure_handler(sender, task_id, exception, args, kwargs, traceback, einfo,
                         extra_data=task,
                         unhandled=True,
                         severity_reason={
-                            'type':'middleware_handler',
+                            'type': 'middleware_handler',
                             'attributes': {
                                 'name': 'celery'
                             }

--- a/bugsnag/celery/__init__.py
+++ b/bugsnag/celery/__init__.py
@@ -15,7 +15,6 @@ def failure_handler(sender, task_id, exception, args, kwargs, traceback, einfo,
     bugsnag.auto_notify(exception, traceback=traceback,
                         context=sender.name,
                         extra_data=task,
-                        unhandled=True,
                         severity_reason={
                             'type': 'middleware_handler',
                             'attributes': {

--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -121,12 +121,19 @@ class Client(object):
             return
 
         initial_severity = notification.severity
+        initial_default_severity = notification.default_severity
+        initial_unhandled = notification.unhandled
+        initial_severity_reason = notification.severity_reason
 
         def send_payload():
             if notification.api_key is None:
                 bugsnag.logger.warning(
                     "No API key configured, couldn't notify")
                 return
+
+            notification.default_severity = initial_default_severity
+            notification.unhandled = initial_unhandled
+            notification.severity_reason = initial_severity_reason
 
             if initial_severity != notification.severity:
                 notification.default_severity = False

--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -121,19 +121,12 @@ class Client(object):
             return
 
         initial_severity = notification.severity
-        initial_default_severity = notification.default_severity
-        initial_unhandled = notification.unhandled
-        initial_severity_reason = notification.severity_reason
 
         def send_payload():
             if notification.api_key is None:
                 bugsnag.logger.warning(
                     "No API key configured, couldn't notify")
                 return
-
-            notification.default_severity = initial_default_severity
-            notification.unhandled = initial_unhandled
-            notification.severity_reason = initial_severity_reason
 
             if initial_severity != notification.severity:
                 notification.default_severity = False

--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -133,7 +133,7 @@ class Client(object):
 
             if initial_severity != notification.severity:
                 notification.severity_reason = {
-                    'type': 'userSpecifiedSeverity'
+                    'type': 'userCallbackSetSeverity'
                 }
             else:
                 notification.severity_reason = initial_reason

--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -87,11 +87,13 @@ class Client(object):
 
     def excepthook(self, exc_type, exc_value, traceback):
         if self.configuration.auto_notify:
-            self.notify_exc_info(exc_type, exc_value, traceback,
-                                 severity='error', unhandled=True,
-                                 severity_reasons={
-                                     'type': 'exception_handler'
-                                 })
+            self.notify_exc_info(
+                exc_type, exc_value, traceback,
+                severity='error',
+                unhandled=True,
+                severity_reason={
+                    'type': 'unhandledException'
+                })
 
     def install_sys_hook(self):
         self.sys_excepthook = sys.excepthook
@@ -121,6 +123,7 @@ class Client(object):
             return
 
         initial_severity = notification.severity
+        initial_reason = notification.severity_reason
 
         def send_payload():
             if notification.api_key is None:
@@ -129,7 +132,11 @@ class Client(object):
                 return
 
             if initial_severity != notification.severity:
-                notification.default_severity = False
+                notification.severity_reason = {
+                    'type': 'userSpecifiedSeverity'
+                }
+            else:
+                notification.severity_reason = initial_reason
 
             try:
                 self.configuration.delivery.deliver(self.configuration,

--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -165,6 +165,8 @@ class ClientContext(object):
     def __init__(self, client, exception_types=None, **options):
         self.client = client
         self.options = options
+        if 'severity' in options:
+            options['severity_reason'] = dict(type='contextSpecifiedSeverity')
         self.exception_types = exception_types or (Exception,)
 
     def __call__(self, function):

--- a/bugsnag/django/middleware.py
+++ b/bugsnag/django/middleware.py
@@ -31,9 +31,9 @@ class BugsnagMiddleware(MiddlewareMixin):
             bugsnag.auto_notify(
                 exception,
                 severity_reason={
-                    "type": "middleware_handler",
+                    "type": "unhandledExceptionMiddleware",
                     "attributes": {
-                        "name": "django"
+                        "framework": "Django"
                     }
                 }
             )

--- a/bugsnag/django/middleware.py
+++ b/bugsnag/django/middleware.py
@@ -30,7 +30,6 @@ class BugsnagMiddleware(MiddlewareMixin):
         try:
             bugsnag.auto_notify(
                 exception,
-                unhandled=True,
                 severity_reason={
                     "type": "middleware_handler",
                     "attributes": {

--- a/bugsnag/django/middleware.py
+++ b/bugsnag/django/middleware.py
@@ -28,11 +28,13 @@ class BugsnagMiddleware(MiddlewareMixin):
 
     def process_exception(self, request, exception):
         try:
-            bugsnag.auto_notify(exception, unhandled=True,
+            bugsnag.auto_notify(
+                exception,
+                unhandled=True,
                 severity_reason={
-                    "type":"middleware_handler",
+                    "type": "middleware_handler",
                     "attributes": {
-                        "name":"django"
+                        "name": "django"
                     }
                 }
             )

--- a/bugsnag/django/middleware.py
+++ b/bugsnag/django/middleware.py
@@ -28,10 +28,17 @@ class BugsnagMiddleware(MiddlewareMixin):
 
     def process_exception(self, request, exception):
         try:
-            bugsnag.auto_notify(exception)
+            bugsnag.auto_notify(exception, unhandled=True,
+                severity_reason={
+                    "type":"middleware_handler",
+                    "attributes": {
+                        "name":"django"
+                    }
+                }
+            )
 
         except Exception:
-            bugsnag.logger.exception('Error in exception middleware')
+            bugsnag.logger.exception("Error in exception middleware")
 
         bugsnag.clear_request_config()
 

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -31,7 +31,7 @@ def handle_exceptions(app):
 
 # pylint: disable-msg=W0613
 def __log_exception(sender, exception, **extra):
-    bugsnag.auto_notify(exception, unhandled=True, severity_reason={
+    bugsnag.auto_notify(exception, severity_reason={
         "type": "middleware_handler",
         "attributes": {
             "name": "flask"

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -12,7 +12,7 @@ def add_flask_request_to_notification(notification):
         notification.context = "%s %s" % (request.method,
                                           request_path(request.environ))
 
-    if 'id' not in notification.user:
+    if "id" not in notification.user:
         notification.set_user(id=request.remote_addr)
     notification.add_tab("session", dict(session))
     notification.add_tab("environment", dict(request.environ))
@@ -31,4 +31,9 @@ def handle_exceptions(app):
 
 # pylint: disable-msg=W0613
 def __log_exception(sender, exception, **extra):
-    bugsnag.auto_notify(exception)
+    bugsnag.auto_notify(exception, unhandled=True, severity_reason={
+        "type": "middleware_handler",
+        "attributes": {
+            "name": "flask"
+        }
+    })

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -32,8 +32,8 @@ def handle_exceptions(app):
 # pylint: disable-msg=W0613
 def __log_exception(sender, exception, **extra):
     bugsnag.auto_notify(exception, severity_reason={
-        "type": "middleware_handler",
+        "type": "unhandledExceptionMiddleware",
         "attributes": {
-            "name": "flask"
+            "framework": "Flask"
         }
     })

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -37,7 +37,14 @@ class BugsnagHandler(logging.Handler, object):
             if path in record.pathname:
                 return
 
-        options = {'meta_data': {}}
+        options = {'meta_data': {}, 'unhandled': True,
+            'severity_reasons': {
+                'type': 'log_level',
+                'attributes': {
+                    'level': record.levelname
+                }
+            }
+        }
 
         for callback in self.callbacks:
             try:

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -39,9 +39,9 @@ class BugsnagHandler(logging.Handler, object):
 
         options = {
             'meta_data': {},
-            'unhandled': True,
-            'severity_reasons': {
-                'type': 'log_level',
+            'unhandled': False,
+            'severity_reason': {
+                'type': 'logs',
                 'attributes': {
                     'level': record.levelname
                 }

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -37,7 +37,9 @@ class BugsnagHandler(logging.Handler, object):
             if path in record.pathname:
                 return
 
-        options = {'meta_data': {}, 'unhandled': True,
+        options = {
+            'meta_data': {},
+            'unhandled': True,
             'severity_reasons': {
                 'type': 'log_level',
                 'attributes': {

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -72,7 +72,7 @@ def auto_notify(exception, **options):
     Notify bugsnag of an exception if auto_notify is enabled.
     """
     if configuration.auto_notify:
-        default_client.notify(exception, severity="error", **options)
+        default_client.notify(exception, unhandled=True, severity="error", **options)
 
 
 def before_notify(callback):

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -72,7 +72,8 @@ def auto_notify(exception, **options):
     Notify bugsnag of an exception if auto_notify is enabled.
     """
     if configuration.auto_notify:
-        default_client.notify(exception, unhandled=True, severity="error", **options)
+        default_client.notify(exception, unhandled=True,
+                              severity="error", **options)
 
 
 def before_notify(callback):

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -47,8 +47,10 @@ def notify(exception, **options):
     """
     Notify bugsnag of an exception.
     """
-    if ('unhandled' not in options or options['unhandled'] is False) and 'severity' in options:
-        options['default_severity'] = False
+    if 'severity' in options:
+        options['severity_reason'] = {'type': 'userSpecifiedSeverity'}
+    else:
+        options['severity_reason'] = {'type': 'handledException'}
 
     if (isinstance(exception, (list, tuple)) and len(exception) == 3 and
             isinstance(exception[2], types.TracebackType)):
@@ -72,8 +74,12 @@ def auto_notify(exception, **options):
     Notify bugsnag of an exception if auto_notify is enabled.
     """
     if configuration.auto_notify:
-        default_client.notify(exception, unhandled=True,
-                              severity="error", **options)
+        default_client.notify(
+            exception,
+            unhandled=options.get('unhandled', True),
+            severity=options.get('severity', 'error'),
+            **options
+        )
 
 
 def before_notify(callback):

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -47,7 +47,7 @@ def notify(exception, **options):
     """
     Notify bugsnag of an exception.
     """
-    if 'severity' in options:
+    if ('unhandled' not in options or options['unhandled'] is False) and 'severity' in options:
         options['default_severity'] = False
 
     if (isinstance(exception, (list, tuple)) and len(exception) == 3 and

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -76,8 +76,11 @@ def auto_notify(exception, **options):
     if configuration.auto_notify:
         default_client.notify(
             exception,
-            unhandled=options.get('unhandled', True),
-            severity=options.get('severity', 'error'),
+            unhandled=options.pop('unhandled', True),
+            severity=options.pop('severity', 'error'),
+            severity_reason=options.pop('severity_reason', {
+                'type': 'unhandledException'
+            }),
             **options
         )
 

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -47,6 +47,9 @@ def notify(exception, **options):
     """
     Notify bugsnag of an exception.
     """
+    if 'severity' in options:
+        options['default_severity'] = False
+
     if (isinstance(exception, (list, tuple)) and len(exception) == 3 and
             isinstance(exception[2], types.TracebackType)):
         default_client.notify_exc_info(*exception, **options)

--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -59,8 +59,10 @@ class Notification(object):
             self.severity = "warning"
 
         self.unhandled = options.pop("unhandled", False)
-        self.severity_reason = options.pop("severity_reason", None)
-        self.default_severity = options.pop("default_severity", True)
+        self.severity_reason = options.pop(
+            "severity_reason",
+            {'type': 'handledException'}
+        )
 
         self.user = options.pop("user", {})
         if "user_id" in options:
@@ -215,7 +217,7 @@ class Notification(object):
         filters = self.config.params_filters
         encoder = SanitizingJSONEncoder(separators=(',', ':'),
                                         keyword_filters=filters)
-        payload = {
+        return encoder.encode({
             "apiKey": self.api_key,
             "notifier": {
                 "name": self.NOTIFIER_NAME,
@@ -225,8 +227,8 @@ class Notification(object):
             "events": [{
                 "payloadVersion": self.PAYLOAD_VERSION,
                 "severity": self.severity,
+                "severityReason": self.severity_reason,
                 "unhandled": self.unhandled,
-                "defaultSeverity": self.default_severity,
                 "releaseStage": self.release_stage,
                 "appVersion": self.app_version,
                 "context": self.context,
@@ -244,7 +246,4 @@ class Notification(object):
                 "projectRoot": self.config.get("project_root"),
                 "libRoot": self.config.get("lib_root")
             }]
-        }
-        if self.unhandled:
-            payload['events'][0]['severityReason'] = self.severity_reason
-        return encoder.encode(payload)
+        })

--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -58,6 +58,10 @@ class Notification(object):
         if self.severity not in self.SUPPORTED_SEVERITIES:
             self.severity = "warning"
 
+        self.unhandled = options.pop("unhandled", False)
+        self.severity_reason = options.pop("severity_reason", None)
+        self.default_severity = True
+
         self.user = options.pop("user", {})
         if "user_id" in options:
             self.user["id"] = options.pop("user_id")
@@ -211,7 +215,7 @@ class Notification(object):
         filters = self.config.params_filters
         encoder = SanitizingJSONEncoder(separators=(',', ':'),
                                         keyword_filters=filters)
-        return encoder.encode({
+        payload = {
             "apiKey": self.api_key,
             "notifier": {
                 "name": self.NOTIFIER_NAME,
@@ -221,6 +225,8 @@ class Notification(object):
             "events": [{
                 "payloadVersion": self.PAYLOAD_VERSION,
                 "severity": self.severity,
+                "unhandled": self.unhandled,
+                "defaultSeverity": self.default_severity,
                 "releaseStage": self.release_stage,
                 "appVersion": self.app_version,
                 "context": self.context,
@@ -238,4 +244,7 @@ class Notification(object):
                 "projectRoot": self.config.get("project_root"),
                 "libRoot": self.config.get("lib_root")
             }]
-        })
+        }
+        if self.unhandled:
+            payload['severityReason'] = self.severity_reason
+        return encoder.encode(payload)

--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -60,7 +60,7 @@ class Notification(object):
 
         self.unhandled = options.pop("unhandled", False)
         self.severity_reason = options.pop("severity_reason", None)
-        self.default_severity = True
+        self.default_severity = options.pop("default_severity", True)
 
         self.user = options.pop("user", {})
         if "user_id" in options:
@@ -246,5 +246,5 @@ class Notification(object):
             }]
         }
         if self.unhandled:
-            payload['severityReason'] = self.severity_reason
+            payload['events'][0]['severityReason'] = self.severity_reason
         return encoder.encode(payload)

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -14,6 +14,13 @@ class BugsnagRequestHandler(RequestHandler):
                 "url": self.request.full_url(),
                 "method": self.request.method,
                 "arguments": self.request.arguments,
+            },
+            "unhandled": True,
+            "severity_reason": {
+                "type": "middleware_handler",
+                "attributes": {
+                    "name": "tornado"
+                }
             }
         }
 
@@ -32,7 +39,7 @@ class BugsnagRequestHandler(RequestHandler):
         RequestHandler._handle_request_exception(self, exc)
 
     def _get_context(self):
-        return "%s %s" % (self.request.method, self.request.uri.split('?')[0])
+        return "%s %s" % (self.request.method, self.request.uri.split("?")[0])
 
     def bugsnag_ignore_status_codes(self):
         # Subclasses can override to add or remove codes

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -15,11 +15,10 @@ class BugsnagRequestHandler(RequestHandler):
                 "method": self.request.method,
                 "arguments": self.request.arguments,
             },
-            "unhandled": True,
             "severity_reason": {
-                "type": "middleware_handler",
+                "type": "unhandledExceptionMiddleware",
                 "attributes": {
-                    "name": "tornado"
+                    "framework": "Tornado"
                 }
             }
         }

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -27,9 +27,9 @@ class WrappedWSGIApp(object):
     """
 
     SEVERITY_REASON = {
-        "type": "middleware_handler",
+        "type": "unhandledExceptionMiddleware",
         "attributes": {
-            "name": "wsgi"
+            "framework": "WSGI"
         }
     }
 

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -26,14 +26,15 @@ class WrappedWSGIApp(object):
     Wraps a running WSGI app and sends all exceptions to bugsnag.
     """
 
+    SEVERITY_REASON = {
+        "type": "middleware_handler",
+        "attributes": {
+            "name": "wsgi"
+        }
+    }
+
     def __init__(self, application, environ, start_response):
         self.environ = environ
-        self.severity_reason = {
-            "type": "middleware_handler",
-            "attributes": {
-                "name": "wsgi"
-            }
-        }
 
         bugsnag.configure_request(wsgi_environ=self.environ)
 
@@ -42,8 +43,7 @@ class WrappedWSGIApp(object):
         except Exception as e:
             bugsnag.auto_notify(
                 e,
-                unhandled=True,
-                severity_reason=self.severity_reason
+                severity_reason=self.SEVERITY_REASON
             )
             raise
 
@@ -55,8 +55,7 @@ class WrappedWSGIApp(object):
         except Exception as e:
             bugsnag.auto_notify(
                 e,
-                unhandled=True,
-                severity_reason=self.severity_reason
+                severity_reason=self.SEVERITY_REASON
             )
             raise
 
@@ -67,8 +66,7 @@ class WrappedWSGIApp(object):
         except Exception as e:
             bugsnag.auto_notify(
                 e,
-                unhandled=True,
-                severity_reason=self.severity_reason
+                severity_reason=self.SEVERITY_REASON
             )
             raise
         finally:

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -33,15 +33,18 @@ class WrappedWSGIApp(object):
             "attributes": {
                 "name": "wsgi"
             }
-        } 
+        }
 
         bugsnag.configure_request(wsgi_environ=self.environ)
 
         try:
             self.app = application(environ, start_response)
         except Exception as e:
-            bugsnag.auto_notify(e, unhandled=True,
-                severity_reason=self.severity_reason)
+            bugsnag.auto_notify(
+                e,
+                unhandled=True,
+                severity_reason=self.severity_reason
+            )
             raise
 
     def __iter__(self):
@@ -50,8 +53,11 @@ class WrappedWSGIApp(object):
                 yield response
 
         except Exception as e:
-            bugsnag.auto_notify(e, unhandled=True,
-                severity_reason=self.severity_reason)
+            bugsnag.auto_notify(
+                e,
+                unhandled=True,
+                severity_reason=self.severity_reason
+            )
             raise
 
     def close(self):
@@ -59,8 +65,11 @@ class WrappedWSGIApp(object):
             if hasattr(self.app, 'close'):
                 return self.app.close()
         except Exception as e:
-            bugsnag.auto_notify(e, unhandled=True,
-                severity_reason=self.severity_reason)
+            bugsnag.auto_notify(
+                e,
+                unhandled=True,
+                severity_reason=self.severity_reason
+            )
             raise
         finally:
             bugsnag.clear_request_config()

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -28,13 +28,20 @@ class WrappedWSGIApp(object):
 
     def __init__(self, application, environ, start_response):
         self.environ = environ
+        self.severity_reason = {
+            "type": "middleware_handler",
+            "attributes": {
+                "name": "wsgi"
+            }
+        } 
 
         bugsnag.configure_request(wsgi_environ=self.environ)
 
         try:
             self.app = application(environ, start_response)
         except Exception as e:
-            bugsnag.auto_notify(e)
+            bugsnag.auto_notify(e, unhandled=True,
+                severity_reason=self.severity_reason)
             raise
 
     def __iter__(self):
@@ -43,7 +50,8 @@ class WrappedWSGIApp(object):
                 yield response
 
         except Exception as e:
-            bugsnag.auto_notify(e)
+            bugsnag.auto_notify(e, unhandled=True,
+                severity_reason=self.severity_reason)
             raise
 
     def close(self):
@@ -51,7 +59,8 @@ class WrappedWSGIApp(object):
             if hasattr(self.app, 'close'):
                 return self.app.close()
         except Exception as e:
-            bugsnag.auto_notify(e)
+            bugsnag.auto_notify(e, unhandled=True,
+                severity_reason=self.severity_reason)
             raise
         finally:
             bugsnag.clear_request_config()

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -65,10 +65,9 @@ class DjangoMiddlewareTests(IntegrationTest):
         event = payload['events'][0]
 
         self.assertTrue(event['unhandled'])
-        self.assertTrue(event['defaultSeverity'])
         self.assertEqual(event['severityReason'], {
-            'type': 'middleware_handler',
+            'type': 'unhandledExceptionMiddleware',
             'attributes': {
-                'name': 'django'
+                'framework': 'Django'
             }
         })

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -54,3 +54,21 @@ class DjangoMiddlewareTests(IntegrationTest):
     def test_ignores_http404(self):
         self.client.get('/404')
         self.assertEqual(len(self.server.received), 0)
+
+    def test_django_intergration_includes_middleware_severity(self):
+        with self.assertRaises(Exception):
+            self.client.get('/crash/')
+
+        self.assertEqual(len(self.server.received), 1)
+
+        payload = self.server.received[0]['json_body']
+        event = payload['events'][0]
+
+        self.assertTrue(event['unhandled'])
+        self.assertTrue(event['defaultSeverity'])
+        self.assertEqual(event['severityReason'], {
+            'type': 'middleware_handler',
+            'attributes': {
+                'name': 'django'
+            }
+        })

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -185,10 +185,9 @@ class TestFlask(IntegrationTest):
         payload = self.server.received[0]['json_body']
         event = payload['events'][0]
         self.assertTrue(event['unhandled'])
-        self.assertTrue(event['defaultSeverity'])
         self.assertEqual(event['severityReason'], {
-            "type": "middleware_handler",
+            "type": "unhandledExceptionMiddleware",
             "attributes": {
-                "name": "flask"
+                "framework": "Flask"
             }
         })

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -170,3 +170,25 @@ class TestFlask(IntegrationTest):
         payload = self.server.received[0]['json_body']
         self.assertEqual(payload['events'][0]['context'],
                          'custom_context_notification_testing')
+
+    def test_flask_intergration_includes_middleware_severity(self):
+        app = Flask("bugsnag")
+
+        @app.route("/test")
+        def test():
+            raise SentinelError("oops")
+
+        handle_exceptions(app)
+        app.test_client().get("/test")
+
+        self.assertEqual(1, len(self.server.received))
+        payload = self.server.received[0]['json_body']
+        event = payload['events'][0]
+        self.assertTrue(event['unhandled'])
+        self.assertTrue(event['defaultSeverity'])
+        self.assertEqual(event['severityReason'], {
+            "type": "middleware_handler",
+            "attributes": {
+                "name": "flask"
+            }
+        })

--- a/tests/integrations/test_wsgi.py
+++ b/tests/integrations/test_wsgi.py
@@ -171,10 +171,9 @@ class TestWSGI(IntegrationTest):
         event = payload['events'][0]
 
         self.assertTrue(event['unhandled'])
-        self.assertTrue(event['defaultSeverity'])
         self.assertEqual(event['severityReason'], {
-            'type': 'middleware_handler',
+            'type': 'unhandledExceptionMiddleware',
             'attributes': {
-                'name': 'wsgi'
+                'framework': 'WSGI'
             }
         })

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -116,6 +116,22 @@ class ClientTest(IntegrationTest):
             'key': 'value'
         })
 
+    def test_notify_capture_change_severity(self):
+        try:
+            with self.client.capture(severity='info'):
+                raise Exception('Testing Notify Context')
+        except Exception:
+            pass
+
+        payload = self.server.received[0]['json_body']
+        event = payload['events'][0]
+
+        self.assertEqual(event['severity'], "info")
+        self.assertFalse(event['unhandled'])
+        self.assertEqual(event['severityReason'], {
+            "type": "contextSpecifiedSeverity"
+        })
+
     def test_notify_capture_types(self):
         try:
             with self.client.capture((ScaryException,)):
@@ -174,6 +190,25 @@ class ClientTest(IntegrationTest):
             return "300"
 
         self.assertEqual(foo(), "300")
+
+    def test_capture_decorator_change_severity(self):
+        @self.client.capture(severity='info')
+        def foo():
+            raise Exception('Testing Capture Function')
+
+        try:
+            foo(Exception)
+        except Exception:
+            pass
+
+        payload = self.server.received[0]['json_body']
+        event = payload['events'][0]
+
+        self.assertEqual(event['severity'], "info")
+        self.assertFalse(event['unhandled'])
+        self.assertEqual(event['severityReason'], {
+            "type": "contextSpecifiedSeverity"
+        })
 
     def test_capture_decorator_raises(self):
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -526,7 +526,7 @@ class TestBugsnag(IntegrationTest):
 
     def test_notify_unhandled_severity_callback(self):
         def callback(report):
-            report.severity = "info"
+            report.severity = "warning"
 
         bugsnag.before_notify(callback)
 


### PR DESCRIPTION
- Adds `defaultSeverity`, `unhandled`, and `severityReasons` payload properties to support upcoming handled/unhandled functionality
- Above properties added through **options parameters
- System error handler, log level handlers, and middleware error handlers set up with severity reasons
_references [PLAT_209](https://bugsnag.atlassian.net/browse/PLAT-209)_