### PR TITLE
Remove 3.3 ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,6 @@ matrix:
   - python: 2.7
     env: TOXENV=py27-django110-migrate1-django1
 
-  - python: 3.3
-    env: TOXENV=py33-test
-  - python: 3.3
-    env: TOXENV=py33-requests-test
-  - python: 3.3
-    env: TOXENV=py33-wsgi
-
   - python: 3.4
     env: TOXENV=py34-test
   - python: 3.4
@@ -48,14 +41,21 @@ matrix:
     env: TOXENV=py35-requests-test
   - python: 3.5
     env: TOXENV=py35-wsgi
-  - python: 3.5
-    env: TOXENV=py35-django18-migrate1-django1
-  - python: 3.5
-    env: TOXENV=py35-django19-migrate1-django1
-  - python: 3.5
-    env: TOXENV=py35-django110-migrate1-django1
-  - python: 3.5
-    env: TOXENV=py35-lint
+
+  - python: 3.6
+    env: TOXENV=py36-test
+  - python: 3.6
+    env: TOXENV=py36-requests-test
+  - python: 3.6
+    env: TOXENV=py36-wsgi
+  - python: 3.6
+    env: TOXENV=py36-django18-migrate1-django1
+  - python: 3.6
+    env: TOXENV=py36-django19-migrate1-django1
+  - python: 3.6
+    env: TOXENV=py36-django110-migrate1-django1
+  - python: 3.6
+    env: TOXENV=py36-lint
 
 install: travis_retry pip install coveralls tox
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,18 @@
 [tox]
 envlist=
-    py{26,27,33,34,35}-{requests-,}test,
+    py{26,27,34,35,36}-{requests-,}test,
     py{26,27}-flask,
-    py{26,27,33,34,35}-wsgi,
-    py{27,35}-django{18,19,110}-migrate1-django1
-    py35-lint,
+    py{26,27,34,35,36}-wsgi,
+    py{27,36}-django{18,19,110}-migrate1-django1
+    py36-lint,
 
 [testenv]
 basepython =
     py26: python2.6
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 whitelist_externals=
     {toxinidir}/scripts/lint.sh
 deps=


### PR DESCRIPTION
## Goal

Python 3.3 is deprecated, and the dropping of support from `wheel` and `setuputils` are causing tests to fail.

This PR removes 3.3 from the tests and tox environment, and adds the newest version of Python, 3.6.  It also moves the tests targeting 3.5 to 3.6, such as linting.
