### PR TITLE
rename 'meta_data'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Please upgrade.
   `bugsnag.event.Event` to better align with Bugsnag libraries on other
   platforms. The `Notification` class is functionally equivalent and will be
   removed in a future release.
+* `Event.meta_data` has been renamed to `Event.metadata`
+* `RequestConfiguration.meta_data` has been renamed to
+  `RequestConfiguration.metadata`
 
 ### Enhancements
 

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -450,7 +450,7 @@ class RequestConfiguration:
         self.context = None
         self.grouping_hash = None
         self.user = {}
-        self.meta_data = {}
+        self.metadata = {}
 
         # legacy fields
         self.user_id = None
@@ -473,3 +473,9 @@ class RequestConfiguration:
             setattr(self, name, value)
 
         return self
+
+    @property
+    def meta_data(self) -> Any:
+        warnings.warn('RequestConfiguration.meta_data has been renamed to ' +
+                      '"metadata"', DeprecationWarning)
+        return self.metadata

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -5,6 +5,7 @@ import os
 import sys
 import traceback
 import inspect
+import warnings
 
 import bugsnag
 
@@ -37,11 +38,11 @@ class Event:
         options can be used to override any of the configuration parameters:
             "api_key", "release_stage", "app_version", "hostname"
         and to provide the following top-level event payload keys:
-            "user", "context", "severity", "grouping_hash", "meta_data",
+            "user", "context", "severity", "grouping_hash", "metadata",
             ("user_id")
         or to provide the exception parameter:
             "traceback"
-        All other keys will be sent as meta-data to Bugsnag.
+        All other keys will be sent as metadata to Bugsnag.
         """
         self.exception = exception
         self.options = options
@@ -82,12 +83,24 @@ class Event:
 
         self.session = None  # type: Optional[Dict]
 
-        self.meta_data = {}  # type: Dict[str, Dict[str, Any]]
-        for name, tab in options.pop("meta_data", {}).items():
+        self.metadata = {}  # type: Dict[str, Dict[str, Any]]
+        if 'meta_data' in options:
+            warnings.warn('The Event "metadata" argument has been replaced ' +
+                          'with "metadata"', DeprecationWarning)
+            for name, tab in options.pop("meta_data").items():
+                self.add_tab(name, tab)
+
+        for name, tab in options.pop('metadata', {}).items():
             self.add_tab(name, tab)
 
         for name, tab in options.items():
             self.add_tab(name, tab)
+
+    @property
+    def meta_data(self) -> Dict[str, Dict[str, Any]]:
+        warnings.warn('The Event "metadata" property has been replaced ' +
+                      'with "meta_data".', DeprecationWarning)
+        return self.metadata
 
     def set_user(self, id=None, name=None, email=None):
         """

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -130,10 +130,10 @@ class Event:
             self.add_tab("custom", {name: dictionary})
             return
 
-        if name not in self.meta_data:
-            self.meta_data[name] = {}
+        if name not in self.metadata:
+            self.metadata[name] = {}
 
-        self.meta_data[name].update(dictionary)
+        self.metadata[name].update(dictionary)
 
     def _generate_stacktrace(self, tb, source_func=None):
         """
@@ -261,7 +261,7 @@ class Event:
                     "message": self.exception,
                     "stacktrace": self.stacktrace,
                 }],
-                "metaData": FilterDict(self.meta_data),
+                "metaData": FilterDict(self.metadata),
                 "user": FilterDict(self.user),
                 "device": FilterDict({
                     "hostname": self.hostname,

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -31,7 +31,7 @@ class BugsnagHandler(logging.Handler, object):
                     return
 
         options = {
-            'meta_data': {},
+            'metadata': {},
             'unhandled': False,
             'severity_reason': {
                 'type': 'log',
@@ -56,11 +56,11 @@ class BugsnagHandler(logging.Handler, object):
                 return
             else:
                 try:
-                    metadata = options['meta_data']
+                    metadata = options['metadata']
                     if isinstance(metadata, dict):
                         metadata['exception'] = exception
                 except TypeError:
-                    # Means options['meta_data'] is no longer a dictionary
+                    # Means options['metadata'] is no longer a dictionary
                     pass
 
         if record.exc_info:
@@ -118,17 +118,17 @@ class BugsnagHandler(logging.Handler, object):
         if self.custom_metadata_fields is None:
             return
 
-        if 'meta_data' not in options:
-            options['meta_data'] = {}
+        if 'metadata' not in options:
+            options['metadata'] = {}
 
         for section in self.custom_metadata_fields:
-            if section not in options['meta_data']:
-                options['meta_data'][section] = {}
+            if section not in options['metadata']:
+                options['metadata'][section] = {}
 
             for field in self.custom_metadata_fields[section]:
                 if hasattr(record, field):
                     attr = getattr(record, field)
-                    options['meta_data'][section][field] = attr
+                    options['metadata'][section][field] = attr
 
     def extract_default_metadata(self, record: LogRecord, options: Dict):
         """
