### PR TITLE
Fix Py26-WSGI CI issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,90 +2,90 @@ language: python
 
 matrix:
   include:
-  # - python: 2.6
-  #   env: TOXENV=py26-test
-  #   install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
-  # - python: 2.6
-  #   env: TOXENV=py26-requests-test
-  #   install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
+  - python: 2.6
+    env: TOXENV=py26-test
+    install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
+  - python: 2.6
+    env: TOXENV=py26-requests-test
+    install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
   - python: 2.6
     env: TOXENV=py26-wsgi
     install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
-  # - python: 2.6
-  #   env: TOXENV=py26-flask
-  #   install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
+  - python: 2.6
+    env: TOXENV=py26-flask
+    install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
 
-  # - python: "2.7_with_system_site_packages"
-  #   env: TOXENV=py27-test
-  # - python: 2.7
-  #   env: TOXENV=py27-test
-  # - python: 2.7
-  #   env: TOXENV=py27-requests-test
-  # - python: 2.7
-  #   env: TOXENV=py27-wsgi
-  # - python: 2.7
-  #   env: TOXENV=py27-flask
-  # - python: 2.7
-  #   env: TOXENV=py27-django18-migrate1-django1
-  # - python: 2.7
-  #   env: TOXENV=py27-django19-migrate1-django1
-  # - python: 2.7
-  #   env: TOXENV=py27-django110-migrate1-django1
-  # - python: 2.7
-  #   env: TOXENV=py27-django111-migrate1-django1
+  - python: "2.7_with_system_site_packages"
+    env: TOXENV=py27-test
+  - python: 2.7
+    env: TOXENV=py27-test
+  - python: 2.7
+    env: TOXENV=py27-requests-test
+  - python: 2.7
+    env: TOXENV=py27-wsgi
+  - python: 2.7
+    env: TOXENV=py27-flask
+  - python: 2.7
+    env: TOXENV=py27-django18-migrate1-django1
+  - python: 2.7
+    env: TOXENV=py27-django19-migrate1-django1
+  - python: 2.7
+    env: TOXENV=py27-django110-migrate1-django1
+  - python: 2.7
+    env: TOXENV=py27-django111-migrate1-django1
 
-  # - python: 3.3
-  #   env: TOXENV=py33-test
-  #   install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
-  # - python: 3.3
-  #   env: TOXENV=py33-requests-test
-  #   install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
-  # - python: 3.3
-  #   env: TOXENV=py33-wsgi
-  #   install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
+  - python: 3.3
+    env: TOXENV=py33-test
+    install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
+  - python: 3.3
+    env: TOXENV=py33-requests-test
+    install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
+  - python: 3.3
+    env: TOXENV=py33-wsgi
+    install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
 
-  # - python: 3.4
-  #   env: TOXENV=py34-test
-  # - python: 3.4
-  #   env: TOXENV=py34-requests-test
-  # - python: 3.4
-  #   env: TOXENV=py34-wsgi
+  - python: 3.4
+    env: TOXENV=py34-test
+  - python: 3.4
+    env: TOXENV=py34-requests-test
+  - python: 3.4
+    env: TOXENV=py34-wsgi
 
-  # - python: 3.5
-  #   env: TOXENV=py35-test
-  # - python: 3.5
-  #   env: TOXENV=py35-requests-test
-  # - python: 3.5
-  #   env: TOXENV=py35-wsgi
-  # - python: 3.5
-  #   env: TOXENV=py35-django18-migrate1-django1
-  # - python: 3.5
-  #   env: TOXENV=py35-django19-migrate1-django1
-  # - python: 3.5
-  #   env: TOXENV=py35-django110-migrate1-django1
-  # - python: 3.5
-  #   env: TOXENV=py35-lint
+  - python: 3.5
+    env: TOXENV=py35-test
+  - python: 3.5
+    env: TOXENV=py35-requests-test
+  - python: 3.5
+    env: TOXENV=py35-wsgi
+  - python: 3.5
+    env: TOXENV=py35-django18-migrate1-django1
+  - python: 3.5
+    env: TOXENV=py35-django19-migrate1-django1
+  - python: 3.5
+    env: TOXENV=py35-django110-migrate1-django1
+  - python: 3.5
+    env: TOXENV=py35-lint
 
