### PR TITLE
add type signatures

### DIFF
--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -2,7 +2,7 @@ import sys
 import threading
 
 from functools import wraps
-from types import FunctionType
+from typing import Union, Tuple, Callable, Optional, List, Type
 
 from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.event import Event
@@ -15,22 +15,25 @@ import bugsnag
 __all__ = ('Client',)
 
 
-class Client(object):
+class Client:
     """
     A Bugsnag monitoring and reporting client.
 
     >>> client = Client(api_key='...')  # doctest: +SKIP
     """
 
-    def __init__(self, configuration=None, install_sys_hook=True, **kwargs):
-        self.configuration = configuration or Configuration()
+    def __init__(self, configuration: Optional[Configuration] = None,
+                 install_sys_hook=True, **kwargs):
+        self.configuration = configuration or Configuration()  # type: Configuration  # noqa: E501
         self.session_tracker = SessionTracker(self.configuration)
         self.configuration.configure(**kwargs)
 
         if install_sys_hook:
             self.install_sys_hook()
 
-    def capture(self, exceptions=None, **options):
+    def capture(self,
+                exceptions: Union[Tuple[Type, ...], Callable, None] = None,
+                **options):
         """
         Run a block of code within the clients context.
         Any exception raised will be reported to bugsnag.
@@ -57,12 +60,12 @@ class Client(object):
         ...     raise Exception('an exception which does not get captured')
         """
 
-        if isinstance(exceptions, FunctionType):
+        if callable(exceptions):
             return ClientContext(self, (Exception,))(exceptions)
 
         return ClientContext(self, exceptions, **options)
 
