### PR TITLE
Enable session tracking by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Enable session tracking by default
+
 ## 3.6.1 (2020-06-04)
 
 ### Fixes

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -77,7 +77,7 @@ class Configuration(_BaseConfiguration):
         ]
         self.endpoint = "https://notify.bugsnag.com"
         self.session_endpoint = "https://sessions.bugsnag.com"
-        self.auto_capture_sessions = False
+        self.auto_capture_sessions = True
         self.traceback_exclude_modules = []
 
         self.middleware = MiddlewareStack()

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -15,7 +15,8 @@ import warnings
 from bugsnag.sessiontracker import SessionMiddleware
 from bugsnag.middleware import DefaultMiddleware, MiddlewareStack
 from bugsnag.utils import fully_qualified_class_name, ThreadLocals
-from bugsnag.delivery import create_default_delivery
+from bugsnag.delivery import (create_default_delivery, DEFAULT_ENDPOINT,
+                              DEFAULT_SESSIONS_ENDPOINT)
 
 
 class _BaseConfiguration(object):
@@ -75,8 +76,8 @@ class Configuration(_BaseConfiguration):
             "django.http.Http404",
             "django.http.response.Http404",
         ]
-        self.endpoint = "https://notify.bugsnag.com"
-        self.session_endpoint = "https://sessions.bugsnag.com"
+        self.endpoint = DEFAULT_ENDPOINT
+        self.session_endpoint = DEFAULT_SESSIONS_ENDPOINT
         self.auto_capture_sessions = True
         self.traceback_exclude_modules = []
 

--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -25,6 +25,9 @@ try:
 except ImportError:
     requests = None
 
+DEFAULT_ENDPOINT = 'https://notify.bugsnag.com'
+DEFAULT_SESSIONS_ENDPOINT = 'https://sessions.bugsnag.com'
+
 
 def create_default_delivery():
     if requests is not None:

--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -1,6 +1,7 @@
 from threading import Thread
 import sys
 import json
+import warnings
 
 from time import strftime, gmtime
 
@@ -49,6 +50,8 @@ class Delivery(object):
     """
     Mechanism for sending a request to Bugsnag
     """
+    def __init__(self):
+        self.sent_session_warning = False
 
     def deliver(self, config, payload):
         """
@@ -60,17 +63,21 @@ class Delivery(object):
         """
         Sends sessions to Bugsnag
         """
-        pass
+        if (config.endpoint != DEFAULT_ENDPOINT and config.session_endpoint ==
+                DEFAULT_SESSIONS_ENDPOINT):
+            if not self.sent_session_warning:
+                warnings.warn('The session endpoint has not been configured. '
+                              'No sessions will be sent to Bugsnag.')
+                self.sent_session_warning = True
+        else:
+            options = {
+                'endpoint': config.session_endpoint,
+                'success': 202,
+            }
+            self.deliver(config, payload, options)
 
 
 class UrllibDelivery(Delivery):
-
-    def deliver_sessions(self, config, payload):
-        options = {
-            'endpoint': config.session_endpoint,
-            'success': 202,
-        }
-        self.deliver(config, payload, options)
 
     def deliver(self, config, payload, options={}):
 
@@ -111,13 +118,6 @@ class UrllibDelivery(Delivery):
 
 
 class RequestsDelivery(Delivery):
-
-    def deliver_sessions(self, config, payload):
-        options = {
-            'endpoint': config.session_endpoint,
-            'success': 202,
-        }
-        self.deliver(config, payload, options)
 
     def deliver(self, config, payload, options={}):
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -97,7 +97,7 @@ class TestConfiguration(unittest.TestCase):
 
     def test_session_tracking_defaults(self):
         c = Configuration()
-        self.assertEqual(c.auto_capture_sessions, False)
+        self.assertTrue(c.auto_capture_sessions)
         self.assertEqual(c.session_endpoint, "https://sessions.bugsnag.com")
 
     def test_default_middleware_location(self):


### PR DESCRIPTION
Turns on session tracking with the following changes:

* `Configuration.auto_capture_sessions` is now `True` by default
* Added constants for default endpoint values
* Attempting to send a session when `Configuration.endpoint` is customized but `Configuration.sessions_endpoint` is not issues a single warning
