### PR TITLE
Ensured logger supplies correct severity reason

### DIFF
--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -41,7 +41,7 @@ class BugsnagHandler(logging.Handler, object):
             'meta_data': {},
             'unhandled': False,
             'severity_reason': {
-                'type': 'logs',
+                'type': 'log',
                 'attributes': {
                     'level': record.levelname
                 }


### PR DESCRIPTION
Minuscule updating to fix the severity_reason type for the log handler