### PR TITLE
Expanded payload filtering to encapsulate device, user, and app

### DIFF
--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -240,10 +240,10 @@ class Notification(object):
                     "stacktrace": self.stacktrace,
                 }],
                 "metaData": FilterDict(self.meta_data),
-                "user": self.user,
-                "device": {
+                "user": FilterDict(self.user),
+                "device": FilterDict({
                     "hostname": self.hostname
-                },
+                }),
                 "projectRoot": self.config.get("project_root"),
                 "libRoot": self.config.get("lib_root"),
                 "session": self.session

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -108,10 +108,10 @@ class SessionTracker(object):
             'device': FilterDict({
                 'hostname': self.config.get('hostname'),
             }),
-            'app': FilterDict({
+            'app': {
                 'releaseStage': self.config.get('release_stage'),
                 'version': self.config.get('app_version')
-            }),
+            },
             'sessionCounts': sessions
         }
 

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -5,7 +5,8 @@ from threading import Lock, Timer
 import atexit
 
 import bugsnag
-from bugsnag.utils import package_version, ThreadLocals, SanitizingJSONEncoder
+from bugsnag.utils import package_version, ThreadLocals, \
+    FilterDict, SanitizingJSONEncoder
 from bugsnag.notification import Notification
 
 
@@ -104,13 +105,13 @@ class SessionTracker(object):
                 'url': Notification.NOTIFIER_URL,
                 'version': notifier_version
             },
-            'device': {
+            'device': FilterDict({
                 'hostname': self.config.get('hostname'),
-            },
-            'app': {
+            }),
+            'app': FilterDict({
                 'releaseStage': self.config.get('release_stage'),
                 'version': self.config.get('app_version')
-            },
+            }),
             'sessionCounts': sessions
         }
 


### PR DESCRIPTION
Wraps the following dictionaries in a FilterDict to enable filtering of contents before payload delivery:
- `SessionTracker`:
  - `device`
  - `app`

- `Notification`:
  - `user`
  - `device`

Would you be able to test this out @tremlab and see if it fixes what you described?