-    def notify(self, exception, asynchronous=None, **options):
+    def notify(self, exception: BaseException, asynchronous=None, **options):
         """
         Notify bugsnag of an exception.
 
@@ -134,7 +137,8 @@ class Client(object):
                 threading.excepthook = self.threading_excepthook
                 self.threading_excepthook = None
 
-    def deliver(self, event, asynchronous=None):  # type: ignore
+    def deliver(self, event: Event,
+                asynchronous: Optional[bool] = None):
         """
         Deliver the exception event to Bugsnag.
         """
@@ -175,7 +179,7 @@ class Client(object):
 
         self.configuration.internal_middleware.run(event, run_middleware)
 
-    def should_deliver(self, event):  # type: (Event) -> bool
+    def should_deliver(self, event: Event) -> bool:
         # Return early if we shouldn't notify for current release stage
         if not self.configuration.should_notify():
             return False
@@ -186,19 +190,21 @@ class Client(object):
 
         return True
 
-    def log_handler(self, extra_fields=None):
+    def log_handler(self, extra_fields: List[str] = None) -> BugsnagHandler:
         return BugsnagHandler(client=self, extra_fields=extra_fields)
 
 
-class ClientContext(object):
-    def __init__(self, client, exception_types=None, **options):
+class ClientContext:
+    def __init__(self, client,
+                 exception_types: Optional[Tuple[Type, ...]] = None,
+                 **options):
         self.client = client
         self.options = options
         if 'severity' in options:
             options['severity_reason'] = dict(type='userContextSetSeverity')
         self.exception_types = exception_types or (Exception,)
 
-    def __call__(self, function):
+    def __call__(self, function: Callable):
         @wraps(function)
         def decorate(*args, **kwargs):
             try:

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -2,6 +2,7 @@ import os
 import platform
 import socket
 import sysconfig
+from typing import List, Any, Tuple, Union
 import warnings
 
 from bugsnag.sessiontracker import SessionMiddleware
@@ -141,7 +142,7 @@ class Configuration:
 
     @api_key.setter  # type: ignore
     @validate_required_str_setter
-    def api_key(self, value):
+    def api_key(self, value: str):
         self._api_key = value
 
     @property
@@ -153,7 +154,7 @@ class Configuration:
 
     @app_type.setter  # type: ignore
     @validate_str_setter
-    def app_type(self, value):
+    def app_type(self, value: str):
         self._app_type = value
 
     @property
@@ -165,7 +166,7 @@ class Configuration:
 
     @app_version.setter  # type: ignore
     @validate_str_setter
-    def app_version(self, value):
+    def app_version(self, value: str):
         self._app_version = value
 
     @property
@@ -177,7 +178,7 @@ class Configuration:
 
     @asynchronous.setter  # type: ignore
     @validate_bool_setter
-    def asynchronous(self, value):
+    def asynchronous(self, value: bool):
         self._asynchronous = value
         if value:
             warn_if_running_uwsgi_without_threads()
@@ -192,7 +193,7 @@ class Configuration:
 
     @auto_capture_sessions.setter  # type: ignore
     @validate_bool_setter
-    def auto_capture_sessions(self, value):
+    def auto_capture_sessions(self, value: bool):
         self._auto_capture_sessions = value
 
     @property
@@ -204,7 +205,7 @@ class Configuration:
 
     @auto_notify.setter  # type: ignore
     @validate_bool_setter
-    def auto_notify(self, value):
+    def auto_notify(self, value: bool):
         self._auto_notify = value
 
     @property
@@ -236,7 +237,7 @@ class Configuration:
 
     @endpoint.setter  # type: ignore
     @validate_required_str_setter
-    def endpoint(self, value):
+    def endpoint(self, value: str):
         self._endpoint = value
 
     @property
@@ -249,7 +250,7 @@ class Configuration:
 
     @hostname.setter  # type: ignore
     @validate_str_setter
-    def hostname(self, value):
+    def hostname(self, value: str):
         self._hostname = value
 
     @property
@@ -263,7 +264,7 @@ class Configuration:
 
     @ignore_classes.setter  # type: ignore
     @validate_iterable_setter
-    def ignore_classes(self, value):
+    def ignore_classes(self, value: Union[List[str], Tuple[str]]):
         self._ignore_classes = value
 
     @property
@@ -277,7 +278,7 @@ class Configuration:
 
     @lib_root.setter  # type: ignore
     @validate_str_setter
-    def lib_root(self, value):
+    def lib_root(self, value: str):
         self._lib_root = value
 
     @property
@@ -291,7 +292,7 @@ class Configuration:
 
     @notify_release_stages.setter  # type: ignore
     @validate_iterable_setter
-    def notify_release_stages(self, value):
+    def notify_release_stages(self, value: List[str]):
         self._notify_release_stages = value
 
     @property
@@ -309,7 +310,7 @@ class Configuration:
 
     @params_filters.setter  # type: ignore
     @validate_iterable_setter
-    def params_filters(self, value):
+    def params_filters(self, value: List[str]):
         self._params_filters = value
 
     @property
@@ -324,7 +325,7 @@ class Configuration:
 
     @project_root.setter  # type: ignore
     @validate_str_setter
-    def project_root(self, value):
+    def project_root(self, value: str):
         self._project_root = value
 
     @property
@@ -336,7 +337,7 @@ class Configuration:
 
     @proxy_host.setter  # type: ignore
     @validate_str_setter
-    def proxy_host(self, value):
+    def proxy_host(self, value: str):
         self._proxy_host = value
 
     @property
@@ -350,7 +351,7 @@ class Configuration:
 
     @release_stage.setter  # type: ignore
     @validate_str_setter
-    def release_stage(self, value):
+    def release_stage(self, value: str):
         self._release_stage = value
 
     @property
@@ -363,7 +364,7 @@ class Configuration:
 
     @send_code.setter  # type: ignore
     @validate_bool_setter
-    def send_code(self, value):
+    def send_code(self, value: bool):
         self._send_code = value
 
     @property
@@ -376,7 +377,7 @@ class Configuration:
 
     @send_environment.setter  # type: ignore
     @validate_bool_setter
-    def send_environment(self, value):
+    def send_environment(self, value: bool):
         self._send_environment = value
 
     @property
@@ -391,7 +392,7 @@ class Configuration:
 
     @session_endpoint.setter  # type: ignore
     @validate_required_str_setter
-    def session_endpoint(self, value):
+    def session_endpoint(self, value: str):
         self._session_endpoint = value
 
     @property
@@ -403,15 +404,15 @@ class Configuration:
 
     @traceback_exclude_modules.setter  # type: ignore
     @validate_iterable_setter
-    def traceback_exclude_modules(self, value):
+    def traceback_exclude_modules(self, value: List[str]):
         self._traceback_exclude_modules = value
 
-    def should_notify(self):  # type: () -> bool
+    def should_notify(self) -> bool:
         return self.notify_release_stages is None or \
             (isinstance(self.notify_release_stages, (tuple, list)) and
              self.release_stage in self.notify_release_stages)
 
-    def should_ignore(self, exception):  # type: (Exception) -> bool
+    def should_ignore(self, exception: BaseException) -> bool:
         return self.ignore_classes is not None and \
             fully_qualified_class_name(exception) in self.ignore_classes
 
@@ -422,7 +423,7 @@ class RequestConfiguration:
     """
 
     @classmethod
