### PR TITLE
refactor(legacy): remove unused bugsnag.send_sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Please upgrade.
 * Removed `bugsnag.utils.ThreadLocals` as it has been superseded by the
   `contextvars` API
 * Removed `bugsnag.utils.merge_dicts`, an unused helper function
+* Removed `bugsnag.send_sessions`
 
 ### Deprecations
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,6 +19,7 @@ guide for migrating from 2.x to 3.x to remove use of `get_endpoint()` and
 * Removed `bugsnag.utils.ThreadLocals` as it has been superseded by the
   `contextvars` API
 * Removed `bugsnag.utils.merge_dicts`
+* Removed `bugsnag.send_sessions`
 
 ### Request environment configuration
 

--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -8,13 +8,13 @@ from bugsnag.client import Client
 from bugsnag.legacy import (configuration, configure, configure_request,
                             add_metadata_tab, clear_request_config, notify,
                             auto_notify, before_notify, start_session,
-                            send_sessions, auto_notify_exc_info)
+                            auto_notify_exc_info)
 
 __all__ = ('Client', 'Event', 'Configuration', 'RequestConfiguration',
            'configuration', 'configure', 'configure_request',
            'add_metadata_tab', 'clear_request_config', 'notify',
            'auto_notify', 'before_notify', 'start_session',
-           'send_sessions', 'auto_notify_exc_info',
+           'auto_notify_exc_info',
            'Notification')
 
 logger = logging.getLogger(__name__)

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -84,13 +84,6 @@ def start_session():
     default_client.session_tracker.start_session()
 
 
-def send_sessions():
-    """
-    Delivers all currently undelivered sessions to Bugsnag
-    """
-    default_client.session_tracker.send_sessions()
-
-
 def auto_notify(exception: BaseException, **options):
     """
     Notify bugsnag of an exception if auto_notify is enabled.


### PR DESCRIPTION
## Goal

This helper is unused, and accessing the session tracker directly could be done if needed