### PR TITLE
fix: add missing typing marker file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## 4.0.1 (2020-10-06)
+
+* Fix issue where types were not packaged with the library
+
 ## 4.0.0 (2020-10-01)
 
 This is a major release which adds new features while removing previously

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Topic :: Software Development'
     ],
+    package_data = {
+        'bugsnag': ['py.typed'],
+    },
     test_suite='tests',
     install_requires=['webob'],
     extras_require={


### PR DESCRIPTION
Typing information is not being exported with the package

## Changeset

Added [`py.typed`](https://www.python.org/dev/peps/pep-0561/#id18) to the root of the package and in the manifest

## Testing

Tested manually by running `mypy` against a script calling prepackaged bugsnag with invalid types. This would be an automated test if not for encountering an internal error in mypy in the automated environment.

Updates #164 