-    def get_instance(cls):  # type: () -> RequestConfiguration
+    def get_instance(cls):
         """
         Get this thread's instance of the RequestConfiguration.
         """
@@ -458,7 +459,7 @@ class RequestConfiguration:
         self.environment_data = {}
         self.session_data = {}
 
-    def get(self, name):
+    def get(self, name) -> Any:
         """
         Get a single configuration option
         """

--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -1,4 +1,5 @@
 from threading import Thread
+from typing import Dict, Callable, Any
 import sys
 import json
 import warnings
@@ -39,7 +40,7 @@ def create_default_delivery():
     return UrllibDelivery()
 
 
-def default_headers(api_key):
+def default_headers(api_key: str):
     return {
         'Bugsnag-Api-Key': api_key,
         'Bugsnag-Payload-Version': Event.PAYLOAD_VERSION,
@@ -48,20 +49,20 @@ def default_headers(api_key):
     }
 
 
-class Delivery(object):
+class Delivery:
     """
     Mechanism for sending a request to Bugsnag
     """
     def __init__(self):
         self.sent_session_warning = False
 
-    def deliver(self, config, payload, options={}):
+    def deliver(self, config, payload: Any, options={}):
         """
         Sends error reports to Bugsnag
         """
         pass
 
-    def deliver_sessions(self, config, payload):
+    def deliver_sessions(self, config, payload: Any):
         """
         Sends sessions to Bugsnag
         """
@@ -78,7 +79,7 @@ class Delivery(object):
             }
             self.deliver(config, payload, options)
 
-    def queue_request(self, request, config, options):
+    def queue_request(self, request: Callable, config, options: Dict):
         if config.asynchronous and options.pop('asynchronous', True):
             Thread(target=request).start()
         else:
@@ -87,7 +88,7 @@ class Delivery(object):
 
 class UrllibDelivery(Delivery):
 
-    def deliver(self, config, payload, options={}):
+    def deliver(self, config, payload: Any, options={}):
 
         def request():
             uri = options.pop('endpoint', config.endpoint)
@@ -124,7 +125,7 @@ class UrllibDelivery(Delivery):
 
 class RequestsDelivery(Delivery):
 
-    def deliver(self, config, payload, options={}):
+    def deliver(self, config, payload: Any, options={}):
 
         def request():
             uri = options.pop('endpoint', config.endpoint)

--- a/bugsnag/django/utils.py
+++ b/bugsnag/django/utils.py
@@ -1,3 +1,3 @@
-class MiddlewareMixin(object):
+class MiddlewareMixin:
     def __init__(self, get_response=None):
         super(MiddlewareMixin, self).__init__()

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -1,3 +1,4 @@
+from typing import Any, Dict, Optional
 import linecache
 import logging
 import os
@@ -23,7 +24,8 @@ class Event:
     PAYLOAD_VERSION = "4.0"
     SUPPORTED_SEVERITIES = ["info", "warning", "error"]
 
