### PR TITLE
tests(mypy): Re-enable default mypy behaviour

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,4 +36,4 @@ commands =
     migrate: python example/django/manage.py migrate
     django: nosetests integrations/test_django.py -sv --with-coverage --cover-package=bugsnag
     lint: {toxinidir}/scripts/lint.sh
-    lint: mypy -2 --ignore-missing-imports bugsnag
+    lint: mypy -2 --ignore-missing-imports --no-strict-optional bugsnag


### PR DESCRIPTION
- Previously --no-strict-optional was default behaviour, added flag to explicitly enable this in newer versions

## Goal

With the release of mypy `0.6` the `--no-strict-optional` setting is no-longer the default behaviour.  This PR ensures that mypy behaves as it used to by explicitly adding the `--no-strict-optional ` to the Tox configuration file.

## Changeset

The second `lint` command was changed, with `--no-strict-optional` being added to the `mypy` command

## Tests

Confirmed that the new command runs correctly locally, and on CI below.

## Discussion

### Alternative Approaches

The alternative would be to fix then issue flagged up, something that would require more time and upfront design while preventing fixes and changes from merging.  I've created a [ticket](https://bugsnag.atlassian.net/browse/PLAT-1161) to address this debt at a later point.
