### PR TITLE
Run Flask tests on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,9 @@ matrix:
   - python: 3.3
     install:
     - travis_retry pip install coveralls 'virtualenv<16'
-    - virtualenv venv --no-wheel --no-download
-    - source venv/bin/activate
     - pip install 'tox<3' 'pluggy<0.6.0' nose-cov webtest
-    script: nosetests --tests=tests integrations/test_wsgi.py -sv --with-coverage --cover-package=bugsnag
+    script:
+      - TOXENV=py33-test,py33-requests,py33-wsgi,py33-flask tox
     dist: trusty
 
   - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,21 +22,22 @@ matrix:
     dist: trusty
 
   - python: 3.4
-    env: TOXENV=py34-test,py34-requests,py34-wsgi
+    env: TOXENV=py34-test,py34-requests,py34-wsgi,py34-flask
 
   - python: 3.5
-    env: TOXENV=py35-test,py35-requests,py35-wsgi,py35-django18-migrate1-django1,py35-django19-migrate1-django1,py35-django110-migrate1-django1,py35-django111-migrate1-django1
+    env: TOXENV=py35-test,py35-requests,py35-wsgi,py35-flask,py35-django18-migrate1-django1,py35-django19-migrate1-django1,py35-django110-migrate1-django1,py35-django111-migrate1-django1
 
   - python: 3.6
-    env: TOXENV=py36-test,py36-requests,py36-wsgi,py36-django18-migrate1-django1,py36-django19-migrate1-django1,py36-django110-migrate1-django1,py36-django111-migrate1-django1,py36-django20-migrate1-django1,py36-django21-migrate1-django1
+    env: TOXENV=py36-test,py36-requests,py36-wsgi,py36-flask,py36-django18-migrate1-django1,py36-django19-migrate1-django1,py36-django110-migrate1-django1,py36-django111-migrate1-django1,py36-django20-migrate1-django1,py36-django21-migrate1-django1
 
   - python: 3.7
-    env: TOXENV=py37-test,py37-requests,py37-wsgi,py37-django18-migrate1-django1,py37-django19-migrate1-django1,py37-django110-migrate1-django1,py37-django111-migrate1-django1,py37-django20-migrate1-django1,py37-django21-migrate1-django1
+    env: TOXENV=py37-test,py37-requests,py37-wsgi,py37-flask,py37-django18-migrate1-django1,py37-django19-migrate1-django1,py37-django110-migrate1-django1,py37-django111-migrate1-django1,py37-django20-migrate1-django1,py37-django21-migrate1-django1
 
   - python: 3.8
-    env: TOXENV=py38-test,py38-requests,py38-wsgi,py38-django18-migrate1-django1,py38-django111-migrate1-django1,py38-django20-migrate1-django1,py38-django21-migrate1-django1,py38-lint
+    env: TOXENV=py38-test,py38-requests,py38-wsgi,py38-flask,py38-django18-migrate1-django1,py38-django111-migrate1-django1,py38-django20-migrate1-django1,py38-django21-migrate1-django1,py38-lint
 
-install: travis_retry pip install coveralls tox
+install:
+  - travis_retry pip install coveralls tox
 
 script:
   - tox
@@ -49,6 +50,7 @@ before_deploy:
   - sudo make deb-bootstrap
   - make deb-build
   - mv deb_dist/python-bugsnag_*.deb deb_dist/python-bugsnag.deb
+
 deploy:
   provider: releases
   api_key:

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     py{26,27,33,34,35,36,37,38}-test,
     py{26,27,33,34,35,36,37,38}-requests,
-    py{26,27}-flask,
+    py{26,27,33,34,35,36,37,38}-flask,
     py{26,27,33,34,35,36,37,38}-wsgi,
     py{35,36,37}-django{18,19,110,111,20,21}-migrate1-django1,
     py27-django{18,19,110,111}-migrate1-django1,


### PR DESCRIPTION
Currently we're only running the Flask tests on Python 2, but they pass as-is on all our supported Python 3 versions so we can enable them everywhere

We also weren't running all of the test suites on Python 3.3. I managed to get this working locally (thanks to [this workaround](https://github.com/pyenv/pyenv/issues/1579#issuecomment-619594433)) and the same suites that we run on Python 3.4 pass, so I've enabled those too