### PR TITLE
Fetch code from files before changing the file path

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,6 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10.0-alpha.1']
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fixed an issue preventing code being fetched from files in the project root but not in the PWD
+  [#246](https://github.com/bugsnag/bugsnag-python/pull/246)
+
 ## 4.0.1 (2020-10-06)
 
 ### Bug fixes

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -190,6 +190,10 @@ class Event:
             if skip_module:
                 continue
 
+            # Fetch the code before (potentially) removing the project root
+            # from the file path
+            code = self._code_for(file_name, int(str(line[1])))
+
             if lib_root and file_name.startswith(lib_root):
                 file_name = file_name[len(lib_root):]
             elif project_root and file_name.startswith(project_root):
@@ -201,7 +205,7 @@ class Event:
                 "lineNumber": int(str(line[1])),
                 "method": str(line[2]),
                 "inProject": in_project,
-                "code": self._code_for(file_name, int(str(line[1])))
+                "code": code
             })
 
         stacktrace.reverse()

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -114,6 +114,15 @@ class TestEvent(unittest.TestCase):
         first_traceback = exception['stacktrace'][0]
 
         self.assertEqual(first_traceback['file'], 'fixtures/helpers.py')
+        self.assertEqual(
+            {
+                '1': 'def invoke_exception_on_other_file(config):',
+                '2': '    from bugsnag.event import Event',
+                '3': '',
+                '4': '    return Event(Exception("another file!"), config, {})'
+            },
+            first_traceback['code']
+        )
 
     def test_traceback_exclude_modules(self):
         # Make sure samples.py is compiling to pyc

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,9 @@ deps=
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
     django3: Django>=3.0,<4.0
-    django{18,19,110,111,20,21,22,3}: pytest-django
+    django{18,19,110,111,20,21}: six
+    django{18,19,110,111,20,21}: pytest-django<4.0
+    django{22,3}: pytest-django
     lint: flake8
     lint: mypy
 


### PR DESCRIPTION
## Goal

Currently we trim the project root from file names before fetching the code for the file. This breaks if the file we want is in the project root, but not in the PWD (see #245)

To fix this, we will now fetch the code using the absolute path of the file

## Changeset

- `.github/workflows/python-package.yml`
    disable fail-fast as it can hide failures (e.g. if Python 3.5 fails, 3.6 will be cancelled and so you can't tell if it passes)
- `bugsnag/event.py`
    Fetch the code before (potentially) removing the project root from the file path
- `tox.ini`
    Install compatible version of `pytest-django` on Django < 2.2 (see [v4.0.0 changelog](https://pytest-django.readthedocs.io/en/latest/changelog.html#v4-0-0-2020-10-16)). I'm not sure why this now requires `six` to be installed explicitly when it didn't before though :/

## Testing

One of the existing tests actually covered this case, it just didn't assert on the code

I also manually tested this before & after with the repro case in #245:

| Before | After |
|-------|------|
| <img width="379" alt="image" src="https://user-images.githubusercontent.com/282732/100899972-48826a80-34ba-11eb-8ebf-def9c4b6dc89.png"> | <img width="438" alt="image" src="https://user-images.githubusercontent.com/282732/100899902-399bb800-34ba-11eb-86f4-9690ab677648.png"> |