@@ -143,7 +143,7 @@ class BugsnagHandler(logging.Handler, object):
             if hasattr(record, field):
                 extra_data[field] = getattr(record, field)
 
-        if 'meta_data' not in options:
-            options['meta_data'] = {}
+        if 'metadata' not in options:
+            options['metadata'] = {}
 
-        options['meta_data']['extra data'] = extra_data
+        options['metadata']['extra data'] = extra_data

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -37,11 +37,11 @@ def add_metadata_tab(tab_name: str, data: Dict[str, Any]):
 
     bugsnag.add_metadata_tab("user", {"id": "1", "name": "Conrad"})
     """
-    meta_data = RequestConfiguration.get_instance().meta_data
-    if tab_name not in meta_data:
-        meta_data[tab_name] = {}
+    metadata = RequestConfiguration.get_instance().metadata
+    if tab_name not in metadata:
+        metadata[tab_name] = {}
 
-    meta_data[tab_name].update(data)
+    metadata[tab_name].update(data)
 
 
 def clear_request_config():

--- a/bugsnag/middleware.py
+++ b/bugsnag/middleware.py
@@ -35,7 +35,7 @@ class SimpleMiddleware:
 class DefaultMiddleware:
     """
     DefaultMiddleware provides the transformation from request_config into
-    meta-data that has always been supported by bugsnag-python.
+    metadata that has always been supported by bugsnag-python.
     """
     def __init__(self, bugsnag: Middleware):
         self.bugsnag = bugsnag
@@ -48,11 +48,11 @@ class DefaultMiddleware:
         if not event.context:
             event.context = config.get("context")
 
-        for name, dictionary in config.meta_data.items():
-            if name in event.meta_data:
+        for name, dictionary in config.metadata.items():
+            if name in event.metadata:
                 for key, value in dictionary.items():
-                    if key not in event.meta_data[name]:
-                        event.meta_data[name][key] = value
+                    if key not in event.metadata[name]:
+                        event.metadata[name][key] = value
             else:
                 event.add_tab(name, dictionary)
 

--- a/example/celery+django/demo/tasks.py
+++ b/example/celery+django/demo/tasks.py
@@ -32,7 +32,7 @@ def metadivide(x, y):
     try:
         return x / y
     except ZeroDivisionError as e:
-        bugsnag.notify(e, meta_data={'Diagnostics': {'x': x, 'y': y}})
+        bugsnag.notify(e, metadata={'Diagnostics': {'x': x, 'y': y}})
 
 
 @shared_task

--- a/example/django21/demo/views.py
+++ b/example/django21/demo/views.py
@@ -84,7 +84,7 @@ def notify_meta(request):
         Exception('Django demo: Manual notification with metadata'),
         # this app adds some metadata globally, but you can also attach specfic
         # details to a particular exception.
-        meta_data={
+        metadata={
             'Request info': {'route': 'notifywithmetadata'},
             'Resolve info': {
                 'status': 200,

--- a/example/flask/server.py
+++ b/example/flask/server.py
@@ -143,7 +143,7 @@ def notifywithmetadata():
         Exception('Flask demo: Manual notification with metadata'),
         # this app adds some metadata globally, but you can also attach
         # specific details to a particular exception
-        meta_data={
+        metadata={
             'Request info': {
                 'route': 'notifywithmetadata',
                 'headers': request.headers,

--- a/example/logger/bugsnag_logger.py
+++ b/example/logger/bugsnag_logger.py
@@ -46,7 +46,7 @@ bugsnag.configure(
 logger = logging.getLogger("test.logger")
 
 # Create a Bugsnag handler.
-# Optionally, add 'extra_fields' which will attach meta_data to every Bugsnag
+# Optionally, add 'extra_fields' which will attach metadata to every Bugsnag
 # report. The values should be attributes to pull off each log record.
 handler = BugsnagHandler(extra_fields={"logger": ["__repr__"]})
 
@@ -99,8 +99,8 @@ def use_custom_exception_data(report):
     exception data with it, overriding the class and message seen on the
     Bugsnag dashboard. This attaches to the bugsnag.before_notify().
     """
