### PR TITLE
feat(notification): add Python runtime version information to device data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Changelog
   due to over-aggressive object id matching
   [#181](https://github.com/bugsnag/bugsnag-python/pull/181)
 
+### Enhancements
+
+* Add Python version string to report and session payloads (device.runtimeVersions)
+  [#179](https://github.com/bugsnag/bugsnag-python/pull/179)
+
 ## 3.5.2 (2019-03-15)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Bugsnag exception reporter for Python
-[![Build status](https://travis-ci.org/bugsnag/bugsnag-python.svg?branch=master)](https://travis-ci.org/bugsnag/bugsnag-python)
+[![Build status](https://img.shields.io/travis/bugsnag/bugsnag-python/master.svg?style=flat-square)](https://travis-ci.com/bugsnag/bugsnag-python)
 [![Documentation](https://img.shields.io/badge/documentation-latest-blue.svg)](https://docs.bugsnag.com/platforms/python/)
 
 The Bugsnag exception reporter for Python automatically detects and reports

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import platform
 import socket
 try:
     import sysconfig
@@ -91,6 +92,8 @@ class Configuration(_BaseConfiguration):
             self.hostname = socket.gethostname()
         else:
             self.hostname = None
+
+        self.runtime_versions = {"python": str(platform.python_version())}
 
     def should_notify(self):  # type: () -> bool
         return self.notify_release_stages is None or \

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -93,7 +93,7 @@ class Configuration(_BaseConfiguration):
         else:
             self.hostname = None
 
-        self.runtime_versions = {"python": str(platform.python_version())}
+        self.runtime_versions = {"python": platform.python_version()}
 
     def should_notify(self):  # type: () -> bool
         return self.notify_release_stages is None or \

--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -51,6 +51,7 @@ class Notification(object):
         self.release_stage = get_config("release_stage")
         self.app_version = get_config("app_version")
         self.hostname = get_config("hostname")
+        self.runtime_versions = get_config("runtime_versions")
         self.send_code = get_config("send_code")
 
         self.context = options.pop("context", None)
@@ -242,7 +243,8 @@ class Notification(object):
                 "metaData": FilterDict(self.meta_data),
                 "user": FilterDict(self.user),
                 "device": FilterDict({
-                    "hostname": self.hostname
+                    "hostname": self.hostname,
+                    "runtimeVersions": self.runtime_versions
                 }),
                 "projectRoot": self.config.get("project_root"),
                 "libRoot": self.config.get("lib_root"),

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -107,6 +107,7 @@ class SessionTracker(object):
             },
             'device': FilterDict({
                 'hostname': self.config.get('hostname'),
+                'runtimeVersions': self.config.get('runtime_versions')
             }),
             'app': {
                 'releaseStage': self.config.get('release_stage'),

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -141,3 +141,18 @@ class TestNotification(unittest.TestCase):
         exception = payload['events'][0]['exceptions'][0]
         first_traceback = exception['stacktrace'][0]
         self.assertEqual(first_traceback['file'], 'test_notification.py')
+
+    def test_device_data(self):
+        """
+            It should include device data
+        """
+        config = Configuration()
+        config.hostname = 'test_host_name'
+        config.runtime_versions = {'python': '9.9.9'}
+        notification = Notification(Exception("oops"), config, {})
+
+        payload = json.loads(notification._payload())
+
+        device = payload['events'][0]['device']
+        self.assertEqual('test_host_name', device['hostname'])
+        self.assertEqual('9.9.9', device['runtimeVersions']['python'])

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -1,3 +1,4 @@
+import platform
 import time
 
 from bugsnag import Client
@@ -94,6 +95,9 @@ class TestConfiguration(IntegrationTest):
         self.assertTrue('hostname' in device)
         self.assertEqual(device['hostname'],
                          client.configuration.get('hostname'))
+        self.assertTrue('runtimeVersions' in device)
+        self.assertEqual(device['runtimeVersions']['python'],
+                         platform.python_version())
 
     def test_session_middleware_attaches_session_to_notification(self):
         client = Client(


### PR DESCRIPTION
adds version string (from platform.python_version()) to device.runtimeVersions.python payload

## Goal

Augments reporting with the version of Python in use when an event occurred in case of issues in a specific Python version.

## Design

Added data to device.runtimeVersions.python as per other notifiers.

## Changeset

### Changed

* Added new field in configuration, set to `platform.python_version()` on init
* `notification` and `sessiontracker` use this data in their payloads

## Tests

* Added unit tests for the presence of the data
* Confirmed data is there in example project

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
