### PR TITLE
Ensure session counts on events do not include future events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Ensure session counts on events do not increment with future events by copying
+  the session information into each event
+
 ## 3.7.0 (2020-07-27)
 
 ### Enhancements

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from copy import deepcopy
 from uuid import uuid4
 from time import strftime, gmtime
 from threading import Lock, Timer
@@ -146,5 +147,5 @@ class SessionMiddleware(object):
                 session['events']['unhandled'] += 1
             else:
                 session['events']['handled'] += 1
-            notification.session = session
+            notification.session = deepcopy(session)
         self.bugsnag(notification)

--- a/tests/test_sessionmiddleware.py
+++ b/tests/test_sessionmiddleware.py
@@ -1,0 +1,44 @@
+import unittest
+
+from bugsnag.sessiontracker import SessionTracker, SessionMiddleware
+from bugsnag.configuration import Configuration
+from bugsnag.notification import Notification
+
+
+class TestSessionMiddleware(unittest.TestCase):
+    def setUp(self):
+        self.config = Configuration()
+        self.config.configure(api_key='fff', auto_capture_sessions=False)
+        self.sessiontracker = SessionTracker(self.config)
+        self.sessiontracker.auto_sessions = True  # Stub session delivery queue
+
+    def tearDown(self):
+        pass
+
+    def test_increment_counts(self):
+        """
+        Every event should keep a list of prior events which occurred in the
+        session
+        """
+
+        def next_callable(event):
+            pass
+
+        middleware = SessionMiddleware(next_callable)
+        self.sessiontracker.start_session()
+
+        event = Notification(Exception('shucks'), self.config, None)
+        middleware(event)
+
+        assert event.session['events']['unhandled'] == 0
+        assert event.session['events']['handled'] == 1
+
+        event2 = Notification(Exception('oh no'), self.config, None)
+        middleware(event2)
+
+        assert event2.session['events']['unhandled'] == 0
+        assert event2.session['events']['handled'] == 2
+
+        # Session counts should not change for events already handled
+        assert event.session['events']['unhandled'] == 0
+        assert event.session['events']['handled'] == 1


### PR DESCRIPTION
Fixes a potential issue where sessions which have not yet been counted and dispatched have incorrect counts because the nested `events` objects were shared across events in the same context. The issue becomes clear by running the new session middleware tests against current master.
This changeset replaces the session with a [`deepcopy()`](https://docs.python.org/3/library/copy.html#copy.deepcopy) of it so there is no shared state between session objects. The copy itself should not have large overhead as the session objects remain small.

[PLAT-4402]