### PR TITLE
Validate and warn for unknown or incorrectly typed options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 
 ### Fixes
 
+* Warn for incorrectly typed configuration options
 * Fix missing reports from failed celery tasks when the worker would terminate
   prior to the event being sent to bugsnag
 

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -129,7 +129,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._api_key
 
-    @api_key.setter
+    @api_key.setter  # type: ignore
     @validate_required_str_setter
     def api_key(self, value):
         self._api_key = value
@@ -141,7 +141,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._app_version
 
-    @app_version.setter
+    @app_version.setter  # type: ignore
     @validate_str_setter
     def app_version(self, value):
         self._app_version = value
@@ -153,7 +153,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._asynchronous
 
-    @asynchronous.setter
+    @asynchronous.setter  # type: ignore
     @validate_bool_setter
     def asynchronous(self, value):
         self._asynchronous = value
@@ -166,7 +166,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._auto_capture_sessions
 
-    @auto_capture_sessions.setter
+    @auto_capture_sessions.setter  # type: ignore
     @validate_bool_setter
     def auto_capture_sessions(self, value):
         self._auto_capture_sessions = value
@@ -178,7 +178,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._auto_notify
 
-    @auto_notify.setter
+    @auto_notify.setter  # type: ignore
     @validate_bool_setter
     def auto_notify(self, value):
         self._auto_notify = value
@@ -191,7 +191,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._delivery
 
-    @delivery.setter
+    @delivery.setter  # type: ignore
     def delivery(self, value):
         if hasattr(value, 'deliver') and callable(value.deliver):
             self._delivery = value
@@ -210,7 +210,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._endpoint
 
-    @endpoint.setter
+    @endpoint.setter  # type: ignore
     @validate_required_str_setter
     def endpoint(self, value):
         self._endpoint = value
@@ -223,7 +223,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._hostname
 
-    @hostname.setter
+    @hostname.setter  # type: ignore
     @validate_str_setter
     def hostname(self, value):
         self._hostname = value
@@ -237,7 +237,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._ignore_classes
 
-    @ignore_classes.setter
+    @ignore_classes.setter  # type: ignore
     @validate_iterable_setter
     def ignore_classes(self, value):
         self._ignore_classes = value
@@ -251,7 +251,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._lib_root
 
-    @lib_root.setter
+    @lib_root.setter  # type: ignore
     @validate_str_setter
     def lib_root(self, value):
         self._lib_root = value
@@ -265,7 +265,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._notify_release_stages
 
-    @notify_release_stages.setter
+    @notify_release_stages.setter  # type: ignore
     @validate_iterable_setter
     def notify_release_stages(self, value):
         self._notify_release_stages = value
@@ -283,7 +283,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._params_filters
 
-    @params_filters.setter
+    @params_filters.setter  # type: ignore
     @validate_iterable_setter
     def params_filters(self, value):
         self._params_filters = value
@@ -298,7 +298,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._project_root
 
-    @project_root.setter
+    @project_root.setter  # type: ignore
     @validate_str_setter
     def project_root(self, value):
         self._project_root = value
@@ -310,7 +310,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._proxy_host
 
-    @proxy_host.setter
+    @proxy_host.setter  # type: ignore
     @validate_str_setter
     def proxy_host(self, value):
         self._proxy_host = value
@@ -324,7 +324,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._release_stage
 
-    @release_stage.setter
+    @release_stage.setter  # type: ignore
     @validate_str_setter
     def release_stage(self, value):
         self._release_stage = value
@@ -337,7 +337,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._send_code
 
-    @send_code.setter
+    @send_code.setter  # type: ignore
     @validate_bool_setter
     def send_code(self, value):
         self._send_code = value
@@ -352,7 +352,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._session_endpoint
 
-    @session_endpoint.setter
+    @session_endpoint.setter  # type: ignore
     @validate_required_str_setter
     def session_endpoint(self, value):
         self._session_endpoint = value
