### PR TITLE
Capture errors occurring outside the Django middleware chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog
 
 * Support reporting exceptions thrown from threads using
   [`threading.excepthook`](https://docs.python.org/3.8/library/threading.html#threading.excepthook)
+* [Django] Capture errors which occur outside of the request/response middleware
+  chain, like uncaught exceptions within 404 or 500 handlers.
 
 ## 3.8.0 (2020-08-18)
 

--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -7,13 +7,13 @@ from bugsnag.client import Client
 from bugsnag.legacy import (configuration, configure, configure_request,
                             add_metadata_tab, clear_request_config, notify,
                             auto_notify, before_notify, start_session,
-                            send_sessions)
+                            send_sessions, auto_notify_exc_info)
 
 __all__ = ('Client', 'Notification', 'Configuration', 'RequestConfiguration',
            'configuration', 'configure', 'configure_request',
            'add_metadata_tab', 'clear_request_config', 'notify',
            'auto_notify', 'before_notify', 'start_session',
-           'send_sessions')
+           'send_sessions', 'auto_notify_exc_info')
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -1,4 +1,5 @@
 import types
+import sys
 
 from bugsnag.configuration import RequestConfiguration
 from bugsnag.client import Client
@@ -97,6 +98,25 @@ def auto_notify(exception, **options):
             }),
             **options
         )
+
+
+def auto_notify_exc_info(exc_info=None, **options):
+    """
+    Notify bugsnag of a exc_info tuple if auto_notify is enabled
+    """
+    if configuration.auto_notify:
+        info = exc_info or sys.exc_info()
+        if info is not None:
+            exc_type, value, tb = info
+            default_client.notify_exc_info(
+                exc_type, value, tb,
+                unhandled=options.pop('unhandled', True),
+                severity=options.pop('severity', 'error'),
+                severity_reason=options.pop('severity_reason', {
+                    'type': 'unhandledException'
+                }),
+                **options
+            )
 
 
 def before_notify(callback):

--- a/tests/fixtures/django1/notes/urls.py
+++ b/tests/fixtures/django1/notes/urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import url
+from . import views
+
+urlpatterns = [
+    url(r'^$', views.index),
+    url(r'unhandled-crash/', views.unhandled_crash, name='crash'),
+    url(r'unhandled-template-crash/',
+        views.unhandled_crash_in_template),
+    url(r'handled-exception/', views.handle_notify),
+    url(r'handled-exception-custom/', views.handle_notify_custom_info),
+]

--- a/tests/fixtures/django1/todo/urls.py
+++ b/tests/fixtures/django1/todo/urls.py
@@ -1,11 +1,16 @@
-from django.conf.urls import url
-from notes import views
+from django.conf.urls import include, url
+from django.http import HttpResponseNotFound
 
 urlpatterns = [
-    url(r'^$', views.index),
-    url(r'^notes/unhandled-crash/$', views.unhandled_crash, name='crash'),
-    url(r'^notes/unhandled-template-crash/$',
-        views.unhandled_crash_in_template),
-    url(r'^notes/handled-exception/$', views.handle_notify),
-    url(r'^notes/handled-exception-custom/$', views.handle_notify_custom_info),
+    url(r'^notes/', include('notes.urls'))
 ]
+
+
+def handler404(request, *args, **kwargs):
+    if 'poorly-handled-404' in request.path:
+        raise Exception('nah')
+
+    response = HttpResponseNotFound('Terrible happenings!',
+                                    content_type='text/plain')
+    response.status_code = 404
+    return response

--- a/tests/fixtures/django30/todo/urls.py
+++ b/tests/fixtures/django30/todo/urls.py
@@ -6,11 +6,11 @@ urlpatterns = [
 ]
 
 
-def handler404(request, exception):
+def handler404(request, *args, **kwargs):
     if 'poorly-handled-404' in request.path:
         raise Exception('nah')
 
-    response = HttpResponseNotFound(b'Terrible happenings!',
+    response = HttpResponseNotFound('Terrible happenings!',
                                     content_type='text/plain')
     response.status_code = 404
     return response

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -242,7 +242,7 @@ def test_report_error_from_http404handler(bugsnag_server, django_client):
     exception = event['exceptions'][0]
 
     assert payload['apiKey'] == 'a05afff2bd2ffaf0ab0f52715bbdcffd'
-    assert event['context'] == 'crash'
+    assert event['context'] == 'GET /notes/poorly-handled-404'
     assert event['severityReason'] == {
         'type': 'unhandledExceptionMiddleware',
         'attributes':  {'framework': 'Django'}
@@ -261,16 +261,16 @@ def test_report_error_from_http404handler(bugsnag_server, django_client):
     assert exception['stacktrace'][0] == {
         'method': 'handler404',
         'file': 'todo/urls.py',
-        'lineNumber': 10,
+        'lineNumber': 11,
         'inProject': True,
         'code': {
-            '7': '',
-            '8': 'def handler404(request, exception):',
-            '9': "    if request.path == '/notes/poorly-handled-404':",
-            '10': "         raise Exception('nah')",
-            '11': '',
-            '12': "    response = HttpResponseNotFound('Terrible happenings!',",  # noqa: E501
-            '13': "                                    content_type='text/plain')",  # noqa: E501
+            '8': '',
+            '9': 'def handler404(request, *args, **kwargs):',
+            '10': "    if 'poorly-handled-404' in request.path:",
+            '11': "        raise Exception('nah')",
+            '12': '',
+            '13': "    response = HttpResponseNotFound('Terrible happenings!',",  # noqa: E501
+            '14': "                                    content_type='text/plain')",  # noqa: E501
         },
     }
 

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -231,7 +231,6 @@ def test_ignores_http404(bugsnag_server, django_client):
     assert len(bugsnag_server.received) == 0
 
 
-@pytest.mark.skip(reason="not currently working correctly")
 def test_report_error_from_http404handler(bugsnag_server, django_client):
     with pytest.raises(Exception):
         django_client.get('/notes/poorly-handled-404')


### PR DESCRIPTION
Some errors were not be reported, like crashes in [error handlers](https://docs.djangoproject.com/en/3.1/topics/http/urls/#error-handling) and others outside of the middleware chain. This change captures those events.

## Changeset

* Subscribe to the `got_request_exception` signal from within the middleware configuration
* Add auto notify hook for `exc_info` tuples

## Testing

* Enabled existing tests for a crashing custom handler