-    def __init__(self, exception, config, request_config, **options):
+    def __init__(self, exception: BaseException, config, request_config,
+                 **options):
         """
         Create a new event
 
@@ -77,9 +79,9 @@ class Event:
         self.grouping_hash = options.pop("grouping_hash", None)
         self.api_key = options.pop("api_key", get_config("api_key"))
 
-        self.session = None
+        self.session = None  # type: Optional[Dict]
 
-        self.meta_data = {}
+        self.meta_data = {}  # type: Dict[str, Dict[str, Any]]
         for name, tab in options.pop("meta_data", {}).items():
             self.add_tab(name, tab)
 

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -7,7 +7,7 @@ from bugsnag.wsgi import request_path
 __all__ = ('handle_exceptions',)
 
 
-def add_flask_request_to_notification(event):
+def add_flask_request_to_notification(event: bugsnag.Event):
     if not flask.request:
         return
 

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -1,4 +1,6 @@
 import logging
+from logging import LogRecord
+from typing import Dict
 
 import bugsnag
 
@@ -18,13 +20,15 @@ class BugsnagHandler(logging.Handler, object):
                           self.extract_custom_metadata,
                           self.extract_severity]
 
-    def emit(self, record):
+    def emit(self, record: LogRecord):
         """
         Outputs the record to Bugsnag
         """
-        for path in bugsnag.__path__:
-            if path in record.pathname:
-                return
+        if hasattr(bugsnag, '__path__'):
+            paths = getattr(bugsnag, '__path__')
+            for path in paths:
+                if path in record.pathname:
+                    return
 
         options = {
             'meta_data': {},
@@ -46,13 +50,15 @@ class BugsnagHandler(logging.Handler, object):
         client = self.client or bugsnag.legacy.default_client
 
         if 'exception' in options:
-            if isinstance(options['exception'], Exception):
-                client.notify(**options)
+            exception = options.pop('exception')
+            if isinstance(exception, Exception):
+                client.notify(exception, **options)
                 return
             else:
-                custom_exception = options.pop('exception')
                 try:
-                    options['meta_data']['exception'] = custom_exception
+                    metadata = options['meta_data']
+                    if isinstance(metadata, dict):
+                        metadata['exception'] = exception
                 except TypeError:
                     # Means options['meta_data'] is no longer a dictionary
                     pass
@@ -91,7 +97,7 @@ class BugsnagHandler(logging.Handler, object):
         """
         del self.callbacks[:]
 
-    def extract_severity(self, record, options):
+    def extract_severity(self, record: LogRecord, options: Dict):
         """
         Convert log record level into severity levels
         """
@@ -104,7 +110,7 @@ class BugsnagHandler(logging.Handler, object):
         else:
             options['severity'] = 'info'
 
-    def extract_custom_metadata(self, record, options):
+    def extract_custom_metadata(self, record: LogRecord, options: Dict):
         """
         Append the contents of selected fields of a record to the metadata
         of a report
@@ -124,7 +130,7 @@ class BugsnagHandler(logging.Handler, object):
                     attr = getattr(record, field)
                     options['meta_data'][section][field] = attr
 
-    def extract_default_metadata(self, record, options):
+    def extract_default_metadata(self, record: LogRecord, options: Dict):
         """
         Extract log record fields into error report metadata
         """

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -1,3 +1,4 @@
+from typing import Dict, Any, Tuple, Type
 import types
 import sys
 
@@ -8,6 +9,7 @@ import bugsnag
 
 default_client = Client()
 configuration = default_client.configuration
+ExcInfoType = Tuple[Type, Exception, types.TracebackType]
 
 
 __all__ = ('configure', 'configure_request', 'add_metadata_tab',
@@ -29,7 +31,7 @@ def configure_request(**options):
     RequestConfiguration.get_instance().configure(**options)
 
 
-def add_metadata_tab(tab_name, data):
+def add_metadata_tab(tab_name: str, data: Dict[str, Any]):
     """
     Add metaData to the tab
 
@@ -49,7 +51,7 @@ def clear_request_config():
     RequestConfiguration.clear()
 
 
-def notify(exception, **options):
+def notify(exception: BaseException, **options):
     """
     Notify bugsnag of an exception.
     """
@@ -89,7 +91,7 @@ def send_sessions():
     default_client.session_tracker.send_sessions()
 
 
-def auto_notify(exception, **options):
+def auto_notify(exception: BaseException, **options):
     """
     Notify bugsnag of an exception if auto_notify is enabled.
     """
@@ -105,7 +107,7 @@ def auto_notify(exception, **options):
         )
 
 
