### PR TITLE
Remove dependency on distutils

### DIFF
--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import socket
+import sysconfig
 import warnings
-from distutils.sysconfig import get_python_lib
 
 from bugsnag.sessiontracker import SessionMiddleware
 from bugsnag.middleware import DefaultMiddleware, MiddlewareStack
@@ -58,7 +58,7 @@ class Configuration(_BaseConfiguration):
         self.asynchronous = True
         self.use_ssl = True  # Deprecated
         self.delivery = create_default_delivery()
-        self.lib_root = get_python_lib()
+        self.lib_root = sysconfig.get_path('purelib')
         self.project_root = os.getcwd()
         self.app_version = None
         self.params_filters = ["password", "password_confirmation", "cookie",


### PR DESCRIPTION
distutils is vaguely "legacy" and on some systems (e.g. Ubuntu 18.04) it's no longer included with the default Python installation, and requires an additional system package (python3-distutils) to be available, making it slightly harder to use bugsnag.

We can get the same kinds of information from sysconfig instead, which is a part of the stdlib and generally provides the same behavior, e.g.:

    >>> distutils.sysconfig.get_python_lib()
    '/home/ckuehl/proj/buggo/venv/lib/python3.6/site-packages'
    >>> sysconfig.get_path('purelib')
    '/home/ckuehl/proj/buggo/venv/lib/python3.6/site-packages'

In the long term, I think it probably makes the most sense to actually report all of `sys.path` along with errors, rather than just this one value. I can submit a patch to do this if you'd be interested.