### PR TITLE
ci: Work around py33 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,13 @@ matrix:
     env: TOXENV=py27-django111-migrate1-django1
 
   - python: 3.3
-    env: TOXENV=py33-test
-    install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
-  - python: 3.3
-    env: TOXENV=py33-requests-test
-    install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
-  - python: 3.3
-    env: TOXENV=py33-wsgi
-    install: travis_retry pip install coveralls 'virtualenv<16' 'tox<3'
+    install:
+    - travis_retry pip install coveralls 'virtualenv<16'
+    - virtualenv venv --no-wheel --no-download
+    - source venv/bin/activate
+    - pip install -r dev_requirements.txt
+    - pip install webtest # For WSGI
+    script: nosetests --tests=tests integrations/test_wsgi.py -sv --with-coverage --cover-package=bugsnag
 
   - python: 3.4
     env: TOXENV=py34-test


### PR DESCRIPTION
* Can't install latest wheel on 3.3, which is tricky to work around with tox without changing the global deps for every build
* No need for non-requests build as its being pulled in implicitly anyway