-def auto_notify_exc_info(exc_info=None, **options):
+def auto_notify_exc_info(exc_info: ExcInfoType = None, **options):
     """
     Notify bugsnag of a exc_info tuple if auto_notify is enabled
     """

--- a/bugsnag/middleware.py
+++ b/bugsnag/middleware.py
@@ -1,11 +1,18 @@
+from typing import Callable, Optional, Type, List
+
 import bugsnag
+from bugsnag.event import Event
 
 
-__all__ = []  # type: ignore
+Middleware = Callable[[Event], Callable]
 
 
-class SimpleMiddleware(object):
-    def __init__(self, before=None, after=None):
+__all__ = []  # type: List[str]
+
+
+class SimpleMiddleware:
+    def __init__(self, before: Optional[Middleware] = None,
+                 after: Optional[Middleware] = None):
         self.before = before
         self.after = after
 
@@ -25,15 +32,15 @@ class SimpleMiddleware(object):
         return middleware
 
 
-class DefaultMiddleware(object):
+class DefaultMiddleware:
     """
     DefaultMiddleware provides the transformation from request_config into
     meta-data that has always been supported by bugsnag-python.
     """
-    def __init__(self, bugsnag):
+    def __init__(self, bugsnag: Middleware):
         self.bugsnag = bugsnag
 
-    def __call__(self, event):
+    def __call__(self, event: Event):
         config = event.request_config
         event.set_user(id=config.user_id)
         event.set_user(**config.user)
@@ -58,14 +65,14 @@ class DefaultMiddleware(object):
         self.bugsnag(event)
 
 
-class MiddlewareStack(object):
+class MiddlewareStack:
     """
     Manages a stack of Bugsnag middleware.
     """
     def __init__(self):
         self.stack = []
 
-    def before_notify(self, func):
+    def before_notify(self, func: Middleware):
         """
         Add a function to be run before bugsnag is notified.
 
@@ -80,7 +87,7 @@ class MiddlewareStack(object):
         """
         self.append(SimpleMiddleware(before=func))
 
-    def after_notify(self, func):
+    def after_notify(self, func: Middleware):
         """
         Add a function to be run after bugsnag is notified.
 
@@ -88,7 +95,7 @@ class MiddlewareStack(object):
         """
         self.append(SimpleMiddleware(after=func))
 
-    def append(self, middleware):
+    def append(self, middleware: Middleware):
         """
         Add a middleware to the end of the stack.
 
@@ -109,7 +116,7 @@ class MiddlewareStack(object):
         """
         self.stack.append(middleware)
 
-    def insert_before(self, target_class, middleware):
+    def insert_before(self, target_class: Type, middleware: Middleware):
         """
         Adds a middleware to the stack in the position before
         the target_class.
@@ -120,7 +127,7 @@ class MiddlewareStack(object):
         except ValueError:
             self.append(middleware)
 
-    def insert_after(self, target_class, middleware):
+    def insert_after(self, target_class: Type, middleware: Middleware):
         """
         Adds a middleware to the stack in the position after
         the target_class.
@@ -131,7 +138,7 @@ class MiddlewareStack(object):
         except ValueError:
             self.append(middleware)
 
-    def run(self, event, callback):
+    def run(self, event: Event, callback: Callable[[], None]):
         """
         Run all the middleware in order, then call the callback.
         """

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from uuid import uuid4
 from time import strftime, gmtime
 from threading import Lock, Timer
+from typing import List, Dict, Callable
 import atexit
 
 try:
@@ -17,10 +18,10 @@ from bugsnag.utils import package_version, FilterDict, SanitizingJSONEncoder
 from bugsnag.event import Event
 
 
-__all__ = []  # type: ignore
+__all__ = []  # type: List[str]
 
 
-class SessionTracker(object):
+class SessionTracker:
 
     MAXIMUM_SESSION_COUNT = 100
     SESSION_PAYLOAD_VERSION = "1.0"
@@ -28,8 +29,9 @@ class SessionTracker(object):
     """
     Session tracking class for Bugsnag
     """
+
     def __init__(self, configuration):
-        self.session_counts = {}
+        self.session_counts = {}  # type: Dict[str, int]
         self.config = configuration
         self.mutex = Lock()
         self.auto_sessions = False
