### PR TITLE
Separate configuration from per-request data

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,6 +20,18 @@ guide for migrating from 2.x to 3.x to remove use of `get_endpoint()` and
   `contextvars` API
 * Removed `bugsnag.utils.merge_dicts`
 
+### Configuration validation
+
+* Setting unknown properties on `Configuration` via `configure(**kwargs)` is no
+longer supported and will cause an error.
+* `Configuration.get('{propname}')` is deprecated in favor of accessing
+  configuration properties directly
+
+  ```diff+py
+  - config.get('release_stage')
+  + config.release_stage
+  ```
+
 ## Migrating from 2.x to 3.x
 
 A few configuration properties were deprecated in the transition from 2.x to

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -24,28 +24,7 @@ except ImportError:
 __all__ = ('Configuration', 'RequestConfiguration')
 
 
-class _BaseConfiguration(object):
-    def get(self, name, overrides=None):
-        """
-        Get a single configuration option, using values from overrides
-        first if they exist.
-        """
-        if overrides:
-            return overrides.get(name, getattr(self, name))
-        else:
-            return getattr(self, name)
-
-    def configure(self, **options):
-        """
-        Set one or more configuration settings.
-        """
-        for name, value in options.items():
-            setattr(self, name, value)
-
-        return self
-
-
-class Configuration(_BaseConfiguration):
+class Configuration:
     """
     Global app-level Bugsnag configuration settings.
     """
@@ -90,31 +69,68 @@ class Configuration(_BaseConfiguration):
 
         self.runtime_versions = {"python": platform.python_version()}
 
-    def configure(self, **options):
+    def configure(self, api_key=None, app_type=None, app_version=None,
+                  asynchronous=None, auto_notify=None,
+                  auto_capture_sessions=None, delivery=None, endpoint=None,
+                  hostname=None, ignore_classes=None, lib_root=None,
+                  notify_release_stages=None, params_filters=None,
+                  project_root=None, proxy_host=None, release_stage=None,
+                  send_code=None, send_environment=None, session_endpoint=None,
+                  traceback_exclude_modules=None):
         """
         Validate and set configuration options. Will warn if an option is of an
         incorrect type.
         """
-        # Overrides the default implementation to provide warnings for unknown
-        # options. In the __future__ this will not be necessary by instead
-        # making configure() enumerate all of the options as kwargs rather than
-        # allowing arbitrary input.
-        configurable_options = [
-            'api_key', 'app_version', 'asynchronous', 'auto_notify',
-            'auto_capture_sessions', 'delivery', 'endpoint', 'hostname',
-            'ignore_classes', 'lib_root', 'notify_release_stages',
-            'params_filters', 'project_root', 'proxy_host', 'release_stage',
-            'send_code', 'session_endpoint', 'traceback_exclude_modules',
-            'app_type', 'send_environment',
-        ]
-
-        for option_name in options.keys():
-            if option_name not in configurable_options:
-                message = 'received unknown configuration option "{0}"'
-                warnings.warn(message.format(option_name), RuntimeWarning)
-            setattr(self, option_name, options.get(option_name))
-
+        if api_key is not None:
+            self.api_key = api_key
+        if app_type is not None:
+            self.app_type = app_type
+        if app_version is not None:
+            self.app_version = app_version
+        if asynchronous is not None:
+            self.asynchronous = asynchronous
+        if auto_notify is not None:
+            self.auto_notify = auto_notify
+        if auto_capture_sessions is not None:
+            self.auto_capture_sessions = auto_capture_sessions
+        if delivery is not None:
+            self.delivery = delivery
+        if endpoint is not None:
+            self.endpoint = endpoint
+        if hostname is not None:
+            self.hostname = hostname
+        if ignore_classes is not None:
+            self.ignore_classes = ignore_classes
+        if lib_root is not None:
+            self.lib_root = lib_root
+        if notify_release_stages is not None:
+            self.notify_release_stages = notify_release_stages
+        if params_filters is not None:
+            self.params_filters = params_filters
+        if project_root is not None:
+            self.project_root = project_root
+        if proxy_host is not None:
+            self.proxy_host = proxy_host
+        if release_stage is not None:
+            self.release_stage = release_stage
+        if send_code is not None:
+            self.send_code = send_code
+        if send_environment is not None:
+            self.send_environment = send_environment
+        if session_endpoint is not None:
+            self.session_endpoint = session_endpoint
+        if traceback_exclude_modules is not None:
+            self.traceback_exclude_modules = traceback_exclude_modules
         return self
