### PR TITLE
fix(sessiontracker): Skip delivery when release stage is filtered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Ensure session counts on events do not increment with future events by copying
   the session information into each event
 
+* Fix erroneously delivered sessions when session tracking is disabled by
+  release stages
+
 ## 3.7.0 (2020-07-27)
 
 ### Enhancements

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -100,7 +100,7 @@ class SessionTracker(object):
             bugsnag.logger.debug("Not delivering due to an invalid api_key")
             return
 
-        if not self.config.should_notify:
+        if not self.config.should_notify():
             bugsnag.logger.debug("Not delivering due to release_stages")
             return
 

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -98,3 +98,38 @@ class TestConfiguration(IntegrationTest):
         self.assertEqual(sesevents['unhandled'], 0)
         self.assertTrue('handled' in sesevents)
         self.assertEqual(sesevents['handled'], 1)
+
+    def test_session_tracker_does_not_send_when_nothing_to_send(self):
+        client = Client(
+            api_key='fff',
+            session_endpoint=self.server.url,
+            asynchronous=False,
+            release_stage="dev",
+            notify_release_stages=["prod"],
+        )
+        client.session_tracker.send_sessions()
+        self.assertEqual(0, len(self.server.received))
+
+    def test_session_tracker_does_not_send_when_disabled(self):
+        client = Client(
+            api_key='fff',
+            session_endpoint=self.server.url,
+            asynchronous=False,
+            release_stage="dev",
+            notify_release_stages=["prod"],
+        )
+        client.session_tracker.start_session()
+        client.session_tracker.send_sessions()
+        self.assertEqual(0, len(self.server.received))
+
+    def test_session_tracker_does_not_send_when_misconfigured(self):
+        client = Client(
+            api_key=None,
+            session_endpoint=self.server.url,
+            asynchronous=False,
+            release_stage="dev",
+            notify_release_stages=["prod"],
+        )
+        client.session_tracker.start_session()
+        client.session_tracker.send_sessions()
+        self.assertEqual(0, len(self.server.received))


### PR DESCRIPTION
## Goal

Fix erroneously delivered sessions when session tracking is disabled by release stages

## Tests

* Added a few tests to cover how session tracker interacts with release stages