### PR TITLE
fix(utils): Make nested dict uniqueness checks work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Ensure nested dicts are not truncated prematurely when checking for recursion
+  due to over-aggressive object id matching
+  [#181](https://github.com/bugsnag/bugsnag-python/pull/181)
+
 ## 3.5.2 (2019-03-15)
 
 ### Fixes

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -66,7 +66,8 @@ class SanitizingJSONEncoder(JSONEncoder):
                 if is_string and any(f in key.lower() for f in self.filters):
                     clean_dict[key] = self.filtered_value
                 else:
-                    clean_dict[key] = self.filter_string_values(value, ignored, seen)
+                    clean_dict[key] = self.filter_string_values(
+                        value, ignored, seen)
 
             return clean_dict
 
@@ -96,7 +97,7 @@ class SanitizingJSONEncoder(JSONEncoder):
             ignored = set()
 
         # Keep track of nested objects to avoid having references garbage
-        # collected (which would cause id reuse and false positive recursion
+        # collected (which would cause id reuse and false positive recursion)
         if seen is None:
             seen = []
 

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -38,12 +38,17 @@ class SanitizingJSONEncoder(JSONEncoder):
         else:
             return payload
 
-    def filter_string_values(self, obj, ignored=None):
+    def filter_string_values(self, obj, ignored=None, seen=None):
         """
         Remove any value from the dictionary which match the key filters
         """
         if not ignored:
             ignored = set()
+
+        # Keep track of nested objects to avoid having references garbage
+        # collected (which would cause id reuse and false positive recursion
+        if seen is None:
+            seen = []
 
         if type(ignored) is list:
             ignored = set(ignored)
@@ -53,6 +58,7 @@ class SanitizingJSONEncoder(JSONEncoder):
 
         if isinstance(obj, dict):
             ignored.add(id(obj))
+            seen.append(obj)
 
             clean_dict = {}
             for key, value in six.iteritems(obj):
@@ -60,7 +66,7 @@ class SanitizingJSONEncoder(JSONEncoder):
                 if is_string and any(f in key.lower() for f in self.filters):
                     clean_dict[key] = self.filtered_value
                 else:
-                    clean_dict[key] = self.filter_string_values(value, ignored)
+                    clean_dict[key] = self.filter_string_values(value, ignored, seen)
 
             return clean_dict
 
@@ -81,13 +87,18 @@ class SanitizingJSONEncoder(JSONEncoder):
             bugsnag.logger.exception('Could not add object to payload')
             return self.unencodeable_value
 
-    def _sanitize(self, obj, trim_strings, ignored=None):
+    def _sanitize(self, obj, trim_strings, ignored=None, seen=None):
         """
         Replace recursive values and trim strings longer than
         MAX_STRING_LENGTH
         """
         if not ignored:
             ignored = set()
+
+        # Keep track of nested objects to avoid having references garbage
+        # collected (which would cause id reuse and false positive recursion
+        if seen is None:
+            seen = []
 
         if type(ignored) is list:
             ignored = set(ignored)
@@ -96,12 +107,15 @@ class SanitizingJSONEncoder(JSONEncoder):
             return self.recursive_value
         elif isinstance(obj, dict):
             ignored.add(id(obj))
-            return self._sanitize_dict(obj, trim_strings, ignored)
+            seen.append(obj)
+            return self._sanitize_dict(obj, trim_strings, ignored, seen)
         elif isinstance(obj, (set, tuple, list)):
             ignored.add(id(obj))
+            seen.append(obj)
             items = []
             for value in obj:
-                items.append(self._sanitize(value, trim_strings, ignored))
+                items.append(
+                        self._sanitize(value, trim_strings, ignored, seen))
             return items
         elif trim_strings and isinstance(obj, six.string_types):
             return obj[:MAX_STRING_LENGTH]
@@ -123,7 +137,7 @@ class SanitizingJSONEncoder(JSONEncoder):
                     'Could not add sanitize key for dictionary, '
                     'dropping value.')
 
-    def _sanitize_dict(self, obj, trim_strings, ignored):
+    def _sanitize_dict(self, obj, trim_strings, ignored, seen):
         """
         Trim individual values in an object, applying filtering if the object
         is a FilterDict
@@ -134,7 +148,7 @@ class SanitizingJSONEncoder(JSONEncoder):
         clean_dict = {}
         for key, value in six.iteritems(obj):
 
-            clean_value = self._sanitize(value, trim_strings, ignored)
+            clean_value = self._sanitize(value, trim_strings, ignored, seen)
 
             self._sanitize_dict_key_value(clean_dict, key, clean_value)
 


### PR DESCRIPTION
## Goal

Fix potentially over-aggressive recursion checking where references are discarded between id() checks.

## Design

References to nested dicts/field are recycled when going out of scope, which is immediately since the references are not retained for the lifetime of the sanitization pass. This change keeps references to seen nested objects in addition to ignored objects to ensure id() returns unique references.

Related reports on the Python issue tracker which explain the issue:
* https://bugs.python.org/issue36156
* https://bugs.python.org/issue33685

```
>>> help(id)

Help on built-in function id in module __builtin__:

id(...)
    id(object) -> integer

    Return the identity of an object.  This is guaranteed to be unique
    among simultaneously existing objects.  (Hint: it's the object's 
    memory address.)
```


## Changeset

* Update `_sanitize` and `_sanitize_dict` encoder methods to keep seen references

## Tests

* Added a new test case which checks for recursion in a large enough dict
* Tested against `tox` config and underlying `nosetests` directly

## Linked issues

Related to #179 
Closes #180

## Review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
