### PR TITLE
add request property to Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ Please upgrade.
   platforms. The `Notification` class is functionally equivalent and will be
   removed in a future release.
 
+### Enhancements
+
+* Added a `request` property to `Event`. Events created by errors which occur in
+  the HTTP request cycle (when using the integrations for Django, Flask, WSGI,
+  or Tornado) will have the request object available. The request object can be
+  used to add custom information to the Event which will be sent to Bugsnag. The
+  request object itself is not serialized.
+
 ## 3.9.0 (2020-08-27)
 
 ### Enhancements

--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -17,6 +17,7 @@ def add_django_request_to_notification(event):
         return
 
     request = event.request_config.django_request
+    event.request = request
 
     if event.context is None:
         try:

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -47,6 +47,7 @@ class Event:
         self.options = options
         self.config = config
         self.request_config = request_config
+        self.request = None  # type: Any
 
         def get_config(key):
             return options.pop(key, getattr(self.config, key))

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -11,6 +11,7 @@ def add_flask_request_to_notification(event: bugsnag.Event):
     if not flask.request:
         return
 
+    event.request = flask.request
     if event.context is None:
         event.context = "%s %s" % (flask.request.method,
                                    request_path(flask.request.environ))

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -13,6 +13,7 @@ class BugsnagRequestHandler(RequestHandler):
         if not hasattr(self, "request"):
             return
 
+        event.request = self.request
         request_tab = {
             'method': self.request.method,
             'path': self.request.path,

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -24,6 +24,7 @@ def add_wsgi_request_data_to_notification(event):
 
     environ = event.request_config.wsgi_environ
     request = Request(environ)
+    event.request = request
     path = request_path(environ)
 
     event.context = "%s %s" % (request.method, path)

--- a/tests/fixtures/django1/notes/urls.py
+++ b/tests/fixtures/django1/notes/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
         views.unhandled_crash_in_template),
     url(r'handled-exception/', views.handle_notify),
     url(r'handled-exception-custom/', views.handle_notify_custom_info),
+    url(r'crash-with-callback/', views.handle_crash_callback),
 ]

--- a/tests/fixtures/django1/notes/views.py
+++ b/tests/fixtures/django1/notes/views.py
@@ -50,3 +50,16 @@ def handle_notify_custom_info(request):
     bugsnag.notify(Exception('something bad happened'), severity='info',
                    context='custom_info')
     return HttpResponse('nothing to see here', content_type='text/plain')
+
+
+def request_inspection(event):
+    event.context = event.request.GET['user_id']
+
+
+def handle_crash_callback(request):
+    bugsnag.before_notify(request_inspection)
+    terrible_event()
+
+
+def terrible_event():
+    raise RuntimeError('I did something wrong')

--- a/tests/fixtures/django30/notes/urls.py
+++ b/tests/fixtures/django30/notes/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path('unhandled-crash/', views.unhandled_crash, name='crash'),
     path('unhandled-template-crash/', views.unhandled_crash_in_template),
     path('handled-exception/', views.handle_notify),
+    path('crash-with-callback/', views.handle_crash_callback),
     path('handled-exception-custom/', views.handle_notify_custom_info),
 ]

--- a/tests/fixtures/django30/notes/views.py
+++ b/tests/fixtures/django30/notes/views.py
@@ -50,3 +50,16 @@ def handle_notify_custom_info(request):
     bugsnag.notify(Exception('something bad happened'), severity='info',
                    context='custom_info')
     return HttpResponse('nothing to see here', content_type='text/plain')
+
+
+def request_inspection(event):
+    event.context = event.request.GET['user_id']
+
+
+def handle_crash_callback(request):
+    bugsnag.before_notify(request_inspection)
+    terrible_event()
+
+
+def terrible_event():
+    raise RuntimeError('I did something wrong')

--- a/tests/fixtures/tornado/server.py
+++ b/tests/fixtures/tornado/server.py
@@ -32,6 +32,9 @@ def callback(notification):
             "code": 200
         }
         notification.add_tab("Diagnostics", tab)
+    args = notification.request.query_arguments
+    if 'user_id' in args:
+        notification.set_user(id=args['user_id'][0])
 
 
 class NotifyHandler(BugsnagRequestHandler):

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -364,3 +364,13 @@ def test_crash_appends_user_data(bugsnag_server, django_client):
         },
     }
     assert exception['stacktrace'][1]['inProject'] is False
+
+
+def test_read_request_in_callback(bugsnag_server, django_client):
+    with pytest.raises(RuntimeError):
+        django_client.get('/notes/crash-with-callback/?user_id=foo')
+
+    bugsnag_server.wait_for_request()
+    payload = bugsnag_server.received[0]['json_body']
+    event = payload['events'][0]
+    assert event['context'] == 'foo'

--- a/tests/integrations/test_tornado.py
+++ b/tests/integrations/test_tornado.py
@@ -182,3 +182,11 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
         event = payload['events'][0]
         self.assertEqual(event['metaData']['environment']['REQUEST_METHOD'],
                          'POST')
+
+    def test_read_request_in_callback(self):
+        self.fetch('/crash_with_callback?user_id=foo')
+        assert len(self.server.received) == 1
+
+        payload = self.server.received[0]['json_body']
+        event = payload['events'][0]
+        assert event['user']['id'] == 'foo'

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -176,3 +176,9 @@ class TestEvent(unittest.TestCase):
         app = payload['events'][0]['app']
 
         assert app['type'] == 'rq'
+
+    def test_default_request(self):
+        config = Configuration()
+        config.configure(app_type='rq')
+        event = self.event_class(Exception("oops"), config, {})
+        assert event.request is None


### PR DESCRIPTION
Adds a `request` property to `Event`. Events created by errors which occur in the HTTP request cycle (when using the integrations for Django, Flask, WSGI, or Tornado) will have the request object available. The request object can be used to add custom information to the Event which will be sent to Bugsnag. The request object itself is not serialized.

This issue will additionally resolve issues like #133 by providing a mechanism for users to refer to the original request in a callback.