### PR TITLE
fix: Handle content types with suffixes

### DIFF
--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
     from django.urls import resolve
 
 import bugsnag
+from bugsnag.utils import is_json_content_type
 import json
 
 
@@ -55,11 +56,10 @@ def add_django_request_to_notification(notification):
         'url': request.build_absolute_uri(),
     }
     try:
-        aj = 'application/json'
-        if request.META.get('CONTENT_TYPE', '').lower().startswith(aj):
-            if request_tab["method"] == "POST":
-                body = request.body.decode('utf-8', 'replace')
-                request_tab["POST"] = json.loads(body)
+        is_json = is_json_content_type(request.META.get('CONTENT_TYPE', ''))
+        if is_json and request_tab["method"] == "POST":
+            body = request.body.decode('utf-8', 'replace')
+            request_tab["POST"] = json.loads(body)
     except Exception:
         pass
 

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -2,6 +2,7 @@ import tornado
 from tornado.web import RequestHandler
 from tornado.web import HTTPError
 from six.moves import urllib
+from bugsnag.utils import is_json_content_type
 import bugsnag
 import json
 
@@ -22,10 +23,9 @@ class BugsnagRequestHandler(RequestHandler):
             if (len(self.request.body) > 0):
                 headers = self.request.headers
                 body = self.request.body.decode('utf-8', 'replace')
-                aj = 'application/json'
-                if headers.get('Content-Type', '').lower().startswith(aj):
-                    if request_tab["method"] == "POST":
-                        request_tab["POST"] = json.loads(body)
+                is_json = is_json_content_type(headers.get('Content-Type', ''))
+                if is_json and request_tab["method"] == "POST":
+                    request_tab["POST"] = json.loads(body)
                 else:
                     request_tab["POST"] = self.request.body_arguments
         except Exception:

--- a/tests/integrations/test_django_1.py
+++ b/tests/integrations/test_django_1.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import os
 import re
@@ -71,6 +72,31 @@ class DjangoMiddlewareTests(IntegrationTest):
             'url': 'http://testserver/notify/',
             'path': '/notify/',
             'POST': {'test': 'post'},
+            'encoding': None,
+            'GET': {}
+        })
+
+    def test_notify_json_subtype_post(self):
+        body = {
+            '_links': {
+                'self': {
+                    'href': 'http://example.com/api/resource/a'
+                }
+            },
+            'id': 'res-a',
+            'name': 'Resource A'
+        }
+        response = self.client.post('/notify/', json.dumps(body),
+                                    content_type='application/hal+json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(self.server.received), 1)
+        payload = self.server.received[0]['json_body']
+        event = payload['events'][0]
+        self.assertEqual(event['metaData']['request'], {
+            'method': 'POST',
+            'url': 'http://testserver/notify/',
+            'path': '/notify/',
+            'POST': body,
             'encoding': None,
             'GET': {}
         })

--- a/tests/integrations/test_tornado.py
+++ b/tests/integrations/test_tornado.py
@@ -85,6 +85,35 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
             'GET': {}
         })
 
+    def test_notify_json_subtype_post(self):
+        body = {
+            '$id': 'https://example.com/person.schema.json',
+            '$schema': 'http://json-schema.org/draft-07/schema#',
+            'title': 'Dog',
+            'type': 'object',
+            "properties": {
+                'sound': {
+                    'type': 'str',
+                    'description': 'The sound the dog makes'
+                }
+            }
+        }
+        headers = {'Content-Type': 'application/schema+json'}
+        response = self.fetch('/notify', method="POST", body=json.dumps(body),
+                              headers=headers)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(self.server.received), 1)
+
+        payload = self.server.received[0]['json_body']
+        event = payload['events'][0]
+        self.assertEqual(event['metaData']['request'], {
+            'method': 'POST',
+            'url': 'http://127.0.0.1:{}/notify'.format(self.get_http_port()),
+            'path': '/notify',
+            'POST': body,
+            'GET': {}
+        })
+
     def test_unhandled(self):
         response = self.fetch('/crash', method="GET")
         self.assertEqual(response.code, 500)


### PR DESCRIPTION
Expands handling for content bodies do not contain literally `application/json` but instead have a `json` suffix according to [RFC 6838](https://tools.ietf.org/html/rfc6838#section-4.2.8). Extends #192.

Some examples I encountered:

* [`application/problem+json`](https://tools.ietf.org/html/rfc7807#section-6.1)
* [`application/schema+json`](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.13.1)
* [`application/hal+json`](https://tools.ietf.org/html/draft-kelly-json-hal-08#section-3)

## Changeset

* [New] `bugsnag.utils.is_json_content_type(str)` - validates that a string is a content type value which represents JSON
* [New] `bugsnag.utils.parse_content_type(str)` - Creates a tuple with four values representing the type, subtype, suffix, and parameters from a string value.

## Tests

* Added unit tests for the new utils functions
* Added additional tests to Django, Tornado, and Flask integrations
