### PR TITLE
urlresolvers removed from django-2.0

### DIFF
--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -2,7 +2,11 @@ from __future__ import division, print_function, absolute_import
 
 import six
 from django.conf import settings
-from django.core.urlresolvers import resolve
+
+try:
+    from django.core.urlresolvers import resolve
+except ImportError:
+    from django.urls import resolve
 
 import bugsnag
 


### PR DESCRIPTION
`django.core.urlresolvers` has been removed from django-2.0 causing bugsnag-python to crash on initialization.

I've added new naming scheme fallback.
Also configured tox to run tests against django-2.0.