@@ -84,7 +86,7 @@ class SessionTracker(object):
 
             atexit.register(cleanup)
 
-    def __queue_session(self, start_time):
+    def __queue_session(self, start_time: str):
         self.mutex.acquire()
         try:
             if start_time not in self.session_counts:
@@ -93,7 +95,7 @@ class SessionTracker(object):
         finally:
             self.mutex.release()
 
-    def __deliver(self, sessions):
+    def __deliver(self, sessions: List[Dict]):
         if not sessions:
             bugsnag.logger.debug("No sessions to deliver")
             return
@@ -135,14 +137,14 @@ class SessionTracker(object):
             bugsnag.logger.exception('Sending sessions failed %s', e)
 
 
-class SessionMiddleware(object):
+class SessionMiddleware:
     """
     Session middleware ensures that a session is appended to the event.
     """
-    def __init__(self, bugsnag):
+    def __init__(self, bugsnag: Callable[[Event], Callable]):
         self.bugsnag = bugsnag
 
-    def __call__(self, event):
+    def __call__(self, event: Event):
         session = _session_info.get()
         if session:
             if event.unhandled:

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -2,6 +2,7 @@ from functools import wraps, partial
 import inspect
 from json import JSONEncoder
 from threading import local as threadlocal
+from typing import Tuple, Optional
 import warnings
 
 import bugsnag
@@ -177,7 +178,10 @@ class FilterDict(dict):
     pass
 
 
-def parse_content_type(value):
+ContentType = Tuple[str, Optional[str], Optional[str], Optional[str]]
+
+
+def parse_content_type(value: str) -> ContentType:
     """
     Generate a tuple of (type, subtype, suffix, parameters) from a type based
     on RFC 6838
@@ -189,10 +193,11 @@ def parse_content_type(value):
     >>> parse_content_type("application/json;schema=\\"ftp://example.com/a\\"")
     ('application', 'json', None, 'schema="ftp://example.com/a"')
     """
+    parameters = None  # type: Optional[str]
     if ';' in value:
         types, parameters = value.split(';', 1)
     else:
-        types, parameters = value, None
+        types = value
     if '/' in types:
         maintype, subtype = types.split('/', 1)
         if '+' in subtype:
@@ -204,7 +209,7 @@ def parse_content_type(value):
         return (types, None, None, parameters)
 
 
-def is_json_content_type(value):  # type: (str) -> bool
+def is_json_content_type(value: str) -> bool:
     """
     Check if a content type is JSON-parseable
 

--- a/bugsnag/wsgi/__init__.py
+++ b/bugsnag/wsgi/__init__.py
@@ -1,5 +1,6 @@
+from typing import Dict
 from urllib.parse import quote
 
 
-def request_path(env):
+def request_path(env: Dict):
     return quote('/' + env.get('PATH_INFO', '').lstrip('/'))

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -38,7 +38,7 @@ def add_wsgi_request_data_to_notification(event):
         event.add_tab("environment", dict(request.environ))
 
 
-class WrappedWSGIApp(object):
+class WrappedWSGIApp:
     """
     Wraps a running WSGI app and sends all exceptions to bugsnag.
     """
@@ -91,7 +91,7 @@ class WrappedWSGIApp(object):
             bugsnag.clear_request_config()
 
 
-class BugsnagMiddleware(object):
+class BugsnagMiddleware:
     """
     Notifies Bugsnag on any unhandled exception that happens while processing
     a request in your application.

--- a/tests/integrations/test_tornado.py
+++ b/tests/integrations/test_tornado.py
@@ -180,4 +180,5 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
 
         payload = self.server.received[0]['json_body']
         event = payload['events'][0]
-        self.assertEqual(event['metaData']['environment'], {})
+        self.assertEqual(event['metaData']['environment']['REQUEST_METHOD'],
+                         'POST')


### PR DESCRIPTION
## Goal

Add type signatures throughout the library to allow tools like mypy to work against `bugsnag` package interfaces.

* Adding typing comments for variables/properties, as type syntax for those was added in py 3.6

## Testing

The new types are checked by the existing linters and some changes took a bit of effort to satisfy mypy