-    if 'custom' in report.meta_data:
-        exception = report.meta_data['custom'].pop('custom exception', None)
+    if 'custom' in report.metadata:
+        exception = report.metadata['custom'].pop('custom exception', None)
         if exception is not None:
             report.exception = exception
 

--- a/tests/integrations/test_asgi.py
+++ b/tests/integrations/test_asgi.py
@@ -104,7 +104,7 @@ class TestASGIMiddleware(IntegrationTest):
         app = Starlette()
 
         async def next_func():
-            bugsnag.configure_request(meta_data={'wave': {'size': '35b'}})
+            bugsnag.configure_request(metadata={'wave': {'size': '35b'}})
             raise ScaryException('fell winds!')
 
         @app.route('/')

--- a/tests/integrations/test_async_asgi.py
+++ b/tests/integrations/test_async_asgi.py
@@ -102,7 +102,7 @@ class TestASGIMiddleware(AsyncIntegrationTest):
 
     async def test_custom_metadata(self):
         async def next_func():
-            bugsnag.configure_request(meta_data={'wave': {'size': '35b'}})
+            bugsnag.configure_request(metadata={'wave': {'size': '35b'}})
             raise CustomException('fell winds!')
 
         async def app(scope, recv, send):

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -88,14 +88,14 @@ class TestFlask(IntegrationTest):
                          'http://localhost/hello')
 
     def test_bugsnag_custom_data(self):
-        meta_data = [{"hello": {"world": "once"}},
-                     {"again": {"hello": "world"}}]
+        metadata = [{"hello": {"world": "once"}},
+                    {"again": {"hello": "world"}}]
 
         app = Flask("bugsnag")
 
         @app.route("/hello")
         def hello():
-            bugsnag.configure_request(meta_data=meta_data.pop())
+            bugsnag.configure_request(metadata=metadata.pop())
             raise SentinelError("oops")
 
         handle_exceptions(app)

--- a/tests/integrations/test_wsgi.py
+++ b/tests/integrations/test_wsgi.py
@@ -128,12 +128,12 @@ class TestWSGI(IntegrationTest):
         payload = self.server.received[0]['json_body']
         self.assertEqual(payload['events'][0]['user']['id'], '5')
 
-    def test_bugsnag_middleware_respects_meta_data(self):
+    def test_bugsnag_middleware_respects_metadata(self):
 
         class CrashAfterSettingMetaData(object):
             def __init__(self, environ, start_response):
-                bugsnag.configure_request(meta_data={"account":
-                                                     {"paying": True}})
+                bugsnag.configure_request(metadata={"account":
+                                                    {"paying": True}})
 
             def __iter__(self):
                 raise SentinelError("oops")

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -5,6 +5,7 @@ import os
 import sys
 import unittest
 
+import pytest
 from bugsnag.configuration import Configuration
 from bugsnag.event import Event
 from tests import fixtures
@@ -182,3 +183,16 @@ class TestEvent(unittest.TestCase):
         config.configure(app_type='rq')
         event = self.event_class(Exception("oops"), config, {})
         assert event.request is None
+
+    def test_meta_data_warning(self):
+        config = Configuration()
+        with pytest.warns(DeprecationWarning) as records:
+            event = self.event_class(Exception('oh no'), config, {},
+                                     meta_data={'nuts': {'almonds': True}})
+
+            assert len(records) > 0
+            i = len(records) - 1
+            assert str(records[i].message) == ('The Event "metadata" ' +
+                                               'argument has been replaced ' +
+                                               'with "metadata"')
+            assert event.metadata['nuts']['almonds']

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -321,7 +321,7 @@ class HandlersTest(IntegrationTest):
 
         def some_callback(record, options):
             for key in record.meals:
