### PR TITLE
feat: support X-Forwarded-For for client IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ Please upgrade.
   used to add custom information to the Event which will be sent to Bugsnag. The
   request object itself is not serialized.
 
+* [WSGI] Use `X-Forwarded-For` header if present to determine the IP address
+  used as the default user ID. The remote address remains available in the
+  request metadata attached to the event.
+  [Wolfgang Schnerring](https://github.com/wosc)
+  [#133](https://github.com/bugsnag/bugsnag-python/pull/133)
+
 ## 3.9.0 (2020-08-27)
 
 ### Enhancements

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -28,7 +28,7 @@ def add_wsgi_request_data_to_notification(event):
     path = request_path(environ)
 
     event.context = "%s %s" % (request.method, path)
-    event.set_user(id=request.remote_addr)
+    event.set_user(id=request.client_addr)
     event.add_tab("request", {
         "url": "%s%s" % (request.application_url, path),
         "headers": dict(request.headers),


### PR DESCRIPTION
## Goal

Updated version of #133 with a changelog entry. This brings the implementation in line with the notifier spec.

## Design

The [webob `Request.client_addr` implementation](https://github.com/Pylons/webob/blob/ac2d238f50bed7fbbf115818ab7f208b71d7bdca/src/webob/request.py#L378) grabs the outermost address in the array (if there are multiple entries). This change can also be overridden if needed using the changes in #237. The complete value for `X-Forwarded-For` (and the rest of the headers) also remain included in the event.

Closes #133