### PR TITLE
refactor(utils): remove unneeded ThreadLocals API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Please upgrade.
 * Removed `Configuration.use_ssl` and `Configuration.get_endpoint()` in favor of
   including the protocol in `Configuration.endpoint`
 
+* Removed `bugsnag.utils.ThreadLocals` as it has been superseded by the
+  `contextvars` API
 
 
 ## 3.9.0 (2020-08-27)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -14,6 +14,10 @@ The properties deprecated in the 3.0.0 release have been removed. See the below
 guide for migrating from 2.x to 3.x to remove use of `get_endpoint()` and
 `use_ssl`.
 
+### Remove unused utilities
+
+* Removed `bugsnag.utils.ThreadLocals` as it has been superseded by the
+  `contextvars` API
 
 ## Migrating from 2.x to 3.x
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import sys
 import datetime
 import re
 
-from bugsnag.utils import (SanitizingJSONEncoder, FilterDict, ThreadLocals,
+from bugsnag.utils import (SanitizingJSONEncoder, FilterDict,
                            is_json_content_type, parse_content_type,
                            ThreadContextVar, merge_dicts)
 
@@ -13,7 +13,6 @@ from bugsnag.utils import (SanitizingJSONEncoder, FilterDict, ThreadLocals,
 class TestUtils(unittest.TestCase):
     def tearDown(self):
         super(TestUtils, self).tearDown()
-        ThreadLocals.LOCALS = None
 
     def test_encode_filters(self):
         data = FilterDict({"credit_card": "123213213123", "password": "456",
@@ -83,20 +82,6 @@ class TestUtils(unittest.TestCase):
         encoder = SanitizingJSONEncoder(keyword_filters=["password"])
         sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data, data)
-
-    def test_thread_locals(self):
-        key = "TEST_THREAD_LOCALS"
-        val = {"Test": "Thread", "Locals": "Here"}
-        locs = ThreadLocals.get_instance()
-        self.assertFalse(locs.has_item(key))
-        locs.set_item(key, val)
-        self.assertTrue(locs.has_item(key))
-        item = locs.get_item(key)
-        self.assertEqual(item, val)
-        locs.del_item(key)
-        self.assertFalse(locs.has_item(key))
-        item = locs.get_item(key, "default")
-        self.assertEqual(item, "default")
 
     def test_thread_context_vars_default(self):
         token = ThreadContextVar("TEST_contextvars")


### PR DESCRIPTION
This utility class was superseded by the `contextvars` wrapper and as such is no longer needed separately.