### PR TITLE
refactor: disable send_environment by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Please upgrade.
 
 * Removed `Configuration.use_ssl` and `Configuration.get_endpoint()` in favor of
   including the protocol in `Configuration.endpoint`
+* `Configuration.send_environment` is now `False` by default. Enable it as a
+  part of your configuration to send the full request context (if any) as a part
+  of each event.
 
 * Removed `bugsnag.utils.ThreadLocals` as it has been superseded by the
   `contextvars` API

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,6 +20,13 @@ guide for migrating from 2.x to 3.x to remove use of `get_endpoint()` and
   `contextvars` API
 * Removed `bugsnag.utils.merge_dicts`
 
+### Request environment configuration
+
+`Configuration.send_environment` is now disabled by default. Set
+`send_environment=True` in your configuration to enable it and send the full
+request context as a part of each event.
+
+
 ## Migrating from 2.x to 3.x
 
 A few configuration properties were deprecated in the transition from 2.x to

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -56,7 +56,7 @@ class Configuration(_BaseConfiguration):
         self.notify_release_stages = None
         self.auto_notify = True
         self.send_code = True
-        self.send_environment = True
+        self.send_environment = False
         self.asynchronous = True
         self.delivery = create_default_delivery()
         self.lib_root = sysconfig.get_path('purelib')

--- a/tests/integrations/test_async_asgi.py
+++ b/tests/integrations/test_async_asgi.py
@@ -69,22 +69,21 @@ class TestASGIMiddleware(AsyncIntegrationTest):
 
         payload = await self.last_event_request()
         request = payload['events'][0]['metaData']['request']
-        environment = payload['events'][0]['metaData']['environment']
         self.assertEqual('/', request['path'])
         self.assertEqual('GET', request['httpMethod'])
         self.assertEqual('http', request['type'])
         self.assertEqual('http://testserver/', request['url'])
         self.assertEqual('testclient', request['clientIp'])
         self.assertEqual('testclient', request['headers']['user-agent'])
-        self.assertEqual('/', environment['path'])
+        assert 'environment' not in payload['events'][0]['metaData']
 
         exception = payload['events'][0]['exceptions'][0]
         self.assertEqual('test_async_asgi.CustomException',
                          exception['errorClass'])
         self.assertEqual('forgot the map', exception['message'])
 
-    async def test_disable_environment(self):
-        bugsnag.configure(send_environment=False)
+    async def test_enable_environment(self):
+        bugsnag.configure(send_environment=True)
 
         async def app(scope, recv, send):
             raise CustomException('forgot the map')
@@ -99,7 +98,7 @@ class TestASGIMiddleware(AsyncIntegrationTest):
 
         payload = await self.last_event_request()
         metadata = payload['events'][0]['metaData']
-        assert 'environment' not in metadata
+        self.assertEqual('/', metadata['environment']['path'])
 
     async def test_custom_metadata(self):
         async def next_func():

--- a/tests/integrations/test_bottle.py
+++ b/tests/integrations/test_bottle.py
@@ -33,13 +33,12 @@ class TestBottle(IntegrationTest):
         self.assertEqual(event['context'], 'GET /beans')
         self.assertEqual(event['exceptions'][0]['errorClass'], 'Exception')
         self.assertEqual(event['exceptions'][0]['message'], 'oh no!')
-        self.assertEqual(event['metaData']['environment']['PATH_INFO'],
-                         '/beans')
         runtime_versions = event['device']['runtimeVersions']
         self.assertEqual(runtime_versions['bottle'], '0.12.18')
+        assert 'environment' not in event['metaData']
 
-    def test_disable_environment(self):
-        bugsnag.configure(send_environment=False)
+    def test_enable_environment(self):
+        bugsnag.configure(send_environment=True)
 
         @route('/beans')
         def index():
@@ -53,7 +52,7 @@ class TestBottle(IntegrationTest):
         self.assertEqual(1, len(self.server.received))
         payload = self.server.received[0]['json_body']
         metadata = payload['events'][0]['metaData']
