### PR TITLE
fix(flask): Guard against JSON parsing failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Ensure `request` tab is attached to Flask requests when JSON data is malformed
+  or otherwise cannot be read at crash time
+  [#176](https://github.com/bugsnag/bugsnag-python/pull/176)
+
 ## 3.5.1 (2019-02-04)
 
 ### Fixes

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -20,7 +20,7 @@ def add_flask_request_to_notification(notification):
         "url": request.base_url,
         "headers": dict(request.headers),
         "params": dict(request.form),
-        "data": request.get_json() or dict(body=request.data)
+        "data": request.get_json(silent=True) or dict(body=request.data)
     })
 
 


### PR DESCRIPTION
If get_json fails, an exception can be thrown and cancel the callback
entirely.

## Changeset

* Silenced JSON parsing errors in Flask integration to ensure request data is appended successfully

## Tests

* Tested manually by constructing requests with errors and broken data with `Content-Type: application/json`
* Added an automated test in a similar setup

## Review

What this changeset needs most is thoroughness - is it possible to create the same situation in another way? I tried a few other options like manipulating the `request` object though all seem to be guarded.
