### PR TITLE
Cawllec/pin 2.6 test versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,16 @@ matrix:
   include:
   - python: 2.6
     env: TOXENV=py26-test
-    install: travis_retry pip install coveralls 'tox<3'
+    install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
   - python: 2.6
     env: TOXENV=py26-requests-test
-    install: travis_retry pip install coveralls 'tox<3'
+    install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
   - python: 2.6
     env: TOXENV=py26-wsgi
-    install: travis_retry pip install coveralls 'tox<3'
+    install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
   - python: 2.6
     env: TOXENV=py26-flask
-    install: travis_retry pip install coveralls 'tox<3'
+    install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
 
   - python: "2.7_with_system_site_packages"
     env: TOXENV=py27-test

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,7 +2,6 @@ twine
 wheel
 
 tox
-idna < 2.8
 nose-cov
 coveralls
 flake8

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,6 +2,7 @@ twine
 wheel
 
 tox
+idna < 2.8
 nose-cov
 coveralls
 flake8


### PR DESCRIPTION
## Goal

Fix breaking Python 2.6 tests due to tox dependencies no-longer supporting Python 2.6 (and not doing a major release)
