### PR TITLE
Allow the 'exception' option to override the logged exception in a handler callback

### DIFF
--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -56,6 +56,13 @@ class BugsnagHandler(logging.Handler, object):
 
         client = self.client or bugsnag.legacy.default_client
 
+        if 'exception' in options:
+            if isinstance(options['exception'], Exception):
+                client.notify(**options)
+                return
+            else:
+                options['meta_data']['exception'] = options.pop('exception')
+
         if record.exc_info:
             client.notify_exc_info(*record.exc_info, **options)
         else:

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -61,7 +61,12 @@ class BugsnagHandler(logging.Handler, object):
                 client.notify(**options)
                 return
             else:
-                options['meta_data']['exception'] = options.pop('exception')
+                custom_exception = options.pop('exception')
+                try:
+                    options['meta_data']['exception'] = custom_exception
+                except TypeError:
+                    # Means options['meta_data'] is no longer a dictionary
+                    pass
 
         if record.exc_info:
             client.notify_exc_info(*record.exc_info, **options)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -409,3 +409,38 @@ class HandlersTest(IntegrationTest):
         self.assertEqual(event['metaData']['tab'], {
             'key': 'value', 'key2': 'other value'
         })
+
+    @use_client_logger
+    def test_client_callback_exception(self, handler, logger):
+
+        def exception_replacing_callback(record, options):
+            options['exception'] = ScaryException('replacement')
+
+        handler.add_callback(exception_replacing_callback)
+        logger.info('Everything is fine')
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+
+        self.assertEqual(exception['errorClass'], 'tests.utils.ScaryException')
+        self.assertEqual(exception['message'], 'replacement')
+
+    @use_client_logger
+    def test_client_callback_exception_metadata(self, handler, logger):
+
+        def exception_replacing_callback(record, options):
+            options['exception'] = 'metadata'
+
+        handler.add_callback(exception_replacing_callback)
+        logger.info('Everything is fine')
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+
+        self.assertEqual(exception['errorClass'], 'LogINFO')
+        self.assertEqual(exception['message'], 'Everything is fine')
+        self.assertEqual(event['metaData']['custom'], {'exception': 'metadata'})

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -443,4 +443,5 @@ class HandlersTest(IntegrationTest):
 
         self.assertEqual(exception['errorClass'], 'LogINFO')
         self.assertEqual(exception['message'], 'Everything is fine')
-        self.assertEqual(event['metaData']['custom'], {'exception': 'metadata'})
+        self.assertEqual(event['metaData']['custom'],
+                         {'exception': 'metadata'})


### PR DESCRIPTION
-Tests whether `exception` is set in options before notifying of a log entry
- If it is and is an instance of an `Exception`, notify using that exception
- If it is and it isn't an instance of an `Exception` add it to metadata and remove original key to avoid name conflicts.