+
+    def get(self, name):
+        """
+        Get a single configuration option
+        """
+        warnings.warn('Using get() to retrieve a Configuration property is ' +
+                      'deprecated in favor of referencing properties directly',
+                      DeprecationWarning)
+        return getattr(self, name)
 
     @property
     def api_key(self):
@@ -400,7 +416,7 @@ class Configuration(_BaseConfiguration):
             fully_qualified_class_name(exception) in self.ignore_classes
 
 
-class RequestConfiguration(_BaseConfiguration):
+class RequestConfiguration:
     """
     Per-request Bugsnag configuration settings.
     """
@@ -441,3 +457,18 @@ class RequestConfiguration(_BaseConfiguration):
         self.request_data = {}
         self.environment_data = {}
         self.session_data = {}
+
+    def get(self, name):
+        """
+        Get a single configuration option
+        """
+        return getattr(self, name)
+
+    def configure(self, **options):
+        """
+        Set one or more configuration settings.
+        """
+        for name, value in options.items():
+            setattr(self, name, value)
+
+        return self

--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -91,7 +91,7 @@ class UrllibDelivery(Delivery):
             uri = options.pop('endpoint', config.endpoint)
             if '://' not in uri:
                 uri = ('https://{}' % uri)
-            api_key = json.loads(payload).pop('apiKey', config.get('api_key'))
+            api_key = json.loads(payload).pop('apiKey', config.api_key)
             req = Request(uri,
                           payload.encode('utf-8', 'replace'),
                           default_headers(api_key))
@@ -129,7 +129,7 @@ class RequestsDelivery(Delivery):
             if '://' not in uri:
                 uri = ('https://{}' % uri)
 
-            api_key = json.loads(payload).pop('apiKey', config.get('api_key'))
+            api_key = json.loads(payload).pop('apiKey', config.api_key)
             req_options = {'data': payload,
                            'headers': default_headers(api_key)}
 

--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -44,7 +44,7 @@ class Notification(object):
         self.request_config = request_config
 
         def get_config(key):
-            return options.pop(key, self.config.get(key))
+            return options.pop(key, getattr(self.config, key))
 
         self.release_stage = get_config("release_stage")
         self.app_version = get_config("app_version")
@@ -128,7 +128,7 @@ class Notification(object):
         bugsnag_module_path = os.path.dirname(bugsnag.__file__)
         logging_module_path = os.path.dirname(logging.__file__)
         exclude_module_paths = [bugsnag_module_path, logging_module_path]
-        user_exclude_modules = self.config.get("traceback_exclude_modules")
+        user_exclude_modules = self.config.traceback_exclude_modules
         for exclude_module in user_exclude_modules:
             try:
                 module_file = exclude_module.__file__
@@ -139,11 +139,11 @@ class Notification(object):
                 bugsnag.logger.exception(
                     'Could not exclude module: %s' % repr(exclude_module))
 
-        lib_root = self.config.get("lib_root")
+        lib_root = self.config.lib_root
         if lib_root and lib_root[-1] != os.sep:
             lib_root += os.sep
 
-        project_root = self.config.get("project_root")
+        project_root = self.config.project_root
         if project_root and project_root[-1] != os.sep:
             project_root += os.sep
 
@@ -248,8 +248,8 @@ class Notification(object):
                     "hostname": self.hostname,
                     "runtimeVersions": self.runtime_versions
                 }),
-                "projectRoot": self.config.get("project_root"),
-                "libRoot": self.config.get("lib_root"),
+                "projectRoot": self.config.project_root,
+                "libRoot": self.config.lib_root,
                 "session": self.session
             }]
         })

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -112,12 +112,12 @@ class SessionTracker(object):
                 'version': notifier_version
             },
             'device': FilterDict({
-                'hostname': self.config.get('hostname'),
-                'runtimeVersions': self.config.get('runtime_versions')
+                'hostname': self.config.hostname,
+                'runtimeVersions': self.config.runtime_versions
             }),
             'app': {
-                'releaseStage': self.config.get('release_stage'),
-                'version': self.config.get('app_version')
+                'releaseStage': self.config.release_stage,
+                'version': self.config.app_version
             },
             'sessionCounts': sessions
         }

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -376,8 +376,5 @@ class TestConfiguration(unittest.TestCase):
 
     def test_validate_unknown_config_option(self):
         c = Configuration()
