### PR TITLE
style: designate public vs internal APIs with __all__ 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ now at
 [end-of-life](https://docs.python.org/devguide/#status-of-python-branches).
 Please upgrade.
 
+* Added `__all__` lists throughout to indicate the boundaries of the public
+  interface. This may affect your integration if using `import *`.
+
 * Removed `Configuration.use_ssl` and `Configuration.get_endpoint()` in favor of
   including the protocol in `Configuration.endpoint`
 * `Configuration.send_environment` is now `False` by default. Enable it as a

--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -29,6 +29,8 @@ except ImportError:
 DEFAULT_ENDPOINT = 'https://notify.bugsnag.com'
 DEFAULT_SESSIONS_ENDPOINT = 'https://sessions.bugsnag.com'
 
+__all__ = ('default_headers', 'Delivery')
+
 
 def create_default_delivery():
     if requests is not None:

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -11,6 +11,9 @@ from bugsnag.utils import fully_qualified_class_name as class_name
 from bugsnag.utils import FilterDict, package_version, SanitizingJSONEncoder
 
 
+__all__ = ('Event',)
+
+
 class Event:
     """
     An occurrence of an exception for delivery to Bugsnag

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -4,6 +4,9 @@ import bugsnag
 from bugsnag.wsgi import request_path
 
 
+__all__ = ('handle_exceptions',)
+
+
 def add_flask_request_to_notification(event):
     if not flask.request:
         return

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -3,6 +3,9 @@ import logging
 import bugsnag
 
 
+__all__ = ('BugsnagHandler',)
+
+
 class BugsnagHandler(logging.Handler, object):
     def __init__(self, client=None, extra_fields=None):
         """

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -10,6 +10,11 @@ default_client = Client()
 configuration = default_client.configuration
 
 
+__all__ = ('configure', 'configure_request', 'add_metadata_tab',
+           'clear_request_config', 'notify', 'start_session', 'auto_notify',
+           'auto_notify_exc_info', 'before_notify')
+
+
 def configure(**options):
     """
     Configure the Bugsnag notifier application-wide settings.

--- a/bugsnag/middleware.py
+++ b/bugsnag/middleware.py
@@ -1,6 +1,9 @@
 import bugsnag
 
 
+__all__ = []  # type: ignore
+
+
 class SimpleMiddleware(object):
     def __init__(self, before=None, after=None):
         self.before = before

--- a/bugsnag/notification.py
+++ b/bugsnag/notification.py
@@ -3,6 +3,9 @@ import warnings
 from bugsnag.event import Event
 
 
+__all__ = ('Notification',)
+
+
 class Notification(Event):
     def __init__(self, exception, config, request_config, **options):
         warnings.warn('The Notification class has been deprecated in favor ' +

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -17,6 +17,9 @@ from bugsnag.utils import package_version, FilterDict, SanitizingJSONEncoder
 from bugsnag.event import Event
 
 
+__all__ = []  # type: ignore
+
+
 class SessionTracker(object):
 
     MAXIMUM_SESSION_COUNT = 100

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -10,6 +10,9 @@ MAX_PAYLOAD_LENGTH = 128 * 1024
 MAX_STRING_LENGTH = 1024
 
 
+__all__ = []  # type: ignore
+
+
 class SanitizingJSONEncoder(JSONEncoder):
     """
     A JSON encoder which handles filtering and conversion from JSON-

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -15,6 +15,9 @@ if 'bottle' in sys.modules:
         bottle_present = False
 
 
+__all__ = ('BugsnagMiddleware',)
+
+
 def add_wsgi_request_data_to_notification(event):
     if not hasattr(event.request_config, "wsgi_environ"):
         return


### PR DESCRIPTION
This change doesn't prevent using any particular piece (if you know what you're looking for) but [serves as an indicator](https://www.python.org/dev/peps/pep-0008/#public-and-internal-interfaces) for what can change without notice in the future.