### PR TITLE
Add support for making individual events or integrations use synchronous delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Support forcing an individual event to be sent synchronously to Bugsnag.
+  Given a configuration where asynchronous=True (the default setting), use
+  `notify(ex, asynchronous=False)` to block until the event is delivered.
+
 ## 3.7.1 (2020-07-30)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Changelog
   Given a configuration where asynchronous=True (the default setting), use
   `notify(ex, asynchronous=False)` to block until the event is delivered.
 
+### Fixes
+
+* Fix missing reports from failed celery tasks when the worker would terminate
+  prior to the event being sent to bugsnag
+
 ## 3.7.1 (2020-07-30)
 
 ### Fixes

--- a/bugsnag/celery/__init__.py
+++ b/bugsnag/celery/__init__.py
@@ -16,6 +16,7 @@ def failure_handler(sender, task_id, exception, args, kwargs, traceback, einfo,
     bugsnag.auto_notify(exception, traceback=traceback,
                         context=sender.name,
                         extra_data=task,
+                        asynchronous=False,
                         severity_reason={
                             'type': 'unhandledExceptionMiddleware',
                             'attributes': {

--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -76,6 +76,12 @@ class Delivery(object):
             }
             self.deliver(config, payload, options)
 
+    def queue_request(self, request, config, options):
+        if config.asynchronous and options.pop('asynchronous', True):
+            Thread(target=request).start()
+        else:
+            request()
+
 
 class UrllibDelivery(Delivery):
 
@@ -111,10 +117,7 @@ class UrllibDelivery(Delivery):
                 bugsnag.logger.warning(
                     'Delivery to %s failed, status %d' % (uri, status))
 
-        if config.asynchronous:
-            Thread(target=request).start()
-        else:
-            request()
+        self.queue_request(request, config, options)
 
 
 class RequestsDelivery(Delivery):
@@ -147,7 +150,4 @@ class RequestsDelivery(Delivery):
                 bugsnag.logger.warning(
                     'Delivery to %s failed, status %d' % (uri, status))
 
-        if config.asynchronous:
-            Thread(target=request).start()
-        else:
-            request()
+        self.queue_request(request, config, options)

--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -53,7 +53,7 @@ class Delivery(object):
     def __init__(self):
         self.sent_session_warning = False
 
-    def deliver(self, config, payload):
+    def deliver(self, config, payload, options={}):
         """
         Sends error reports to Bugsnag
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -52,7 +52,7 @@ class ClientTest(IntegrationTest):
 
         class FooDelivery:
 
-            def deliver(foo, config, payload):
+            def deliver(foo, config, payload, options={}):
                 self.called = True
 
         c.configure(delivery=FooDelivery(), api_key='abc')
@@ -74,7 +74,7 @@ class ClientTest(IntegrationTest):
 
         class FooDelivery:
 
-            def deliver(foo, config, payload):
+            def deliver(foo, config, payload, options={}):
                 self.called = True
                 raise ScaryException('something gone wrong')
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -716,3 +716,9 @@ class TestBugsnag(IntegrationTest):
                 "name": "test middleware"
             }
         })
+
+    def test_synchronous_individual_notify(self):
+        bugsnag.configure(asynchronous=True)
+        bugsnag.notify(ScaryException('unexpected failover'),
+                       asynchronous=False)
+        assert len(self.server.received) == 1


### PR DESCRIPTION
## Goal

In some cases, asynchronous delivery would mean lost events as the application is terminating. This changeset adds capability for mitigating this on an ad-hoc basis, as well as making it the default setting for failures detected in Celery tasks.


## Changeset

* Adds an optional `asynchronous` keyword argument to `Client.notify()`. When set to `False` the event will be synchronously delivered
* Corrects a longstanding issue in the delivery interface which would be directly affected by this change

Fixes #177 