-        with pytest.warns(RuntimeWarning) as record:
+        with pytest.raises(TypeError):
             c.configure(emperor=True)
-            assert len(record) == 1
-            assert (str(record[0].message) ==
-                    'received unknown configuration option "emperor"')

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -66,33 +66,22 @@ class TestConfiguration(unittest.TestCase):
 
     def test_validate_api_key(self):
         c = Configuration()
-        with pytest.warns(RuntimeWarning) as record:
+        with pytest.raises(TypeError) as e:
             c.configure(api_key=[])
-
-            assert len(record) == 1
-            assert (str(record[0].message) ==
-                    'api_key should be str, got list. ' +
-                    'This will be an error in a future release.')
-            c.configure(api_key='ffff')
-
-            assert len(record) == 1
-            assert c.api_key == 'ffff'
+            assert str(e) == 'api_key should be str, got list.'
+        c.configure(api_key='ffff')
+        assert c.api_key == 'ffff'
 
     def test_validate_endpoint(self):
         c = Configuration()
-        with pytest.warns(RuntimeWarning) as record:
+        with pytest.raises(TypeError) as e:
             c.configure(endpoint=56)
 
-            assert len(record) == 1
-            assert (str(record[0].message) ==
-                    'endpoint should be str, got int. ' +
-                    'This will be an error in a future release.')
+            assert str(e) == 'endpoint should be str, got int. '
             assert c.endpoint == 'https://notify.bugsnag.com'
 
-            c.configure(endpoint='https://notify.example.com')
-
-            assert len(record) == 1
-            assert c.endpoint == 'https://notify.example.com'
+        c.configure(endpoint='https://notify.example.com')
+        assert c.endpoint == 'https://notify.example.com'
 
     def test_validate_app_type(self):
         c = Configuration()
@@ -344,19 +333,14 @@ class TestConfiguration(unittest.TestCase):
 
     def test_validate_session_endpoint(self):
         c = Configuration()
-        with pytest.warns(RuntimeWarning) as record:
+        with pytest.raises(TypeError) as e:
             c.configure(session_endpoint=False)
 
-            assert len(record) == 1
-            assert (str(record[0].message) ==
-                    'session_endpoint should be str, got bool. This will be' +
-                    ' an error in a future release.')
+            assert str(e) == 'session_endpoint should be str, got bool.'
             assert c.session_endpoint == 'https://sessions.bugsnag.com'
 
-            c.configure(session_endpoint='https://sessions.example.com')
-
-            assert len(record) == 1
-            assert c.session_endpoint == 'https://sessions.example.com'
+        c.configure(session_endpoint='https://sessions.example.com')
+        assert c.session_endpoint == 'https://sessions.example.com'
 
     def test_validate_traceback_exclude_modules(self):
         c = Configuration()

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -182,7 +182,8 @@ class TestBugsnag(IntegrationTest):
         self.assertEqual(0, len(self.server.received))
 
     def test_notify_configured_invalid_api_key(self):
-        bugsnag.configure(api_key=None)
+        config = bugsnag.configure()
+        config.api_key = None
         bugsnag.notify(ScaryException('unexpected failover'))
         self.assertEqual(0, len(self.server.received))
 

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -62,15 +62,15 @@ class TestConfiguration(IntegrationTest):
         app = json_body['app']
         self.assertTrue('releaseStage' in app)
         self.assertEqual(app['releaseStage'],
-                         client.configuration.get('release_stage'))
+                         client.configuration.release_stage)
         self.assertTrue('version' in app)
         self.assertEqual(app['version'],
-                         client.configuration.get('app_version'))
+                         client.configuration.app_version)
         # Device properties
         device = json_body['device']
         self.assertTrue('hostname' in device)
         self.assertEqual(device['hostname'],
-                         client.configuration.get('hostname'))
+                         client.configuration.hostname)
         self.assertTrue('runtimeVersions' in device)
         self.assertEqual(device['runtimeVersions']['python'],
                          platform.python_version())


### PR DESCRIPTION
Updated the class hierarchy of `Configuration` and `RequestConfiguration` to not share a base class, as they are used in different ways. This allows for stricter validation on `Configuration.configure()` while keeping `RequestConfiguration` open-ended.

Since `Configuration` options are registered as properties, this change also deprecates the `get()` accessor in favor of accessing the properties by name directly.

Included a small change to make required config properties raise `TypeError` for invalid values passed to setters.