### PR TITLE
remove obsolete imports / deps

### DIFF
--- a/bugsnag/celery/__init__.py
+++ b/bugsnag/celery/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 import celery
 from celery.signals import task_failure
 import bugsnag

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 import platform
 import socket

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -1,13 +1,7 @@
 import os
 import platform
 import socket
-try:
-    import sysconfig
-
-    def get_python_lib(): sysconfig.get_path('purelib')
-except ImportError:
-    # Compatibility with Python 2.6
-    from distutils.sysconfig import get_python_lib
+import sysconfig
 import warnings
 
 from bugsnag.sessiontracker import SessionMiddleware
@@ -65,7 +59,7 @@ class Configuration(_BaseConfiguration):
         self.send_environment = True
         self.asynchronous = True
         self.delivery = create_default_delivery()
-        self.lib_root = get_python_lib()
+        self.lib_root = sysconfig.get_path('purelib')
         self.project_root = os.getcwd()
         self.app_type = None
         self.app_version = None

--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -5,7 +5,7 @@ import warnings
 
 from time import strftime, gmtime
 
-from six.moves.urllib.request import (
+from urllib.request import (
     Request,
     ProxyHandler,
     build_opener

--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -1,4 +1,3 @@
-import six
 import django
 from django.conf import settings
 from django.core.signals import request_started, got_request_exception
@@ -42,7 +41,7 @@ def add_django_request_to_notification(notification):
             try:
                 name = request.user.get_full_name()
                 email = getattr(request.user, 'email', None)
-                username = six.text_type(request.user.get_username())
+                username = str(request.user.get_username())
                 notification.set_user(id=username, email=email, name=name)
             except Exception:
                 bugsnag.logger.exception('Could not get user data')

--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 import six
 import django
 from django.conf import settings

--- a/bugsnag/django/middleware.py
+++ b/bugsnag/django/middleware.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:

--- a/bugsnag/django/utils.py
+++ b/bugsnag/django/utils.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, absolute_import
-
-
 class MiddlewareMixin(object):
     def __init__(self, get_response=None):
         super(MiddlewareMixin, self).__init__()

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 import logging
 
 import bugsnag

--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import linecache
 import logging
 import os

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from copy import deepcopy
 from uuid import uuid4
 from time import strftime, gmtime

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -1,7 +1,7 @@
 import tornado
 from tornado.web import RequestHandler
 from tornado.web import HTTPError
-from six.moves import urllib
+from urllib.parse import parse_qs
 from bugsnag.utils import is_json_content_type
 import bugsnag
 import json
@@ -15,7 +15,7 @@ class BugsnagRequestHandler(RequestHandler):
         request_tab = {
             'method': self.request.method,
             'path': self.request.path,
-            'GET': urllib.parse.parse_qs(self.request.query),
+            'GET': parse_qs(self.request.query),
             'POST': {},
             'url': self.request.full_url(),
         }

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 from functools import wraps, partial
 import inspect
 import six

--- a/bugsnag/wsgi/__init__.py
+++ b/bugsnag/wsgi/__init__.py
@@ -1,5 +1,5 @@
-from six.moves import urllib
+from urllib.parse import quote
 
 
 def request_path(env):
-    return urllib.parse.quote('/' + env.get('PATH_INFO', '').lstrip('/'))
+    return quote('/' + env.get('PATH_INFO', '').lstrip('/'))

--- a/example/celery+django/celery_django/__init__.py
+++ b/example/celery+django/celery_django/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, unicode_literals
 from .celery import app as celery_app
 
 __all__ = ['celery_app']

--- a/example/celery+django/celery_django/celery.py
+++ b/example/celery+django/celery_django/celery.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, unicode_literals
 import os
 from celery import Celery
 import bugsnag

--- a/example/celery+django/demo/tasks.py
+++ b/example/celery+django/demo/tasks.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, unicode_literals
 from celery import shared_task
 import bugsnag
 

--- a/example/celery+django/requirements.txt
+++ b/example/celery+django/requirements.txt
@@ -7,6 +7,5 @@ kombu==4.1.0
 Markdown==2.6.8
 pytz==2017.2
 redis==2.10.6
-six==1.10.0
 vine==1.1.4
 WebOb==1.7.3

--- a/example/flask/requirements.txt
+++ b/example/flask/requirements.txt
@@ -5,6 +5,5 @@ Flask==1.1.2
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
-six==1.15.0
 WebOb==1.8.6
 Werkzeug==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'Topic :: Software Development'
     ],
     test_suite='tests',
-    install_requires=['webob', 'six>=1.9,<2'],
+    install_requires=['webob'],
     extras_require={
         'flask': ['flask', 'blinker']
     },

--- a/tests/integrations/test_wsgi.py
+++ b/tests/integrations/test_wsgi.py
@@ -1,7 +1,6 @@
 from webtest import TestApp
 
 from bugsnag.wsgi.middleware import BugsnagMiddleware
-from six import Iterator
 import bugsnag.notification
 import bugsnag
 from tests.utils import IntegrationTest
@@ -67,7 +66,7 @@ class TestWSGI(IntegrationTest):
         assert 'environment' not in payload['events'][0]['metaData']
 
     def test_bugsnag_middleware_crash_on_iter(self):
-        class CrashOnIterApp(Iterator):
+        class CrashOnIterApp:
             def __init__(self, environ, start_response):
                 pass
 
@@ -86,7 +85,7 @@ class TestWSGI(IntegrationTest):
         self.assertEqual(environ['PATH_INFO'], '/beans')
 
     def test_bugsnag_middleware_crash_on_close(self):
-        class CrashOnCloseApp(Iterator):
+        class CrashOnCloseApp:
             def __init__(self, environ, start_response):
                 pass
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,8 +1,6 @@
 from functools import wraps
 import logging
 
-from six import u
-
 from bugsnag.handlers import BugsnagHandler
 from bugsnag import Client
 import bugsnag
@@ -73,7 +71,7 @@ class HandlersTest(IntegrationTest):
         self.assertEqual('error', event['severity'])
         self.assertEqual(logging.CRITICAL,
                          event['metaData']['extra data']['levelno'])
-        self.assertEqual(u('CRITICAL'),
+        self.assertEqual('CRITICAL',
                          event['metaData']['extra data']['levelname'])
 
     def test_severity_error(self):
@@ -93,7 +91,7 @@ class HandlersTest(IntegrationTest):
         self.assertEqual('error', event['severity'])
         self.assertEqual(logging.ERROR,
                          event['metaData']['extra data']['levelno'])
-        self.assertEqual(u('ERROR'),
+        self.assertEqual('ERROR',
                          event['metaData']['extra data']['levelname'])
 
     def test_severity_warning(self):
@@ -112,7 +110,7 @@ class HandlersTest(IntegrationTest):
         self.assertEqual('warning', event['severity'])
         self.assertEqual(logging.WARNING,
                          event['metaData']['extra data']['levelno'])
-        self.assertEqual(u('WARNING'),
+        self.assertEqual('WARNING',
                          event['metaData']['extra data']['levelname'])
 
     def test_severity_info(self):
@@ -132,7 +130,7 @@ class HandlersTest(IntegrationTest):
         self.assertEqual('info', event['severity'])
         self.assertEqual(logging.INFO,
                          event['metaData']['extra data']['levelno'])
-        self.assertEqual(u('INFO'),
+        self.assertEqual('INFO',
                          event['metaData']['extra data']['levelname'])
 
     def test_levelname_message(self):
@@ -266,7 +264,7 @@ class HandlersTest(IntegrationTest):
         self.assertEqual('error', event['severity'])
         self.assertEqual(logging.CRITICAL,
                          event['metaData']['extra data']['levelno'])
-        self.assertEqual(u('CRITICAL'),
+        self.assertEqual('CRITICAL',
                          event['metaData']['extra data']['levelname'])
 
     @use_client_logger
@@ -283,7 +281,7 @@ class HandlersTest(IntegrationTest):
         self.assertEqual('error', event['severity'])
         self.assertEqual(logging.ERROR,
                          event['metaData']['extra data']['levelno'])
-        self.assertEqual(u('ERROR'),
+        self.assertEqual('ERROR',
                          event['metaData']['extra data']['levelname'])
 
     @use_client_logger
@@ -299,7 +297,7 @@ class HandlersTest(IntegrationTest):
         self.assertEqual('warning', event['severity'])
         self.assertEqual(logging.WARNING,
                          event['metaData']['extra data']['levelno'])
-        self.assertEqual(u('WARNING'),
+        self.assertEqual('WARNING',
                          event['metaData']['extra data']['levelname'])
 
     @use_client_logger
@@ -315,7 +313,7 @@ class HandlersTest(IntegrationTest):
         self.assertEqual('info', event['severity'])
         self.assertEqual(logging.INFO,
                          event['metaData']['extra data']['levelno'])
-        self.assertEqual(u('INFO'),
+        self.assertEqual('INFO',
                          event['metaData']['extra data']['levelname'])
 
     @use_client_logger

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -3,8 +3,6 @@
 import sys
 import time
 
-from six import u
-
 import bugsnag
 from tests.utils import ScaryException, IntegrationTest
 from tests.fixtures import samples
@@ -176,7 +174,7 @@ class TestBugsnag(IntegrationTest):
 
         self.assertEqual(4, event['metaData']['custom']['foo'])
         self.assertEqual('[FILTERED]', event['metaData']['custom']['bar'])
-        self.assertEqual(171, exception['stacktrace'][0]['lineNumber'])
+        self.assertEqual(169, exception['stacktrace'][0]['lineNumber'])
 
     def test_notify_ignore_class(self):
         bugsnag.configure(ignore_classes=['tests.utils.ScaryException'])
@@ -444,7 +442,7 @@ class TestBugsnag(IntegrationTest):
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual(1, len(self.server.received))
-        self.assertEqual(u("RuntimeError"), exception['errorClass'])
+        self.assertEqual("RuntimeError", exception['errorClass'])
 
     def test_notify_metadata_set_value(self):
         bugsnag.notify(ScaryException('unexpected failover'),
@@ -474,25 +472,25 @@ class TestBugsnag(IntegrationTest):
         self.assertEqual(-13, event['metaData']['custom']['value2'])
 
     def test_notify_error_message(self):
-        bugsnag.notify(ScaryException(u('unexpécted failover')))
+        bugsnag.notify(ScaryException('unexpécted failover'))
         json_body = self.server.received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
-        self.assertEqual(u('unexpécted failover'), exception['message'])
+        self.assertEqual('unexpécted failover', exception['message'])
 
     def test_notify_unicode_metadata(self):
-        bins = (u('\x98\x00\x00\x00\t\x81\x19\x1b\x00\x00\x00\x00\xd4\x07\x00'
-                  '\x00\x00\x00\x00\x00R\x00\x00\x00\x00\x00\xff\xff\xff\xffe'
-                  '\x00\x00\x00\x02project\x00%\x00\x00\x00f65f051b-d762-5983'
-                  '-838b-a05aadc06a5\x00\x02uid\x00%\x00\x00\x001bab969f-7b30'
-                  '-459a-adee-917b9e028eed\x00\x00'))
+        bins = ('\x98\x00\x00\x00\t\x81\x19\x1b\x00\x00\x00\x00\xd4\x07\x00'
+                '\x00\x00\x00\x00\x00R\x00\x00\x00\x00\x00\xff\xff\xff\xffe'
+                '\x00\x00\x00\x02project\x00%\x00\x00\x00f65f051b-d762-5983'
+                '-838b-a05aadc06a5\x00\x02uid\x00%\x00\x00\x001bab969f-7b30'
+                '-459a-adee-917b9e028eed\x00\x00')
         self_class = 'tests.test_notify.TestBugsnag'
         bugsnag.notify(Exception('free food'), meta_data={'payload': {
-            'project': u('∆πåß∂ƒ'),
-            'filename': u('DISPOSITIFS DE SÉCURITÉ.pdf'),
-            u('♥♥i'): u('♥♥♥♥♥♥'),
-            'src_name': u('☻☻☻☻☻ RDC DISPOSITIFS DE SÉCURTÉ.pdf'),
-            u('accénted'): u('☘☘☘éééé@me.com'),
+            'project': '∆πåß∂ƒ',
+            'filename': 'DISPOSITIFS DE SÉCURITÉ.pdf',
+            '♥♥i': '♥♥♥♥♥♥',
+            'src_name': '☻☻☻☻☻ RDC DISPOSITIFS DE SÉCURTÉ.pdf',
+            'accénted': '☘☘☘éééé@me.com',
             'class': self.__class__,
             'another_class': dict,
             'self': self,
@@ -500,15 +498,15 @@ class TestBugsnag(IntegrationTest):
         }})
         json_body = self.server.received[0]['json_body']
         event = json_body['events'][0]
-        self.assertEqual(u('∆πåß∂ƒ'), event['metaData']['payload']['project'])
-        self.assertEqual(u('♥♥♥♥♥♥'),
-                         event['metaData']['payload'][u('♥♥i')])
-        self.assertEqual(u('DISPOSITIFS DE SÉCURITÉ.pdf'),
+        self.assertEqual('∆πåß∂ƒ', event['metaData']['payload']['project'])
+        self.assertEqual('♥♥♥♥♥♥',
+                         event['metaData']['payload']['♥♥i'])
+        self.assertEqual('DISPOSITIFS DE SÉCURITÉ.pdf',
                          event['metaData']['payload']['filename'])
-        self.assertEqual(u('☻☻☻☻☻ RDC DISPOSITIFS DE SÉCURTÉ.pdf'),
+        self.assertEqual('☻☻☻☻☻ RDC DISPOSITIFS DE SÉCURTÉ.pdf',
                          event['metaData']['payload']['src_name'])
-        self.assertEqual(u('☘☘☘éééé@me.com'),
-                         event['metaData']['payload'][u('accénted')])
+        self.assertEqual('☘☘☘éééé@me.com',
+                         event['metaData']['payload']['accénted'])
         self.assertEqual('test_notify_unicode_metadata (%s)' % self_class,
                          event['metaData']['payload']['self'])
         self.assertEqual(bins, event['metaData']['payload']['var'])

--- a/tests/test_path_encoding.py
+++ b/tests/test_path_encoding.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 import unittest
-from six.moves import urllib
+from urllib.parse import quote
 
 from bugsnag.notification import Notification
 from bugsnag.configuration import (Configuration, RequestConfiguration)
@@ -62,7 +62,7 @@ class PathEncodingTest(unittest.TestCase):
         # differs on different Python versions because of how they handle
         # invalid encoding sequences
         self.assertEqual(
-            'http://localhost/%s' % urllib.parse.quote('%83'),
+            'http://localhost/%s' % quote('%83'),
             notification.meta_data['request']['url']
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ import sys
 import datetime
 import re
 
-from six import u, PY3 as is_py3
 from bugsnag.utils import (SanitizingJSONEncoder, FilterDict, ThreadLocals,
                            is_json_content_type, parse_content_type,
                            ThreadContextVar, merge_dicts)
@@ -36,7 +35,7 @@ class TestUtils(unittest.TestCase):
                                      "passwords": "[FILTERED]"})
 
     def test_sanitize_valid_unicode_object(self):
-        data = {"item": u('\U0001f62c')}
+        data = {"item": '\U0001f62c'}
         encoder = SanitizingJSONEncoder(keyword_filters=[])
         sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data, data)
@@ -49,7 +48,7 @@ class TestUtils(unittest.TestCase):
                          {"metadata": {"another_password": "[FILTERED]"}})
 
     def test_sanitize_bad_utf8_object(self):
-        data = {"bad_utf8": u("test \xe9")}
+        data = {"bad_utf8": "test \xe9"}
         encoder = SanitizingJSONEncoder(keyword_filters=[])
         sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data, data)
@@ -61,8 +60,8 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(sane_data, {"exc": ""})
 
     def test_json_encode(self):
-        payload = {"a": u("a") * 512 * 1024}
-        expected = {"a": u("a") * 1024}
+        payload = {"a": "a" * 512 * 1024}
+        expected = {"a": "a" * 1024}
         encoder = SanitizingJSONEncoder(keyword_filters=[])
         self.assertEqual(json.loads(encoder.encode(payload)), expected)
 
@@ -74,9 +73,6 @@ class TestUtils(unittest.TestCase):
                          {"metadata": {"another_password": "[FILTERED]"}})
 
     def test_decode_bytes(self):
-        if not is_py3:
-            return
-
         data = FilterDict({b"metadata": "value"})
         encoder = SanitizingJSONEncoder(keyword_filters=["password"])
         sane_data = json.loads(encoder.encode(data))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ import time
 import unittest
 from threading import Thread
 
-from six.moves import BaseHTTPServer
+from http.server import SimpleHTTPRequestHandler, HTTPServer
 
 import bugsnag
 
@@ -52,7 +52,7 @@ class FakeBugsnagServer(object):
         self.received = []
         self.paused = False
 
-        class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
+        class Handler(SimpleHTTPRequestHandler):
 
             def do_POST(handler):
                 start = time.time()
@@ -77,7 +77,7 @@ class FakeBugsnagServer(object):
             def log_request(self, *args):
                 pass
 
-        self.server = BaseHTTPServer.HTTPServer(('localhost', 0), Handler)
+        self.server = HTTPServer(('localhost', 0), Handler)
         self.server.timeout = 0.5
         self.thread = Thread(target=self.server.serve_forever, args=(0.1,))
         self.thread.daemon = True


### PR DESCRIPTION
Removing 2.6/2.7 support means the following bits are no longer required:

* `__future__` imports for print, division, etc
* six
* distutils