### PR TITLE
ci: speed up test runs by running envs in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ develop-eggs
 pip-log.txt
 
 # Unit test / coverage reports
-.coverage
+.coverage*
 .tox
 htmlcov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ install:
   - travis_retry pip install coveralls tox tox-factor
 
 script:
-  - tox
+  - tox --parallel
 
 after_success:
+  - coverage combine
   - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ addopts   = --cov=bugsnag --cov-report html --cov-append --cov-report term
 passenv = TRAVIS TRAVIS_*
 setenv  =
     PYTHONPATH = {toxinidir}
+    COVERAGE_FILE=.coverage.{envname}
     django{18,19,110,111,20,21,22}: PYTHONPATH=tests/fixtures/django1{:}{toxinidir}
     django3: PYTHONPATH=tests/fixtures/django30{:}{toxinidir}
     !celery: DJANGO_SETTINGS_MODULE=todo.settings


### PR DESCRIPTION
Shaves 90-130 seconds per job

* requires `coverage combine` after runs to get a local coverage report