@@ -364,7 +364,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._traceback_exclude_modules
 
-    @traceback_exclude_modules.setter
+    @traceback_exclude_modules.setter  # type: ignore
     @validate_iterable_setter
     def traceback_exclude_modules(self, value):
         self._traceback_exclude_modules = value
@@ -377,7 +377,7 @@ class Configuration(_BaseConfiguration):
         """
         return self._use_ssl
 
-    @use_ssl.setter
+    @use_ssl.setter  # type: ignore
     @validate_bool_setter
     def use_ssl(self, value):
         warnings.warn('use_ssl is deprecated in favor of including the '

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -14,7 +14,9 @@ import warnings
 
 from bugsnag.sessiontracker import SessionMiddleware
 from bugsnag.middleware import DefaultMiddleware, MiddlewareStack
-from bugsnag.utils import fully_qualified_class_name
+from bugsnag.utils import (fully_qualified_class_name, validate_str_setter,
+                           validate_bool_setter, validate_iterable_setter,
+                           validate_required_str_setter)
 from bugsnag.delivery import (create_default_delivery, DEFAULT_ENDPOINT,
                               DEFAULT_SESSIONS_ENDPOINT)
 
@@ -23,8 +25,10 @@ try:
     _request_info = ContextVar('bugsnag-request', default=None)  # type: ignore
 except ImportError:
     from bugsnag.utils import ThreadContextVar
-    # flake8: noqa
-    _request_info = ThreadContextVar('bugsnag-request', default=None)  # type: ignore
+    _request_info = ThreadContextVar('bugsnag-request', default=None)  # type: ignore  # noqa: E501
+
+
+__all__ = ('Configuration', 'RequestConfiguration')
 
 
 class _BaseConfiguration(object):
@@ -33,12 +37,6 @@ class _BaseConfiguration(object):
         Get a single configuration option, using values from overrides
         first if they exist.
         """
-        if name == 'use_ssl':
-            warnings.warn('use_ssl is deprecated in favor of including the '
-                          'protocol in the endpoint property and will be '
-                          'removed in a future release',
-                          DeprecationWarning)
-
         if overrides:
             return overrides.get(name, getattr(self, name))
         else:
@@ -49,12 +47,6 @@ class _BaseConfiguration(object):
         Set one or more configuration settings.
         """
         for name, value in options.items():
-            if name == 'use_ssl':
-                warnings.warn('use_ssl is deprecated in favor of including '
-                              'the protocol in the endpoint property and will '
-                              'be removed in a future release',
-                              DeprecationWarning)
-
             setattr(self, name, value)
 
         return self
@@ -103,6 +95,295 @@ class Configuration(_BaseConfiguration):
             self.hostname = None
 
         self.runtime_versions = {"python": platform.python_version()}
+
+    def configure(self, **options):
+        """
+        Validate and set configuration options. Will warn if an option is of an
+        incorrect type.
+        """
+        # Overrides the default implementation to provide warnings for unknown
+        # options. In the __future__ this will not be necessary by instead
+        # making configure() enumerate all of the options as kwargs rather than
+        # allowing arbitrary input.
+        configurable_options = [
+            'api_key', 'app_version', 'asynchronous', 'auto_notify',
+            'auto_capture_sessions', 'delivery', 'endpoint', 'hostname',
+            'ignore_classes', 'lib_root', 'notify_release_stages',
+            'params_filters', 'project_root', 'proxy_host', 'release_stage',
+            'send_code', 'session_endpoint', 'traceback_exclude_modules',
+            'use_ssl',
+        ]
+
+        for option_name in options.keys():
+            if option_name not in configurable_options:
+                message = 'received unknown configuration option "{0}"'
+                warnings.warn(message.format(option_name), RuntimeWarning)
+            setattr(self, option_name, options.get(option_name))
+
+        return self
+
+    @property
+    def api_key(self):
+        """
+        Unique application identifier
+        """
+        return self._api_key
+
+    @api_key.setter
+    @validate_required_str_setter
+    def api_key(self, value):
+        self._api_key = value
+
+    @property
+    def app_version(self):
+        """
+        Release version of the current application
+        """
+        return self._app_version
+
+    @app_version.setter
+    @validate_str_setter
+    def app_version(self, value):
+        self._app_version = value
+
+    @property
+    def asynchronous(self):
+        """
+        If API requests should be sent asynchronously
+        """
+        return self._asynchronous
+
+    @asynchronous.setter
+    @validate_bool_setter
+    def asynchronous(self, value):
+        self._asynchronous = value
+
+    @property
+    def auto_capture_sessions(self):
+        """
+        If sessions should be automatically detected and delivered from web
+        request integrations
+        """
+        return self._auto_capture_sessions
+
+    @auto_capture_sessions.setter
+    @validate_bool_setter
+    def auto_capture_sessions(self, value):
+        self._auto_capture_sessions = value
+
+    @property
+    def auto_notify(self):
+        """
+        If uncaught exceptions should be automatically captured and reported
+        """
+        return self._auto_notify
+
+    @auto_notify.setter
+    @validate_bool_setter
+    def auto_notify(self, value):
+        self._auto_notify = value
+
+    @property
+    def delivery(self):
+        """
+        Transport mechanism used to make API requests. Implement the Delivery
+        interface to customize how requests are sent.
+        """
+        return self._delivery
+
+    @delivery.setter
+    def delivery(self, value):
+        if hasattr(value, 'deliver') and callable(value.deliver):
+            self._delivery = value
+        else:
+            message = ('delivery should implement Delivery interface, got ' +
+                       '{0}. This will be an error in a future release.')
+            warnings.warn(message.format(type(value).__name__), RuntimeWarning)
+
+    @property
+    def endpoint(self):
+        """
+        Event API endpoint. Set this property if using Bugsnag On-Premise.
+
+        >>> config = Configuration()
+        >>> config.endpoint = 'https://notify.bugsnag.example.co'
+        """
+        return self._endpoint
+
+    @endpoint.setter
+    @validate_required_str_setter
+    def endpoint(self, value):
+        self._endpoint = value
+
+    @property
+    def hostname(self):
+        """
+        The host name of the application server. This value is automatically
+        detected for Heroku applications and included in event device metadata.
+        """
+        return self._hostname
+
+    @hostname.setter
+    @validate_str_setter
+    def hostname(self, value):
+        self._hostname = value
+
+    @property
+    def ignore_classes(self):
+        """
+        Fully qualified class names which should be ignored when capturing
+        uncaught exceptions and other events. KeyboardInterrupt and Http404
+        exceptions are ignored by default.
+        """
+        return self._ignore_classes
+
+    @ignore_classes.setter
+    @validate_iterable_setter
+    def ignore_classes(self, value):
+        self._ignore_classes = value
+
+    @property
+    def lib_root(self):
+        """
+        The path to the Python library. Any traceback frame which contains
+        lib_root as a prefix is considered out-of-project. The prefix is also
+        stripped to make file names easier to read.
+        """
+        return self._lib_root
+
+    @lib_root.setter
+    @validate_str_setter
+    def lib_root(self, value):
+        self._lib_root = value
+
+    @property
+    def notify_release_stages(self):
+        """
+        A list of release_stage values which are permitted to capture and send
+        events and sessions. By default this value is None and all events and
+        sessions are delivered.
+        """
+        return self._notify_release_stages
+
+    @notify_release_stages.setter
+    @validate_iterable_setter
+    def notify_release_stages(self, value):
+        self._notify_release_stages = value
+
+    @property
+    def params_filters(self):
+        """
+        A list of filters applied to event metadata to prevent the values from
+        being sent in events. By default the following keys are filtered:
+
+        * authorization
+        * cookie
+        * password
+        * password_confirmation
+        """
+        return self._params_filters
+
+    @params_filters.setter
+    @validate_iterable_setter
+    def params_filters(self, value):
+        self._params_filters = value
+
+    @property
+    def project_root(self):
+        """
+        The working directory containing the application source code.
+        Traceback file paths which contain this prefix are considered a part of
+        the project. This prefix is also stripped to increase file name
+        readability in traceback lines.
+        """
+        return self._project_root
+
+    @project_root.setter
+    @validate_str_setter
+    def project_root(self, value):
+        self._project_root = value
+
+    @property
+    def proxy_host(self):
+        """
+        The host name of the proxy to use to deliver requests, if any
+        """
+        return self._proxy_host
+
+    @proxy_host.setter
+    @validate_str_setter
+    def proxy_host(self, value):
+        self._proxy_host = value
+
+    @property
+    def release_stage(self):
+        """
+        The development phase of the deployed application. This value is used
+        to differentiate events which occur in production vs development or
+        staging environments.
+        """
+        return self._release_stage
+
+    @release_stage.setter
+    @validate_str_setter
+    def release_stage(self, value):
+        self._release_stage = value
+
+    @property
+    def send_code(self):
+        """
+        If the source code lines immediately surrounding traceback locations
+        should be sent with events
+        """
+        return self._send_code
+
+    @send_code.setter
+    @validate_bool_setter
+    def send_code(self, value):
+        self._send_code = value
+
+    @property
+    def session_endpoint(self):
+        """
+        Sessions API endpoint. Set this property if using Bugsnag On-Premise.
+
+        >>> config = Configuration()
+        >>> config.session_endpoint = 'https://sessions.bugsnag.example.co'
+        """
+        return self._session_endpoint
+
+    @session_endpoint.setter
+    @validate_required_str_setter
+    def session_endpoint(self, value):
+        self._session_endpoint = value
+
+    @property
+    def traceback_exclude_modules(self):
+        """
+        Modules which should be stripped from event tracebacks entirely
+        """
+        return self._traceback_exclude_modules
+
+    @traceback_exclude_modules.setter
+    @validate_iterable_setter
+    def traceback_exclude_modules(self, value):
+        self._traceback_exclude_modules = value
+
+    @property
+    def use_ssl(self):
+        """
+        This property is used to determine the protocol of endpoint and is
+        deprecated in favor of including the protocol in the endpoint property.
+        """
+        return self._use_ssl
+
+    @use_ssl.setter
+    @validate_bool_setter
+    def use_ssl(self, value):
+        warnings.warn('use_ssl is deprecated in favor of including the '
+                      'protocol in the endpoint property and will be removed '
+                      'in a future release', DeprecationWarning)
+        self._use_ssl = value
 
     def should_notify(self):  # type: () -> bool
         return self.notify_release_stages is None or \

--- a/tests/integrations/test_requests_delivery.py
+++ b/tests/integrations/test_requests_delivery.py
@@ -11,12 +11,11 @@ class RequestsDeliveryTest(IntegrationTest):
         self.config = Configuration()
         self.config.configure(
             api_key='abc',
-            endpoint=self.server.address,
-            use_ssl=False,
             asynchronous=False
         )
 
     def test_requests_delivery(self):
+        self.config.configure(endpoint=self.server.address, use_ssl=False)
         RequestsDelivery().deliver(self.config, '{"legit": 4}')
 
         self.assertSentReportCount(1)
@@ -31,7 +30,6 @@ class RequestsDeliveryTest(IntegrationTest):
 
     def test_requests_delivery_full_url(self):
         self.config.configure(endpoint=self.server.url)
-        del self.config.use_ssl
 
         RequestsDelivery().deliver(self.config, '{"good": 5}')
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -6,6 +6,8 @@ from bugsnag.configuration import Configuration
 from bugsnag.middleware import DefaultMiddleware
 from bugsnag.sessiontracker import SessionMiddleware
 
+import pytest
+
 
 class TestConfiguration(unittest.TestCase):
 
@@ -105,3 +107,291 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual(c.internal_middleware.stack,
                          [DefaultMiddleware, SessionMiddleware])
         self.assertEqual(len(c.middleware.stack), 0)
+
+    def test_validate_api_key(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(api_key=[])
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'api_key should be str, got list. ' +
+                    'This will be an error in a future release.')
+            c.configure(api_key='ffff')
+
+            assert len(record) == 1
+            assert c.api_key == 'ffff'
+
+    def test_validate_endpoint(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(endpoint=56)
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'endpoint should be str, got int. ' +
+                    'This will be an error in a future release.')
+            assert c.endpoint == 'https://notify.bugsnag.com'
+
+            c.configure(endpoint='https://notify.example.com')
+
+            assert len(record) == 1
+            assert c.endpoint == 'https://notify.example.com'
+
+    def test_validate_app_version(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(app_version=[])
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'app_version should be str, got list')
+            assert c.app_version is None
+
+            c.configure(app_version='1.2.6')
+
+            assert len(record) == 1
+            assert c.app_version == '1.2.6'
+
+    def test_validate_asynchronous(self):
+        c = Configuration()
+        assert c.asynchronous is True
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(asynchronous='true')
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'asynchronous should be bool, got str')
+            assert c.asynchronous is True
+
+            c.configure(asynchronous=False)
+            assert len(record) == 1
+            assert c.asynchronous is False
+
+    def test_validate_auto_notify(self):
+        c = Configuration()
+        assert c.auto_notify is True
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(auto_notify='true')
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'auto_notify should be bool, got str')
+
+            c.configure(auto_notify=False)
+            assert len(record) == 1
+            assert c.auto_notify is False
+
+    def test_validate_auto_capture_sessions(self):
+        c = Configuration()
+        assert c.auto_capture_sessions is True
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(auto_capture_sessions='true')
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'auto_capture_sessions should be bool, got str')
+
+            c.configure(auto_capture_sessions=False)
+            assert len(record) == 1
+            assert c.auto_capture_sessions is False
+
+    def test_validate_delivery(self):
+        c = Configuration()
+        assert c.delivery is not None
+
+        class BadDelivery(object):
+            def deliv(self, *args, **kwargs):
+                pass
+
+        class GoodDelivery(object):
+            def deliver(self, *args, **kwargs):
+                pass
+
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(delivery=BadDelivery())
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    ('delivery should implement Delivery interface, ' +
+                     'got BadDelivery. This will be an error in a future ' +
+                     'release.'))
+
+            good = GoodDelivery()
+            c.configure(delivery=good)
+            assert len(record) == 1
+            assert c.delivery == good
+
+    def test_validate_hostname(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(hostname=[])
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'hostname should be str, got list')
+            assert c.hostname is None
+
+            c.configure(hostname='testserver')
+
+            assert len(record) == 1
+            assert c.hostname == 'testserver'
+
+    def test_validate_ignore_classes(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(ignore_classes=302)
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'ignore_classes should be list or tuple, got int')
+            assert isinstance(c.ignore_classes, (list, tuple))
+
+            c.configure(ignore_classes=['LookupError'])
+
+            assert len(record) == 1
+            assert c.ignore_classes == ['LookupError']
+
+    def test_validate_lib_root(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(lib_root=False)
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'lib_root should be str, got bool')
+
+            c.configure(lib_root='/path/to/python/lib')
+
+            assert len(record) == 1
+            assert c.lib_root == '/path/to/python/lib'
+
+    def test_validate_notify_release_stages(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(notify_release_stages='beta')
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'notify_release_stages should be list or tuple, got str')
+            assert c.notify_release_stages is None
+
+            c.configure(notify_release_stages=['beta'])
+
+            assert len(record) == 1
+            assert c.notify_release_stages == ['beta']
+
+    def test_validate_params_filters(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(params_filters='pw')
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'params_filters should be list or tuple, got str')
+            assert isinstance(c.params_filters, list)
+
+            c.configure(params_filters=['pw'])
+
+            assert len(record) == 1
+            assert c.params_filters == ['pw']
+
+    def test_validate_project_root(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(project_root=True)
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'project_root should be str, got bool')
+            assert c.project_root == os.getcwd()
+
+            c.configure(project_root='/path/to/python/project')
+
+            assert len(record) == 1
+            assert c.project_root == '/path/to/python/project'
+
+    def test_validate_proxy_host(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(proxy_host=True)
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'proxy_host should be str, got bool')
+            assert c.proxy_host is None
+
+            c.configure(proxy_host='112.0.0.45')
+
+            assert len(record) == 1
+            assert c.proxy_host == '112.0.0.45'
+
+    def test_validate_release_stage(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(release_stage=False)
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'release_stage should be str, got bool')
+            assert c.release_stage == 'production'
+
+            c.configure(release_stage='beta-2')
+
+            assert len(record) == 1
+            assert c.release_stage == 'beta-2'
+
+    def test_validate_send_code(self):
+        c = Configuration()
+        assert c.send_code is True
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(send_code='false')
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'send_code should be bool, got str')
+            assert c.send_code is True
+
+            c.configure(send_code=False)
+            assert len(record) == 1
+            assert c.send_code is False
+
+    def test_validate_session_endpoint(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(session_endpoint=False)
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'session_endpoint should be str, got bool. This will be' +
+                    ' an error in a future release.')
+            assert c.session_endpoint == 'https://sessions.bugsnag.com'
+
+            c.configure(session_endpoint='https://sessions.example.com')
+
+            assert len(record) == 1
+            assert c.session_endpoint == 'https://sessions.example.com'
+
+    def test_validate_traceback_exclude_modules(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(traceback_exclude_modules='_.logger')
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'traceback_exclude_modules should be list or tuple, ' +
+                    'got str')
+            assert isinstance(c.traceback_exclude_modules, list)
+
+            c.configure(traceback_exclude_modules=['_.logger'])
+
+            assert len(record) == 1
+            assert c.traceback_exclude_modules == ['_.logger']
+
+    def test_validate_unknown_config_option(self):
+        c = Configuration()
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(emperor=True)
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'received unknown configuration option "emperor"')

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -58,7 +58,7 @@ class TestBugsnag(IntegrationTest):
         self.assertEqual('dev', event['releaseStage'])
 
     def test_notify_unconfigured_release_stage(self):
-        bugsnag.configure(release_stage=['pickles'])
+        bugsnag.configure(release_stage='pickles')
         bugsnag.notify(ScaryException('unexpected failover'))
         self.assertEqual(0, len(self.server.received))
 


### PR DESCRIPTION
## Goal

When configuring the bugsnag client, emit warnings for incorrectly used configuration.

## Changeset

* [utils] Adds helpers to check if a setter function is of a provided type, otherwise issuing a warning
* [config] Adds a property for each config option, using the validation helpers to check each type
* [config] Emit a warning if an unknown configuration option is specified

## Tests

* Added new tests for each config property and setting unknown options

## Discussion

This is a larger change because its the first time all config options have been enumerated, which has the added benefit of adding a place for documentation of each one.

In a future (breaking) release:

1. the class hierarchy for `Configuration` and `RequestConfiguration` should be separated since the behavior differs completely aside from having a helper function to set multiple options at once. `Configuration` should enumerate all valid options in `configure()`, catching potential problems earlier.

1. the package as a whole can raise the minimum supported py version (from 2.6) to take advantage of the `typing` package to reduce the amount of type checking boilerplate

1. config options which are essential for the correct functioning of the library (api key, endpoint, delivery) should throw `TypeError` for incorrect types and `ValueError` for unusable values of the correct type (e.g. empty strings).

### Linked issues

Fixes #193 