-        assert 'environment' not in metadata
+        self.assertEqual(metadata['environment']['PATH_INFO'], '/beans')
 
     def test_template_error(self):
         @route('/berries/<variety>')
@@ -74,7 +73,6 @@ class TestBottle(IntegrationTest):
         self.assertEqual(event['exceptions'][0]['errorClass'], 'NameError')
         self.assertEqual(event['exceptions'][0]['message'],
                          "name 'type2' is not defined")
-        self.assertEqual(event['metaData']['environment']['PATH_INFO'],
-                         '/berries/red')
+        assert 'environment' not in event['metaData']
         runtime_versions = event['device']['runtimeVersions']
         self.assertEqual(runtime_versions['bottle'], bottle.__version__)

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -52,7 +52,7 @@ def test_notify(bugsnag_server, django_client):
     assert event['context'] == 'notes.views.handle_notify'
     assert event['severityReason'] == {'type': 'handledException'}
     assert event['device']['runtimeVersions']['django'] == django.__version__
-    assert event['metaData']['environment']['REQUEST_METHOD'] == 'GET'
+    assert 'environment' not in payload['events'][0]['metaData']
     assert event['metaData']['request'] == {
         'method': 'GET',
         'url': 'http://testserver/notes/handled-exception/?foo=strawberry',
@@ -81,14 +81,15 @@ def test_notify(bugsnag_server, django_client):
     }
 
 
-def test_disable_environment(bugsnag_server, django_client):
-    bugsnag.configure(send_environment=False)
+def test_enable_environment(bugsnag_server, django_client):
+    bugsnag.configure(send_environment=True)
     response = django_client.get('/notes/handled-exception/?foo=strawberry')
     assert response.status_code == 200
 
     bugsnag_server.wait_for_request()
     payload = bugsnag_server.received[0]['json_body']
-    assert 'environment' not in payload['events'][0]['metaData']
+    event = payload['events'][0]
+    assert event['metaData']['environment']['REQUEST_METHOD'] == 'GET'
 
 
 def test_notify_custom_info(bugsnag_server, django_client):

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -51,11 +51,10 @@ class TestFlask(IntegrationTest):
                          'test_flask.SentinelError')
         self.assertEqual(event['metaData']['request']['url'],
                          'http://localhost/hello')
-        self.assertEqual(event['metaData']['environment']['REMOTE_ADDR'],
-                         '127.0.0.1')
+        assert 'environment' not in event['metaData']
 
-    def test_disable_environment(self):
-        bugsnag.configure(send_environment=False)
+    def test_enable_environment(self):
+        bugsnag.configure(send_environment=True)
 
         app = Flask("bugsnag")
 
@@ -68,7 +67,9 @@ class TestFlask(IntegrationTest):
 
         self.assertEqual(1, len(self.server.received))
         payload = self.server.received[0]['json_body']
-        assert 'environment' not in payload['events'][0]['metaData']
+        event = payload['events'][0]
+        self.assertEqual(event['metaData']['environment']['REMOTE_ADDR'],
+                         '127.0.0.1')
 
     def test_bugsnag_notify(self):
         app = Flask("bugsnag")

--- a/tests/integrations/test_tornado.py
+++ b/tests/integrations/test_tornado.py
@@ -121,7 +121,6 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
         payload = self.server.received[0]['json_body']
         event = payload['events'][0]
         expectedUrl = 'http://127.0.0.1:{}/crash'.format(self.get_http_port())
-        self.assertEqual(event['metaData']['environment'], {})
         self.assertEqual(event['metaData']['request'], {
             'method': 'GET',
             'url': expectedUrl,
@@ -130,6 +129,7 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
             'POST': {},
             'GET': {}
         })
+        assert 'environment' not in payload['events'][0]['metaData']
 
     def test_unhandled_post(self):
         response = self.fetch('/crash', method="POST", body="test=post")
@@ -172,11 +172,12 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
         self.assertEqual(response.code, 404)
         self.assertEqual(len(self.server.received), 0)
 
