### PR TITLE
ci: notify coveralls when parallel jobs complete

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,21 @@ jobs:
     - name: Upload code coverage data
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_FLAG_NAME: ${{ matrix.test-name }}
+        COVERALLS_PARALLEL: true
       run: |
         coverage combine
         coveralls
+
+  coveralls:
+    name: Finish Coveralls processing
+    needs: test
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+    - name: Send request
+      run: |
+        pip3 install --upgrade coveralls
+        coveralls --finish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Avoid situation where first job to complete is deemed the entire build's coverage.

[Found some useful docs on the topic](https://github.com/coveralls-clients/coveralls-python/blob/458e22defbdeaf86458cccf315eee5000bf97689/docs/usage/configuration.rst#github-actions-gotcha)