-  # - python: 3.6
-  #   env: TOXENV=py36-test
-  # - python: 3.6
-  #   env: TOXENV=py36-requests-test
-  # - python: 3.6
-  #   env: TOXENV=py36-wsgi
-  # - python: 3.6
-  #   env: TOXENV=py36-django18-migrate1-django1
-  # - python: 3.6
-  #   env: TOXENV=py36-django19-migrate1-django1
-  # - python: 3.6
-  #   env: TOXENV=py36-django110-migrate1-django1
-  # - python: 3.6
-  #   env: TOXENV=py36-django111-migrate1-django1
-  # - python: 3.6
-  #   env: TOXENV=py36-django20-migrate1-django1
-  # - python: 3.6
-  #   env: TOXENV=py36-django21-migrate1-django1
-  # - python: 3.6
-  #   env: TOXENV=py36-lint
+  - python: 3.6
+    env: TOXENV=py36-test
+  - python: 3.6
+    env: TOXENV=py36-requests-test
+  - python: 3.6
+    env: TOXENV=py36-wsgi
+  - python: 3.6
+    env: TOXENV=py36-django18-migrate1-django1
+  - python: 3.6
+    env: TOXENV=py36-django19-migrate1-django1
+  - python: 3.6
+    env: TOXENV=py36-django110-migrate1-django1
+  - python: 3.6
+    env: TOXENV=py36-django111-migrate1-django1
+  - python: 3.6
+    env: TOXENV=py36-django20-migrate1-django1
+  - python: 3.6
+    env: TOXENV=py36-django21-migrate1-django1
+  - python: 3.6
+    env: TOXENV=py36-lint
 
 install: travis_retry pip install coveralls tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,90 +2,90 @@ language: python
 
 matrix:
   include:
-  - python: 2.6
-    env: TOXENV=py26-test
-    install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
-  - python: 2.6
-    env: TOXENV=py26-requests-test
-    install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
+  # - python: 2.6
+  #   env: TOXENV=py26-test
+  #   install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
+  # - python: 2.6
+  #   env: TOXENV=py26-requests-test
+  #   install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
   - python: 2.6
     env: TOXENV=py26-wsgi
     install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
-  - python: 2.6
-    env: TOXENV=py26-flask
-    install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
+  # - python: 2.6
+  #   env: TOXENV=py26-flask
+  #   install: travis_retry pip install coveralls 'tox<3' 'idna<2.8' 'pycparser<2.19'
 
-  - python: "2.7_with_system_site_packages"
-    env: TOXENV=py27-test
-  - python: 2.7
-    env: TOXENV=py27-test
-  - python: 2.7
-    env: TOXENV=py27-requests-test
-  - python: 2.7
-    env: TOXENV=py27-wsgi
-  - python: 2.7
-    env: TOXENV=py27-flask
-  - python: 2.7
-    env: TOXENV=py27-django18-migrate1-django1
-  - python: 2.7
-    env: TOXENV=py27-django19-migrate1-django1
-  - python: 2.7
-    env: TOXENV=py27-django110-migrate1-django1
-  - python: 2.7
-    env: TOXENV=py27-django111-migrate1-django1
+  # - python: "2.7_with_system_site_packages"
+  #   env: TOXENV=py27-test
+  # - python: 2.7
+  #   env: TOXENV=py27-test
+  # - python: 2.7
+  #   env: TOXENV=py27-requests-test
+  # - python: 2.7
+  #   env: TOXENV=py27-wsgi
+  # - python: 2.7
+  #   env: TOXENV=py27-flask
+  # - python: 2.7
+  #   env: TOXENV=py27-django18-migrate1-django1
+  # - python: 2.7
+  #   env: TOXENV=py27-django19-migrate1-django1
+  # - python: 2.7
+  #   env: TOXENV=py27-django110-migrate1-django1
+  # - python: 2.7
+  #   env: TOXENV=py27-django111-migrate1-django1
 