-    def test_disable_environment(self):
-        bugsnag.configure(send_environment=False)
+    def test_enable_environment(self):
+        bugsnag.configure(send_environment=True)
         response = self.fetch('/notify', method="POST", body="test=post")
         self.assertEqual(response.code, 200)
         self.assertEqual(len(self.server.received), 1)
 
         payload = self.server.received[0]['json_body']
-        assert 'environment' not in payload['events'][0]['metaData']
+        event = payload['events'][0]
+        self.assertEqual(event['metaData']['environment'], {})

--- a/tests/integrations/test_wsgi.py
+++ b/tests/integrations/test_wsgi.py
@@ -47,11 +47,10 @@ class TestWSGI(IntegrationTest):
         payload = self.server.received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['context'], 'GET /beans')
-        self.assertEqual(event['metaData']['environment']['PATH_INFO'],
-                         '/beans')
+        assert 'environment' not in event['metaData']
 
-    def test_disable_environment(self):
-        bugsnag.configure(send_environment=False)
+    def test_enable_environment(self):
+        bugsnag.configure(send_environment=True)
 
         class CrashOnStartApp(object):
             def __init__(self, environ, start_response):
@@ -63,7 +62,9 @@ class TestWSGI(IntegrationTest):
 
         self.assertEqual(1, len(self.server.received))
         payload = self.server.received[0]['json_body']
-        assert 'environment' not in payload['events'][0]['metaData']
+        event = payload['events'][0]
+        self.assertEqual(event['metaData']['environment']['PATH_INFO'],
+                         '/beans')
 
     def test_bugsnag_middleware_crash_on_iter(self):
         class CrashOnIterApp:
@@ -81,8 +82,8 @@ class TestWSGI(IntegrationTest):
 
         self.assertEqual(1, len(self.server.received))
         payload = self.server.received[0]['json_body']
-        environ = payload['events'][0]['metaData']['environment']
-        self.assertEqual(environ['PATH_INFO'], '/beans')
+        event = payload['events'][0]
+        assert 'environment' not in event['metaData']
 
     def test_bugsnag_middleware_crash_on_close(self):
         class CrashOnCloseApp:
@@ -104,8 +105,8 @@ class TestWSGI(IntegrationTest):
 
         self.assertEqual(1, len(self.server.received))
         payload = self.server.received[0]['json_body']
-        environ = payload['events'][0]['metaData']['environment']
-        self.assertEqual(environ['PATH_INFO'], '/beans')
+        event = payload['events'][0]
+        assert 'environment' not in event['metaData']
 
     def test_bugsnag_middleware_respects_user_id(self):
 
@@ -165,8 +166,8 @@ class TestWSGI(IntegrationTest):
 
         self.assertEqual(1, len(self.server.received))
         payload = self.server.received[0]['json_body']
-        environ = payload['events'][0]['metaData']['environment']
-        self.assertEqual(environ['PATH_INFO'], '/beans')
+        event = payload['events'][0]
+        assert 'environment' not in event['metaData']
 
     def test_bugsnag_middleware_attaches_unhandled_data(self):
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -329,18 +329,18 @@ class TestConfiguration(unittest.TestCase):
 
     def test_validate_send_environment(self):
         c = Configuration()
-        assert c.send_environment is True
+        assert c.send_environment is False
         with pytest.warns(RuntimeWarning) as record:
-            c.configure(send_environment='False')
+            c.configure(send_environment='True')
 
             assert len(record) == 1
             assert (str(record[0].message) ==
                     'send_environment should be bool, got str')
-            assert c.send_environment is True
-
-            c.configure(send_environment=False)
-            assert len(record) == 1
             assert c.send_environment is False
+
+            c.configure(send_environment=True)
+            assert len(record) == 1
+            assert c.send_environment is True
 
     def test_validate_session_endpoint(self):
         c = Configuration()


### PR DESCRIPTION
## Goal

Match the default behavior of other platforms/conventions by disabling including environment by default.