### PR TITLE
Fixed linting issues

### DIFF
--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -59,7 +59,7 @@ def notify(exception, **options):
         if not isinstance(exception, BaseException):
             try:
                 value = repr(exception)
-            except:
+            except Exception:
                 value = '[BADENCODING]'
 
             bugsnag.logger.warning('Coercing invalid notify()'

--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -133,7 +133,7 @@ class Notification(object):
                 if module_file[-4:] == '.pyc':
                     module_file = module_file[:-1]
                 exclude_module_paths.append(module_file)
-            except:
+            except Exception:
                 bugsnag.logger.exception(
                     'Could not exclude module: %s' % repr(exclude_module))
 
@@ -207,7 +207,7 @@ class Notification(object):
 
             return dict((n, lines[n - 1].rstrip()) for n in range(start, end))
 
-        except:
+        except Exception:
             return None
 
     def _payload(self):

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -42,7 +42,7 @@ class DeliveryTest(IntegrationTest):
 
         try:
             import requests  # noqa
-        except:
+        except ImportError:
             raise SkipTest("Requests is not installed")
 
         RequestsDelivery().deliver(self.config, '{"legit":4}')
@@ -59,7 +59,7 @@ class DeliveryTest(IntegrationTest):
 
         try:
             import requests  # noqa
-        except:
+        except ImportError:
             raise SkipTest("Requests is not installed")
 
         self.config.configure(endpoint=self.server.url)

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -356,7 +356,7 @@ class TestBugsnag(IntegrationTest):
         backtrace = None
         try:
             raise ScaryException('foo')
-        except:
+        except ScaryException:
             backtrace = sys.exc_info()[2]
 
         bugsnag.notify(Exception("foo"), traceback=backtrace)
@@ -375,7 +375,7 @@ class TestBugsnag(IntegrationTest):
             backtrace = None
             try:
                 raise ScaryException('foo')
-            except:
+            except ScaryException:
                 backtrace = sys.exc_info()[2]
             bugsnag.notify((Exception, Exception("foo"), backtrace))
 


### PR DESCRIPTION
After Flake8 updates the linter picked up issues with no Exception types being defined on excepts.

To remedy this:
- Named errors were used where appropriate in tests (ImportError and ScaryException)
- Generic excepts were given "Exception" to avoid changing functionality