### PR TITLE
Ensured is_authenticated is used correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+#IDE files
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ matrix:
   - python: 2.7
     env: TOXENV=py27-flask
   - python: 2.7
-    env: TOXENV=py27-django18-django
+    env: TOXENV=py27-django18-migrate-django
   - python: 2.7
-    env: TOXENV=py27-django19-django
+    env: TOXENV=py27-django19-migrate-django
   - python: 2.7
-    env: TOXENV=py27-django110-django
+    env: TOXENV=py27-django110-migrate-django
 
   - python: 3.3
     env: TOXENV=py33-test
@@ -49,11 +49,11 @@ matrix:
   - python: 3.5
     env: TOXENV=py35-wsgi
   - python: 3.5
-    env: TOXENV=py35-django18-django
+    env: TOXENV=py35-django18-migrate-django
   - python: 3.5
-    env: TOXENV=py35-django19-django
+    env: TOXENV=py35-django19-migrate-django
   - python: 3.5
-    env: TOXENV=py35-django110-django
+    env: TOXENV=py35-django110-migrate-django
   - python: 3.5
     env: TOXENV=py35-lint
 

--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -26,14 +26,19 @@ def add_django_request_to_notification(notification):
             notification.context = "%s %s" % (request.method,
                                               request.path_info)
 
-    if hasattr(request, 'user') and request.user.is_authenticated():
-        try:
-            name = request.user.get_full_name()
-            email = getattr(request.user, 'email', None)
-            username = six.text_type(request.user.get_username())
-            notification.set_user(id=username, email=email, name=name)
-        except Exception:
-            bugsnag.logger.exception('Could not get user data')
+    if hasattr(request, 'user'):
+        if hasattr(request.user.is_authenticated, '__call__'):
+            is_authenticated = request.user.is_authenticated()
+        else:
+            is_authenticated = request.user.is_authenticated
+        if is_authenticated:
+            try:
+                name = request.user.get_full_name()
+                email = getattr(request.user, 'email', None)
+                username = six.text_type(request.user.get_username())
+                notification.set_user(id=username, email=email, name=name)
+            except Exception:
+                bugsnag.logger.exception('Could not get user data')
     else:
         notification.set_user(id=request.META['REMOTE_ADDR'])
 

--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -27,7 +27,7 @@ def add_django_request_to_notification(notification):
                                               request.path_info)
 
     if hasattr(request, 'user'):
-        if hasattr(request.user.is_authenticated, '__call__'):
+        if callable(request.user.is_authenticated):
             is_authenticated = request.user.is_authenticated()
         else:
             is_authenticated = request.user.is_authenticated

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist=
     py{26,27,33,34,35}-{requests-,}test,
     py{26,27}-flask,
     py{26,27,33,34,35}-wsgi,
-    py{27,35}-django{18,19,110}-django
+    py{27,35}-django{18,19,110}-migrate-django
     py35-lint,
 
 [testenv]
@@ -33,6 +33,7 @@ commands =
     test: nosetests --tests=tests -sv --with-coverage --cover-package=bugsnag
     wsgi: nosetests integrations/test_wsgi.py -sv --with-coverage --cover-package=bugsnag
     flask: nosetests integrations/test_flask.py -sv --with-coverage --cover-package=bugsnag
+    migrate: python example/django/manage.py migrate
     django: nosetests integrations/test_django.py -sv --with-coverage --cover-package=bugsnag
     lint: {toxinidir}/scripts/lint.sh
     lint: mypy -2 --ignore-missing-imports bugsnag


### PR DESCRIPTION
Fixes warnings that `is_authenticated` is not callable.

This has been tested manually on Django 1.11 & 2.0.