### PR TITLE
ci: Enforce optional checking

### DIFF
--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -23,7 +23,7 @@ try:
 
     import requests
 except ImportError:
-    requests = None
+    requests = None  # type: ignore
 
 
 def create_default_delivery():

--- a/tox.ini
+++ b/tox.ini
@@ -47,4 +47,4 @@ commands =
     migrate1: python tests/fixtures/django1/manage.py migrate
     django1: nosetests integrations/test_django_1.py -sv --with-coverage --cover-package=bugsnag
     lint: {toxinidir}/scripts/lint.sh
-    lint: mypy -2 --ignore-missing-imports --no-strict-optional bugsnag
+    lint: mypy -2 --ignore-missing-imports bugsnag


### PR DESCRIPTION
Enforces optional checking for type hints, ignoring one special case where the type is `Optional[Module]` to ensure a partial import isn't left around in the event of failure.