### PR TITLE
fix(wsgi): warn if running uWSGI without threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelog
 ### Fixes
 
 * Warn for incorrectly typed configuration options
+* Warn if running under uWSGI without thread support
 * Fix missing reports from failed celery tasks when the worker would terminate
   prior to the event being sent to bugsnag
 * [Django] Fix missing event context when a route did not have a name. Routes

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -19,6 +19,7 @@ from bugsnag.utils import (fully_qualified_class_name, validate_str_setter,
                            validate_required_str_setter)
 from bugsnag.delivery import (create_default_delivery, DEFAULT_ENDPOINT,
                               DEFAULT_SESSIONS_ENDPOINT)
+from bugsnag.uwsgi import warn_if_running_uwsgi_without_threads
 
 try:
     from contextvars import ContextVar
@@ -171,6 +172,8 @@ class Configuration(_BaseConfiguration):
     @validate_bool_setter
     def asynchronous(self, value):
         self._asynchronous = value
+        if value:
+            warn_if_running_uwsgi_without_threads()
 
     @property
     def auto_capture_sessions(self):

--- a/bugsnag/uwsgi.py
+++ b/bugsnag/uwsgi.py
@@ -1,0 +1,29 @@
+import warnings
+
+running_uwsgi = False
+threads_enabled = False
+
+# From docs (https://uwsgi-docs.readthedocs.io/en/latest/PythonModule.html):
+# > The uWSGI server automagically adds a uwsgi module into your Python
+#   apps.
+# > This is useful for configuring the uWSGI server, use its internal
+#   functions and get statistics. Also useful for detecting whether you're
+#   actually running under uWSGI; if you attempt to import uwsgi and
+#   receive an ImportError you're not running under uWSGI.
+try:
+    # > uwsgi.opt
+    # > The current configuration options, including any custom placeholders.
+    from uwsgi import opt
+    running_uwsgi = True
+    threads_enabled = opt.get('enable-threads', False)
+except ImportError:
+    pass
+
+__all__ = ('warn_if_running_uwsgi_without_threads',)
+
+
+def warn_if_running_uwsgi_without_threads():
+    if running_uwsgi and not threads_enabled:
+        warnings.warn(('Bugsnag cannot run asynchronously under uWSGI' +
+                       ' without enabling thread support. Please run uwsgi' +
+                       ' with --enable-threads'), RuntimeWarning)

--- a/example/wsgi/README.md
+++ b/example/wsgi/README.md
@@ -9,5 +9,5 @@ pip install -r requirements.txt
 ## Run
 
 ```bash
-uwsgi --http :9090 --wsgi-file app.py
+uwsgi --http :9090 --wsgi-file app.py --enable-threads
 ```


### PR DESCRIPTION
Add a warning if running in async mode under uWSGI without threading support enabled

## Changeset

* [Added] `uwsgi.warn_if_running_uwsgi_without_threads`
* [Changed] calling `config.asynchronous=` triggers the check for uWSGI if being set to async mode. By default this is just once at launch (since `True` is the default value)

## Testing

Manually tested running apps under uWSGI using the instructions for [Django](https://uwsgi-docs.readthedocs.io/en/latest/WSGIquickstart.html#deploying-django), [Flask](https://uwsgi-docs.readthedocs.io/en/latest/WSGIquickstart.html#deploying-flask), and [plain WSGI](https://uwsgi-docs.readthedocs.io/en/latest/WSGIquickstart.html#deploy-it-on-http-port-9090) (including bottle).