-  - python: 3.3
-    env: TOXENV=py33-test
-    install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
-  - python: 3.3
-    env: TOXENV=py33-requests-test
-    install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
-  - python: 3.3
-    env: TOXENV=py33-wsgi
-    install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
+  # - python: 3.3
+  #   env: TOXENV=py33-test
+  #   install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
+  # - python: 3.3
+  #   env: TOXENV=py33-requests-test
+  #   install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
+  # - python: 3.3
+  #   env: TOXENV=py33-wsgi
+  #   install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
 
-  - python: 3.4
-    env: TOXENV=py34-test
-  - python: 3.4
-    env: TOXENV=py34-requests-test
-  - python: 3.4
-    env: TOXENV=py34-wsgi
+  # - python: 3.4
+  #   env: TOXENV=py34-test
+  # - python: 3.4
+  #   env: TOXENV=py34-requests-test
+  # - python: 3.4
+  #   env: TOXENV=py34-wsgi
 
-  - python: 3.5
-    env: TOXENV=py35-test
-  - python: 3.5
-    env: TOXENV=py35-requests-test
-  - python: 3.5
-    env: TOXENV=py35-wsgi
-  - python: 3.5
-    env: TOXENV=py35-django18-migrate1-django1
-  - python: 3.5
-    env: TOXENV=py35-django19-migrate1-django1
-  - python: 3.5
-    env: TOXENV=py35-django110-migrate1-django1
-  - python: 3.5
-    env: TOXENV=py35-lint
+  # - python: 3.5
+  #   env: TOXENV=py35-test
+  # - python: 3.5
+  #   env: TOXENV=py35-requests-test
+  # - python: 3.5
+  #   env: TOXENV=py35-wsgi
+  # - python: 3.5
+  #   env: TOXENV=py35-django18-migrate1-django1
+  # - python: 3.5
+  #   env: TOXENV=py35-django19-migrate1-django1
+  # - python: 3.5
+  #   env: TOXENV=py35-django110-migrate1-django1
+  # - python: 3.5
+  #   env: TOXENV=py35-lint
 
-  - python: 3.6
-    env: TOXENV=py36-test
-  - python: 3.6
-    env: TOXENV=py36-requests-test
-  - python: 3.6
-    env: TOXENV=py36-wsgi
-  - python: 3.6
-    env: TOXENV=py36-django18-migrate1-django1
-  - python: 3.6
-    env: TOXENV=py36-django19-migrate1-django1
-  - python: 3.6
-    env: TOXENV=py36-django110-migrate1-django1
-  - python: 3.6
-    env: TOXENV=py36-django111-migrate1-django1
-  - python: 3.6
-    env: TOXENV=py36-django20-migrate1-django1
-  - python: 3.6
-    env: TOXENV=py36-django21-migrate1-django1
-  - python: 3.6
-    env: TOXENV=py36-lint
+  # - python: 3.6
+  #   env: TOXENV=py36-test
+  # - python: 3.6
+  #   env: TOXENV=py36-requests-test
+  # - python: 3.6
+  #   env: TOXENV=py36-wsgi
+  # - python: 3.6
+  #   env: TOXENV=py36-django18-migrate1-django1
+  # - python: 3.6
+  #   env: TOXENV=py36-django19-migrate1-django1
+  # - python: 3.6
+  #   env: TOXENV=py36-django110-migrate1-django1
+  # - python: 3.6
+  #   env: TOXENV=py36-django111-migrate1-django1
+  # - python: 3.6
+  #   env: TOXENV=py36-django20-migrate1-django1
+  # - python: 3.6
+  #   env: TOXENV=py36-django21-migrate1-django1
+  # - python: 3.6
+  #   env: TOXENV=py36-lint
 
 install: travis_retry pip install coveralls tox
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ whitelist_externals=
 deps=
     .
     nose-cov
+    py26: beautifulsoup4==4.6.3
     requests: requests
     wsgi: webtest==2.0.23
     flask: flask


### PR DESCRIPTION
## Goal
With the recent release of beautifulsoup4, `4.7.1`, the `py26-wsgi` test has starting failing on CI.  This fixes the beautifulsoup4 version in that test run to `4.6.3`, the previous working version.