-                options['meta_data'][key] = record.meals[key]
+                options['metadata'][key] = record.meals[key]
 
         handler.add_callback(some_callback)
         logger.info('Everything is fine', extra={'meals': {
@@ -343,10 +343,10 @@ class HandlersTest(IntegrationTest):
     def test_client_remove_callback(self, handler, logger):
 
         def some_callback(record, options):
-            options['meta_data']['tab'] = {'key': 'value'}
+            options['metadata']['tab'] = {'key': 'value'}
 
         def some_other_callback(record, options):
-            options['meta_data']['tab2'] = {'key': 'value'}
+            options['metadata']['tab2'] = {'key': 'value'}
 
         handler.add_callback(some_callback)
         handler.add_callback(some_other_callback)
@@ -365,10 +365,10 @@ class HandlersTest(IntegrationTest):
     def test_client_clear_callbacks(self, handler, logger):
 
         def some_callback(record, options):
-            options['meta_data']['tab'] = {'key': 'value'}
+            options['metadata']['tab'] = {'key': 'value'}
 
         def some_other_callback(record, options):
-            options['meta_data']['tab2'] = {'key': 'value'}
+            options['metadata']['tab2'] = {'key': 'value'}
 
         handler.add_callback(some_callback)
         handler.add_callback(some_other_callback)
@@ -385,11 +385,11 @@ class HandlersTest(IntegrationTest):
     def test_client_crashing_callback(self, handler, logger):
 
         def some_callback(record, options):
-            options['meta_data']['tab'] = {'key': 'value'}
+            options['metadata']['tab'] = {'key': 'value'}
             raise ScaryException('Oh dear')
 
         def some_other_callback(record, options):
-            options['meta_data']['tab']['key2'] = 'other value'
+            options['metadata']['tab']['key2'] = 'other value'
 
         handler.add_callback(some_callback)
         handler.add_callback(some_other_callback)

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -3,6 +3,7 @@
 import sys
 import time
 
+import pytest
 import bugsnag
 from tests.utils import ScaryException, IntegrationTest
 from tests.fixtures import samples
@@ -800,3 +801,17 @@ class TestBugsnag(IntegrationTest):
         bugsnag.notify(ScaryException('unexpected failover'),
                        asynchronous=False)
         assert len(self.server.received) == 1
+
+    def test_meta_data_warning(self):
+        with pytest.warns(DeprecationWarning) as records:
+            bugsnag.notify(ScaryException('false equivalence'),
+                           meta_data={'fruit': {'apples': 2}})
+
+            assert len(records) == 1
+            assert str(records[0].message) == ('The Event "metadata" ' +
+                                               'argument has been replaced ' +
+                                               'with "metadata"')
+
+        json_body = self.server.received[0]['json_body']
+        metadata = json_body['events'][0]['metaData']
+        assert metadata['fruit']['apples'] == 2

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -115,8 +115,7 @@ class TestBugsnag(IntegrationTest):
     def test_notify_override_metadata_sections(self):
         bugsnag.add_metadata_tab('food', {'beans': 3, 'corn': 'purple'})
         bugsnag.notify(ScaryException('unexpected failover'),
-                       meta_data={'food': {'beans': 5},
-                                  'skills': {'spear': 6}})
+                       metadata={'food': {'beans': 5}, 'skills': {'spear': 6}})
         json_body = self.server.received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual(6, event['metaData']['skills']['spear'])
@@ -248,7 +247,7 @@ class TestBugsnag(IntegrationTest):
     def test_notify_before_notify_modifying_metadata(self):
 
         def callback(report):
-            report.meta_data['foo'] = {'sandwich': 'bar'}
+            report.metadata['foo'] = {'sandwich': 'bar'}
 
         bugsnag.before_notify(callback)
         bugsnag.notify(ScaryException('unexpected failover'))
@@ -487,7 +486,7 @@ class TestBugsnag(IntegrationTest):
                 '-838b-a05aadc06a5\x00\x02uid\x00%\x00\x00\x001bab969f-7b30'
                 '-459a-adee-917b9e028eed\x00\x00')
         self_class = 'tests.test_notify.TestBugsnag'
-        bugsnag.notify(Exception('free food'), meta_data={'payload': {
+        bugsnag.notify(Exception('free food'), metadata={'payload': {
             'project': '∆πåß∂ƒ',
             'filename': 'DISPOSITIFS DE SÉCURITÉ.pdf',
             '♥♥i': '♥♥♥♥♥♥',
@@ -594,10 +593,10 @@ class TestBugsnag(IntegrationTest):
 
     def test_middleware_stack_order_legacy(self):
         def first_callback(event):
-            event.meta_data['test']['array'].append(1)
+            event.metadata['test']['array'].append(1)
 
         def second_callback(event):
-            event.meta_data['test']['array'].append(2)
+            event.metadata['test']['array'].append(2)
 
         # Add a regular callback function
         bugsnag.before_notify(second_callback)
@@ -621,10 +620,10 @@ class TestBugsnag(IntegrationTest):
                                 asynchronous=False)
 
         def first_callback(event):
-            event.meta_data['test']['array'].append(1)
+            event.metadata['test']['array'].append(1)
 
         def second_callback(event):
-            event.meta_data['test']['array'].append(2)
+            event.metadata['test']['array'].append(2)
 
         client.configuration.middleware.before_notify(second_callback)
         client.configuration.internal_middleware.before_notify(first_callback)

--- a/tests/test_path_encoding.py
+++ b/tests/test_path_encoding.py
@@ -36,7 +36,7 @@ class PathEncodingTest(unittest.TestCase):
 
         self.assertEqual(
             'http://localhost/hello/world',
-            event.meta_data['request']['url']
+            event.metadata['request']['url']
         )
 
     def test_wrongly_encoded_url_should_not_raise(self):
@@ -63,7 +63,7 @@ class PathEncodingTest(unittest.TestCase):
         # invalid encoding sequences
         self.assertEqual(
             'http://localhost/%s' % quote('%83'),
-            event.meta_data['request']['url']
+            event.metadata['request']['url']
         )
 
     def test_path_supports_emoji(self):
@@ -88,7 +88,7 @@ class PathEncodingTest(unittest.TestCase):
         # You can validate this by using "encodeURIComponent" in a browser.
         self.assertEqual(
             'http://localhost/%F0%9F%98%87',
-            event.meta_data['request']['url']
+            event.metadata['request']['url']
         )
 
     def test_path_supports_non_ascii_characters(self):
@@ -113,7 +113,7 @@ class PathEncodingTest(unittest.TestCase):
         # You can validate this by using "encodeURIComponent" in a browser.
         self.assertEqual(
             'http://localhost/%C3%B4%C3%9F%C5%82%E3%82%AC',
-            event.meta_data['request']['url']
+            event.metadata['request']['url']
         )
 
 

--- a/tests/test_request_config.py
+++ b/tests/test_request_config.py
@@ -1,0 +1,14 @@
+import pytest
+
+from bugsnag import RequestConfiguration
+
+
+def test_request_config_meta_data_warns():
+    config = RequestConfiguration.get_instance()
+
+    with pytest.warns(DeprecationWarning) as records:
+        config.meta_data['foo'] = 'bar'
+        assert len(records) == 1
+        assert str(records[0].message) == ('RequestConfiguration.meta_data ' +
+                                           'has been renamed to "metadata"')
+    assert config.metadata['foo'] == 'bar'


### PR DESCRIPTION
## Goal

Rename `meta_data` to metadata, which should be more in line with the spec and the dictionary.

## Changeset

* Updated `Event.meta_data` and `RequestConfiguration.meta_data`, adding deprecation warnings
* Updated every use of `meta_data` to `metadata` in the library. This is in the latter commit to make it easier to review.

## Testing

* Tested that the library still functioned as expected after the initial change (but still using `meta_data` everywhere). The only test breakages were related to the tests which verified the number of warnings sent.
* Manually sent events to verify payload contents
* Added new tests for the warnings themselves