### PR TITLE
tests(celery): test against v4 and v5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{35,36,37,38,39}-{test,celery,requests,flask,tornado,wsgi,bottle},
-    py{36,37,38,39}-asgi,
+    py{35,36,37,38,39}-{test,celery4,requests,flask,tornado,wsgi,bottle},
+    py{36,37,38,39}-{asgi,celery5},
     py{35,36,37}-django{18,19,110,111}
     py{35,36,37,38,39}-django{20,21,22}
     py{36,37,38,39}-django3
@@ -19,7 +19,7 @@ setenv  =
     COVERAGE_FILE=.coverage.{envname}
     django{18,19,110,111,20,21,22}: PYTHONPATH=tests/fixtures/django1{:}{toxinidir}
     django3: PYTHONPATH=tests/fixtures/django30{:}{toxinidir}
-    !celery: DJANGO_SETTINGS_MODULE=todo.settings
+    django{18,19,110,111,20,21,22,3}: DJANGO_SETTINGS_MODULE=todo.settings
 basepython =
     py35: python3.5
     py36: python3.6
@@ -38,7 +38,9 @@ deps=
     asgi: requests
     bottle: webtest==2.0.23
     bottle: bottle==0.12.18
-    celery: celery>=4,<5
+    celery4: celery>=4,<5
+    celery5: celery>=5,<6
+    celery5: pytest-celery
     flask: flask
     flask: blinker
     tornado: tornado
@@ -61,7 +63,7 @@ commands =
     threadtest: pytest tests/integrations/test_thread_excepthook.py
     requests: pytest --ignore=tests/integrations tests tests/integrations/test_requests_delivery.py
     bottle: pytest tests/integrations/test_bottle.py
-    celery: pytest tests/integrations/test_celery.py
+    celery{4,5}: pytest tests/integrations/test_celery.py
     wsgi: pytest tests/integrations/test_wsgi.py
     asgi: pytest tests/integrations/test_asgi.py
     flask: pytest tests/integrations/test_flask.py


### PR DESCRIPTION
Celery 5.0 removes the pytest fixtures and instead puts them in a
separate pytest-celery package.