### PR TITLE
Add option to enable/disable sending request env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
 * Support configuring app type, which is a searchable field on the Bugsnag
   dashboard. Set `Configuration.app_type` to add a `type` property to the app
   metadata of an event.
+* Support disabling automatic attachment of the request environment to events.
+  Set `Configuration.send_environment` to `False` to remove the metadata.
+* [ASGI] Collect request enviroment in an "environment" metadata section
 
 ### Fixes
 

--- a/bugsnag/asgi.py
+++ b/bugsnag/asgi.py
@@ -100,6 +100,8 @@ class BugsnagMiddleware:
             request['url'] = parse_url(request, server)
 
             event.add_tab("request", request)
+            if bugsnag.configure().send_environment:
+                event.add_tab("environment", scope)
 
         stack.before_notify(add_request_info)
 

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -63,6 +63,7 @@ class Configuration(_BaseConfiguration):
         self.notify_release_stages = None
         self.auto_notify = True
         self.send_code = True
+        self.send_environment = True
         self.asynchronous = True
         self.use_ssl = True  # Deprecated
         self.delivery = create_default_delivery()
@@ -112,7 +113,7 @@ class Configuration(_BaseConfiguration):
             'ignore_classes', 'lib_root', 'notify_release_stages',
             'params_filters', 'project_root', 'proxy_host', 'release_stage',
             'send_code', 'session_endpoint', 'traceback_exclude_modules',
-            'use_ssl', 'app_type',
+            'use_ssl', 'app_type', 'send_environment',
         ]
 
         for option_name in options.keys():
@@ -354,6 +355,19 @@ class Configuration(_BaseConfiguration):
     @validate_bool_setter
     def send_code(self, value):
         self._send_code = value
+
+    @property
+    def send_environment(self):
+        """
+        If the request environment should be automatically collected and
+        attached to events
+        """
+        return self._send_environment
+
+    @send_environment.setter  # type: ignore
+    @validate_bool_setter
+    def send_environment(self, value):
+        self._send_environment = value
 
     @property
     def session_endpoint(self):

--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -70,7 +70,8 @@ def add_django_request_to_notification(notification):
         pass
 
     notification.add_tab("request", request_tab)
-    notification.add_tab("environment", dict(request.META))
+    if bugsnag.configure().send_environment:
+        notification.add_tab("environment", dict(request.META))
 
 
 def configure():

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -15,7 +15,8 @@ def add_flask_request_to_notification(notification):
     if "id" not in notification.user:
         notification.set_user(id=flask.request.remote_addr)
     notification.add_tab("session", dict(flask.session))
-    notification.add_tab("environment", dict(flask.request.environ))
+    if bugsnag.configure().send_environment:
+        notification.add_tab("environment", dict(flask.request.environ))
     notification.add_tab("request", {
         "url": flask.request.base_url,
         "headers": dict(flask.request.headers),

--- a/bugsnag/middleware.py
+++ b/bugsnag/middleware.py
@@ -47,7 +47,8 @@ class DefaultMiddleware(object):
                 notification.add_tab(name, dictionary)
 
         notification.add_tab("request", config.get("request_data"))
-        notification.add_tab("environment", config.get("environment_data"))
+        if bugsnag.configure().send_environment:
+            notification.add_tab("environment", config.get("environment_data"))
         notification.add_tab("session", config.get("session_data"))
         notification.add_tab("extraData", config.get("extra_data"))
 

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -33,8 +33,9 @@ class BugsnagRequestHandler(RequestHandler):
 
         notification.add_tab("request", request_tab)
 
-        notification.add_tab("environment",
-                             tornado.wsgi.WSGIContainer.environ(self.request))
+        if bugsnag.configure().send_environment:
+            env = tornado.wsgi.WSGIContainer.environ(self.request)
+            notification.add_tab("environment", env)
 
     def _handle_request_exception(self, exc):
         options = {

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -30,7 +30,9 @@ def add_wsgi_request_data_to_notification(notification):
         "headers": dict(request.headers),
         "params": dict(request.params),
     })
-    notification.add_tab("environment", dict(request.environ))
+
+    if bugsnag.configure().send_environment:
+        notification.add_tab("environment", dict(request.environ))
 
 
 class WrappedWSGIApp(object):

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from tests.utils import FakeBugsnagServer
 
+import bugsnag.legacy as global_setup
 import bugsnag
 
 
@@ -11,5 +12,8 @@ def bugsnag_server():
 
     yield server
 
-    bugsnag.configure(app_type=None)
+    # Reset shared client config
+    global_setup.configuration = bugsnag.Configuration()
+    global_setup.default_client.configuration = global_setup.configuration
+
     server.shutdown()

--- a/tests/integrations/test_tornado.py
+++ b/tests/integrations/test_tornado.py
@@ -122,6 +122,7 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
         payload = self.server.received[0]['json_body']
         event = payload['events'][0]
         expectedUrl = 'http://127.0.0.1:{}/crash'.format(self.get_http_port())
+        self.assertEqual(event['metaData']['environment'], {})
         self.assertEqual(event['metaData']['request'], {
             'method': 'GET',
             'url': expectedUrl,
@@ -171,3 +172,12 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
         response = self.fetch('/unknown_endpoint')
         self.assertEqual(response.code, 404)
         self.assertEqual(len(self.server.received), 0)
+
+    def test_disable_environment(self):
+        bugsnag.configure(send_environment=False)
+        response = self.fetch('/notify', method="POST", body="test=post")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(self.server.received), 1)
+
+        payload = self.server.received[0]['json_body']
+        assert 'environment' not in payload['events'][0]['metaData']

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -371,6 +371,21 @@ class TestConfiguration(unittest.TestCase):
             assert len(record) == 1
             assert c.send_code is False
 
+    def test_validate_send_environment(self):
+        c = Configuration()
+        assert c.send_environment is True
+        with pytest.warns(RuntimeWarning) as record:
+            c.configure(send_environment='False')
+
+            assert len(record) == 1
+            assert (str(record[0].message) ==
+                    'send_environment should be bool, got str')
+            assert c.send_environment is True
+
+            c.configure(send_environment=False)
+            assert len(record) == 1
+            assert c.send_environment is False
+
     def test_validate_session_endpoint(self):
         c = Configuration()
         with pytest.warns(RuntimeWarning) as record:


### PR DESCRIPTION
## Goal

It should be possible to skip collecting request environment altogether using a single option.

## Changeset

### Added

* `Configuration.send_environment` (bool)

### Changed

* Web framework integrations now check send_env before attaching environment tab

## Tests

* Added new tests to validate the config option
* Added new integration tests for each framework to ensure disabling send_env works