### PR TITLE
Add platform to config runtime_versions

### DIFF
--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -97,7 +97,10 @@ class Configuration(_BaseConfiguration):
         else:
             self.hostname = None
 
-        self.runtime_versions = {"python": platform.python_version()}
+        self.runtime_versions = {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+        }
 
     def configure(self, **options):
         """

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -257,7 +257,7 @@ class TestFlask(IntegrationTest):
         payload = self.server.received[0]['json_body']
         device_data = payload['events'][0]['device']
 
-        self.assertEquals(len(device_data['runtimeVersions']), 2)
+        self.assertEquals(len(device_data['runtimeVersions']), 3)
         self.assertTrue(re.match(r'\d+\.\d+\.\d+',
                                  device_data['runtimeVersions']['python']))
         self.assertTrue(re.match(r'\d+\.\d+\.\d+',

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -74,6 +74,8 @@ class TestConfiguration(IntegrationTest):
         self.assertTrue('runtimeVersions' in device)
         self.assertEqual(device['runtimeVersions']['python'],
                          platform.python_version())
+        self.assertEqual(device['runtimeVersions']['platform'],
+                         platform.platform())
 
     def test_session_middleware_attaches_session_to_notification(self):
         client = Client(


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
The platform that the app runs on may be useful information for debugging.

## Design

<!-- Why was this approach used? -->
`Configuration`'s `runtime_versions` seemed like a good place to attach this piece of information.

## Changeset

The `runtime_versions` attribute of `Configuration` instances now includes the platform key in its dict.

## Testing

A unittest was added to confirm it works

<!-- How was it tested? What manual and automated tests were
     run/added? -->