### PR TITLE
support capturing uncaught exceptions which occur on background threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Support reporting exceptions thrown from threads using
+  [`threading.excepthook`](https://docs.python.org/3.8/library/threading.html#threading.excepthook)
+
 ## 3.8.0 (2020-08-18)
 
 ### Enhancements

--- a/tests/async_utils.py
+++ b/tests/async_utils.py
@@ -17,6 +17,7 @@ class AsyncIntegrationTest(IsolatedAsyncioTestCase):
                           api_key='ffffffffffffffffff')
 
     async def asyncTearDown(self):
+        bugsnag.legacy.default_client.uninstall_sys_hook()
         self.server.shutdown()
 
     async def last_event_request(self):

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -15,5 +15,6 @@ def bugsnag_server():
     # Reset shared client config
     global_setup.configuration = bugsnag.Configuration()
     global_setup.default_client.configuration = global_setup.configuration
+    global_setup.default_client.uninstall_sys_hook()
 
     server.shutdown()

--- a/tests/integrations/test_thread_excepthook.py
+++ b/tests/integrations/test_thread_excepthook.py
@@ -1,0 +1,43 @@
+import bugsnag
+import threading
+
+
+class Terrible(Exception):
+    pass
+
+
+def test_uncaught_exception_on_thread_sends_event(bugsnag_server):
+    """
+    Python 3.8+ has an excepthook for spawned threads. This test checks that
+    exceptions thrown by threads are handled.
+    """
+
+    def process():
+        raise Terrible('oh no')
+
+    def my_program(*args):
+        return process()
+
+    def callback(event):
+        event.severity = "info"
+
+    bugsnag.configure(app_type='dispatch')
+    bugsnag.before_notify(callback)
+    thread = threading.Thread(target=my_program)
+    thread.start()
+    thread.join()
+
+    bugsnag_server.wait_for_request()
+
+    event = bugsnag_server.received[0]['json_body']['events'][0]
+    exception = event['exceptions'][0]
+
+    assert 'dispatch' == event['app']['type']
+    assert 'info' == event['severity']
+    assert 'test_thread_excepthook.Terrible' == exception['errorClass']
+    assert 'oh no' == exception['message']
+    assert 'process' == exception['stacktrace'][0]['method']
+    assert exception['stacktrace'][0]['inProject']
+    assert 'my_program' == exception['stacktrace'][1]['method']
+    assert exception['stacktrace'][1]['inProject']
+    assert not exception['stacktrace'][2]['inProject']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,6 +22,7 @@ class IntegrationTest(unittest.TestCase):
         self.server.received = []
 
     def tearDown(self):
+        bugsnag.legacy.default_client.uninstall_sys_hook()
         client = bugsnag.Client()
         client.configuration.api_key = 'some key'
         bugsnag.legacy.default_client = client

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist=
     py{27,35,36,37}-django{18,19,110,111}
     py{35,36,37,38,39}-django{20,21,22}
     py{36,37,38,39}-django3
-    py{38,39}-asynctest
+    py{38,39}-{asynctest,threadtest}
     py38-lint
 
 [pytest]
@@ -67,6 +67,7 @@ deps=
 commands =
     test: pytest --ignore=tests/integrations
     asynctest: pytest tests/integrations/test_async_asgi.py tests/integrations/test_async_request.py
+    threadtest: pytest tests/integrations/test_thread_excepthook.py
     requests: pytest --ignore=tests/integrations tests tests/integrations/test_requests_delivery.py
     bottle: pytest tests/integrations/test_bottle.py
     celery: pytest tests/integrations/test_celery.py


### PR DESCRIPTION
## Goal

Add support for automatic reporting for uncaught exceptions on spawned threads using [`threading.excepthook`](https://docs.python.org/3.8/library/threading.html#threading.excepthook).

Background: https://bugs.python.org/issue1230540

## Changeset

* [Changed] `Client.install_sys_hook` checks if the `threading` module supports custom exception hooks. If so, it installs a threading excepthook.

## Testing

* Added a new test to check that a background thread crash is captured