### PR TITLE
[PLAT-861] Use contextvars where available to store request locals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     env: TOXENV=py37-test,py37-requests,py37-asgi,py37-wsgi,py37-flask,py37-django18-migrate1-django1,py37-django19-migrate1-django1,py37-django110-migrate1-django1,py37-django111-migrate1-django1,py37-django20-migrate1-django1,py37-django21-migrate1-django1,py37-tornado
 
   - python: 3.8
-    env: TOXENV=py38-test,py38-requests,py38-asgi,py38-wsgi,py38-flask,py38-django18-migrate1-django1,py38-django111-migrate1-django1,py38-django20-migrate1-django1,py38-django21-migrate1-django1,py38-tornado,py38-lint
+    env: TOXENV=py38-test,py38-asynctest,py38-requests,py38-asgi,py38-wsgi,py38-flask,py38-django18-migrate1-django1,py38-django111-migrate1-django1,py38-django20-migrate1-django1,py38-django21-migrate1-django1,py38-tornado,py38-lint
 
 install:
   - travis_retry pip install coveralls tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
   [documentation](https://docs.bugsnag.com/platforms/python/asgi/) for more
   information about getting started.
 
+### Fixes
+
+* Fix diagnostic data being swapped between contexts and attached to an
+  unrelated Bugsnag event when using `asyncio` features
+  [#199](https://github.com/bugsnag/bugsnag-python/pull/199)
+
 ## 3.6.1 (2020-06-04)
 
 ### Fixes

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -265,3 +265,21 @@ class ThreadLocals(object):
 
     def del_item(self, key):
         return delattr(ThreadLocals.LOCALS, key)
+
+
+class ThreadContextVar(object):
+    """
+    A wrapper around ThreadLocals to mimic the API of contextvars
+    """
+    def __init__(self, name, default=None):
+        self.name = name
+        ThreadLocals.get_instance().set_item(name, default)
+
+    def get(self):
+        local = ThreadLocals.get_instance()
+        if local.has_item(self.name):
+            return local.get_item(self.name)
+        raise LookupError("No value for '{}'".format(self.name))
+
+    def set(self, new_value):
+        ThreadLocals.get_instance().set_item(self.name, new_value)

--- a/tests/async_utils.py
+++ b/tests/async_utils.py
@@ -1,0 +1,127 @@
+import asyncio
+import json
+from typing import Dict, Any
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+from threading import Thread
+from unittest import IsolatedAsyncioTestCase
+
+import bugsnag
+
+
+class AsyncIntegrationTest(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.server = FakeBugsnag()
+        bugsnag.configure(asynchronous=True,
+                          endpoint=self.server.events_url,
+                          session_endpoint=self.server.sessions_url,
+                          api_key='ffffffffffffffffff')
+
+    async def asyncTearDown(self):
+        self.server.shutdown()
+
+    async def last_event_request(self):
+        """
+        Waits for a request to be received by the event server, timing out
+        after a few seconds
+        """
+        async def poll():
+            while len(self.server.events_received) == 0:
+                await asyncio.sleep(0.1)
+            return self.server.events_received[0]
+        try:
+            return await asyncio.wait_for(poll(), timeout=1.0)
+        except asyncio.TimeoutError:
+            assert 0, 'Timeout while waiting for a request'
+
+
+class ASGITestClient:
+    def __init__(self, app):
+        self.app = app
+
+    async def invoke(self, scope):
+        received = None
+
+        async def send(message: Dict[str, Any]):
+            nonlocal received
+            received = message
+
+        async def receive():
+            pass
+
+        await self.app(scope, receive, send)
+        return received
+
+    async def request(self, path: str, query: str = '', method: str = 'GET'):
+        return await self.invoke({
+            'method': method,
+            'path': path,
+            'query_string': query.encode(),
+            'scheme': 'http',
+            'type': 'http',
+            'server': ['testserver', 80],
+            'client': ['testclient', 8080],
+            'headers': [
+                [b'user-agent', b'testclient'],
+            ],
+        })
+
+    async def websocket_request(self, path: str):
+        return await self.invoke({
+            'path': path,
+            'scheme': 'ws',
+            'type': 'websocket',
+            'server': ['testserver', 80],
+            'client': ['testclient', 8080],
+            'headers': [
+                [b'user-agent', b'testclient'],
+                [b'sec-websocket-version', b'13'],
+            ],
+        })
+
+
+class FakeBugsnag:
+    def __init__(self):
+        self.events_received = []
+        self.sessions_received = []
+        server = self
+
+        class Handler(SimpleHTTPRequestHandler):
+            def do_POST(self):
+                length = int(self.headers['Content-Length'])
+                raw_body = self.rfile.read(length).decode('utf-8')
+                json_body = json.loads(raw_body)
+                if self.path == '/sessions':
+                    server.sessions_received.append(json_body)
+                    self.send_response(202)
+                elif self.path == '/events':
+                    server.events_received.append(json_body)
+                    self.send_response(202)
+                else:
+                    assert 0, ('unknown endpoint requested: {}' % self.path)
+                self.end_headers()
+                return ()
+
+            def log_request(self, *args):
+                pass
+
+        self.server = HTTPServer(('localhost', 0), Handler)
+        self.thread = Thread(target=self.server.serve_forever, args=(0.1,))
+        self.thread.daemon = True
+        self.thread.start()
+
+    @property
+    def address(self):
+        return '{0}:{1}'.format(*self.server.server_address)
+
+    @property
+    def events_url(self):
+        return 'http://%s/events' % self.address
+
+    @property
+    def sessions_url(self):
+        return 'http://%s/sessions' % self.address
+
+    def shutdown(self):
+        self.server.shutdown()
+        self.thread.join()
+        self.server.server_close()

--- a/tests/integrations/test_async_asgi.py
+++ b/tests/integrations/test_async_asgi.py
@@ -1,0 +1,160 @@
+import bugsnag
+from bugsnag.asgi import BugsnagMiddleware
+from tests.async_utils import AsyncIntegrationTest, ASGITestClient
+
+
+class CustomException(Exception):
+    pass
+
+
+class TestASGIMiddleware(AsyncIntegrationTest):
+    async def test_normal_http_operation(self):
+        async def app(scope, recv, send):
+            await send({
+                'type': 'http.request',
+                'body': b'hi hi hi',
+            })
+
+        app = ASGITestClient(BugsnagMiddleware(app))
+        resp = await app.request('/')
+        assert resp is not None
+        assert b'hi hi hi' == resp['body']
+        assert len(self.server.events_received) == 0
+
+    async def test_routing_crash(self):
+        async def other_func():
+            raise CustomException('fell winds!')
+
+        async def app(scope, recv, send):
+            await other_func()
+            await send({
+                'type': 'http.request',
+                'body': b'pineapple',
+            })
+
+        app = ASGITestClient(BugsnagMiddleware(app))
+
+        try:
+            await app.request('/')
+            assert 0, 'An exception should have been raised'
+        except CustomException:
+            pass
+
+        payload = await self.last_event_request()
+
+        request = payload['events'][0]['metaData']['request']
+        self.assertEqual('/', request['path'])
+        self.assertEqual('GET', request['httpMethod'])
+        self.assertEqual('http', request['type'])
+        self.assertEqual('http://testserver/', request['url'])
+
+        exception = payload['events'][0]['exceptions'][0]
+        self.assertEqual('test_async_asgi.CustomException',
+                         exception['errorClass'])
+        self.assertEqual('fell winds!', exception['message'])
+        self.assertEqual('other_func', exception['stacktrace'][0]['method'])
+        self.assertEqual('app', exception['stacktrace'][1]['method'])
+
+    async def test_boot_crash(self):
+        async def app(scope, recv, send):
+            raise CustomException('forgot the map')
+
+        app = ASGITestClient(BugsnagMiddleware(app))
+
+        try:
+            await app.request('/')
+            assert 0, 'An exception should have been raised'
+        except CustomException:
+            pass
+
+        payload = await self.last_event_request()
+        request = payload['events'][0]['metaData']['request']
+        self.assertEqual('/', request['path'])
+        self.assertEqual('GET', request['httpMethod'])
+        self.assertEqual('http', request['type'])
+        self.assertEqual('http://testserver/', request['url'])
+        self.assertEqual('testclient', request['clientIp'])
+        self.assertEqual('testclient', request['headers']['user-agent'])
+
+        exception = payload['events'][0]['exceptions'][0]
+        self.assertEqual('test_async_asgi.CustomException',
+                         exception['errorClass'])
+        self.assertEqual('forgot the map', exception['message'])
+
+    async def test_custom_metadata(self):
+        async def next_func():
+            bugsnag.configure_request(meta_data={'wave': {'size': '35b'}})
+            raise CustomException('fell winds!')
+
+        async def app(scope, recv, send):
+            await next_func()
+            await send({})
+
+        app = ASGITestClient(BugsnagMiddleware(app))
+
+        try:
+            await app.request('/')
+            assert 0, 'An exception should have been raised'
+        except CustomException:
+            pass
+
+        payload = await self.last_event_request()
+        metadata = payload['events'][0]['metaData']
+        request = metadata['request']
+        self.assertEqual('/', request['path'])
+        self.assertEqual('GET', request['httpMethod'])
+        self.assertEqual('http', request['type'])
+        self.assertEqual('http://testserver/', request['url'])
+        self.assertEqual('35b', metadata['wave']['size'])
+
+        exception = payload['events'][0]['exceptions'][0]
+        self.assertEqual('test_async_asgi.CustomException',
+                         exception['errorClass'])
+        self.assertEqual('fell winds!', exception['message'])
+        self.assertEqual('next_func', exception['stacktrace'][0]['method'])
+        self.assertEqual('app', exception['stacktrace'][1]['method'])
+
+    async def test_websocket_crash(self):
+        async def app(scope, receive, send):
+            await send({'type': 'websocket.accept'})
+            raise CustomException('invalid inputs')
+            await send({'type': 'websocket.close'})
+
+        app = ASGITestClient(BugsnagMiddleware(app))
+
+        try:
+            await app.websocket_request('/')
+            assert 0, 'An exception should have been raised'
+        except CustomException:
+            pass
+
+        payload = await self.last_event_request()
+        metadata = payload['events'][0]['metaData']
+        request = metadata['request']
+        self.assertEqual('/', request['path'])
+        self.assertNotIn('httpMethod', request)
+        self.assertEqual('websocket', request['type'])
+        self.assertEqual('ws://testserver/', request['url'])
+        self.assertEqual('13', request['headers']['sec-websocket-version'])
+
+        exception = payload['events'][0]['exceptions'][0]
+        self.assertEqual('test_async_asgi.CustomException',
+                         exception['errorClass'])
+        self.assertEqual('invalid inputs', exception['message'])
+        self.assertEqual('app', exception['stacktrace'][0]['method'])
+
+    async def test_url_components(self):
+        async def app(scope, recv, send):
+            raise CustomException('forgot the map')
+
+        app = ASGITestClient(BugsnagMiddleware(app))
+
+        try:
+            await app.request('/path', 'page=6')
+            assert 0, 'An exception should have been raised'
+        except CustomException:
+            pass
+
+        payload = await self.last_event_request()
+        request = payload['events'][0]['metaData']['request']
+        self.assertEqual('http://testserver/path?page=6', request['url'])

--- a/tests/integrations/test_async_request.py
+++ b/tests/integrations/test_async_request.py
@@ -1,0 +1,35 @@
+import asyncio
+from unittest import IsolatedAsyncioTestCase
+
+import bugsnag
+from bugsnag.configuration import RequestConfiguration
+
+
+class AsyncRequestTest(IsolatedAsyncioTestCase):
+    """
+    Test the RequestConfiguration plumbing, which underpins the integrations'
+    handling of request-specific data in async contexts
+    """
+    async def test_async_task_metadata(self):
+        bugsnag.configure_request(wins={'total': 3, 'last': 2})
+
+        async def coro():
+            bugsnag.configure_request(wins={'total': 1, 'last': 1})
+
+        asyncio.ensure_future(coro())
+        data = RequestConfiguration.get_instance().wins
+
+        assert data['total'] == 3
+        assert data['last'] == 2
+
+    async def test_async_context_storage(self):
+        async def slow_crash():
+            bugsnag.configure_request(local_data={'apples': 1})
+            await asyncio.sleep(1)
+            data = RequestConfiguration.get_instance().local_data
+            assert data['apples'] == 1
+
+        async def other_func():
+            bugsnag.configure_request(local_data={'apples': 4})
+
+        await asyncio.gather(slow_crash(), other_func())

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -5,7 +5,7 @@ from bugsnag import Client
 from bugsnag.notification import Notification
 from bugsnag.configuration import Configuration
 from bugsnag.sessiontracker import SessionTracker
-from bugsnag.utils import ThreadLocals, package_version
+from bugsnag.utils import package_version
 from tests.utils import IntegrationTest
 
 
@@ -22,30 +22,6 @@ class TestConfiguration(IntegrationTest):
         self.assertEqual(len(tracker.session_counts), 1)
         for key, value in tracker.session_counts.items():
             self.assertEqual(value, 1)
-
-    def test_session_tracker_stores_session_in_threadlocals(self):
-        locs = ThreadLocals.get_instance()
-        tracker = SessionTracker(self.config)
-        tracker.auto_sessions = True
-        tracker.start_session()
-        session = locs.get_item('bugsnag-session')
-        self.assertTrue('id' in session)
-        self.assertTrue('startedAt' in session)
-        self.assertTrue('events' in session)
-        self.assertTrue('handled' in session['events'])
-        self.assertTrue('unhandled' in session['events'])
-        self.assertEqual(session['events']['handled'], 0)
-        self.assertEqual(session['events']['unhandled'], 0)
-
-    def test_session_tracker_sessions_are_unique(self):
-        tracker = SessionTracker(self.config)
-        tracker.auto_sessions = True
-        locs = ThreadLocals.get_instance()
-        tracker.start_session()
-        session_one = locs.get_item('bugsnag-session').copy()
-        tracker.start_session()
-        session_two = locs.get_item('bugsnag-session').copy()
-        self.assertNotEqual(session_one['id'], session_two['id'])
 
     def test_session_tracker_send_sessions_sends_sessions(self):
         client = Client(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,10 +7,14 @@ import re
 
 from six import u, PY3 as is_py3
 from bugsnag.utils import (SanitizingJSONEncoder, FilterDict, ThreadLocals,
-                           is_json_content_type, parse_content_type)
+                           is_json_content_type, parse_content_type,
+                           ThreadContextVar)
 
 
 class TestUtils(unittest.TestCase):
+    def tearDown(self):
+        super(TestUtils, self).tearDown()
+        ThreadLocals.LOCALS = None
 
     def test_encode_filters(self):
         data = FilterDict({"credit_card": "123213213123", "password": "456",
@@ -97,6 +101,19 @@ class TestUtils(unittest.TestCase):
         self.assertFalse(locs.has_item(key))
         item = locs.get_item(key, "default")
         self.assertEqual(item, "default")
+
+    def test_thread_context_vars_default(self):
+        token = ThreadContextVar("TEST_contextvars")
+        self.assertEqual(None, token.get())  # default value is none
+
+    def test_thread_context_vars_set_default_value(self):
+        token = ThreadContextVar("TEST_contextvars", {'pips': 3})
+        self.assertEqual({'pips': 3}, token.get())
+
+    def test_thread_context_vars_set_new_value(self):
+        token = ThreadContextVar("TEST_contextvars", {'pips': 3})
+        token.set({'carrots': 'no'})
+        self.assertEqual({'carrots': 'no'}, token.get())
 
     def test_encoding_recursive(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist=
     py{35,36,37}-django{18,19,110,111,20,21}-migrate1-django1,
     py27-django{18,19,110,111}-migrate1-django1,
     py38-django{18,111,20,21}-migrate1-django1,
+    py38-asynctest
     py38-lint
 
 [testenv]
@@ -46,6 +47,7 @@ deps=
 
 commands =
     test: nosetests -sv --with-coverage --cover-package=bugsnag
+    asynctest: nosetests integrations/test_async_asgi.py integrations/test_async_request.py -sv --with-coverage --cover-package=bugsnag
     requests: nosetests -sv --with-coverage --cover-package=bugsnag tests requests/test_requests_delivery.py
     wsgi: nosetests integrations/test_wsgi.py -sv --with-coverage --cover-package=bugsnag
     asgi: nosetests integrations/test_asgi.py -sv --with-coverage --cover-package=bugsnag


### PR DESCRIPTION
Fixes cases where coroutines / tasks can share threads reporting
incorrect metadata

## Design

Previously, request / async context was stored in thread locals, which may be shared for coroutines as they can pause and start on the same thread. This changeset instead uses [context variables](https://www.python.org/dev/peps/pep-0567/), falling back to thread locals if not available.

## Changeset

* [New] `bugsnag.utils.ThreadContextVar` - a `contextvars.ContextVar` API-compatible wrapper for thread locals
* [Changed] Configuration and SessionTracker use a `ContextVar`-ish object to store request context

## Tests

* Added tests for the `ThreadContextVar` functions
* Added integration tests for async state in `integrations/test_async_*` files

## Linked issues

Fixes #109

<!-- 
## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language

-->
