### PR TITLE
Setup: Only include Bugsnag packages in Dist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email='simon@bugsnag.com',
     url='https://bugsnag.com/',
     license='MIT',
-    packages=find_packages(),
+    packages=find_packages(include=['bugsnag', 'bugsnag.*']),
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
## Goal
Ensures `tests` and other development packages within this repo aren't included in the released distribution, by specifically targeting `bugsnag` and child packages.

Tests performed:
- Ensured all files under bugsnag directory are included in sdist tarball
- Run examples after installing from sdist tarball