### PR TITLE
Fix for Bugsnag-Python to support multiple threads in Python 2.7

### DIFF
--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -298,6 +298,7 @@ class ThreadContextVar:
         if hasattr(local, self.name):
             return getattr(local, self.name)
         elif self.default is not None:
+            # Make a deep copy so that each thread starts with a fresh default
             result = copy.deepcopy(self.default)
             self.set(result)
             return result


### PR DESCRIPTION
## Goal

In Python 2.7, Bugsnag-Python uses an in-house backport of ContextVar called ThreadContextVar.  However, ThreadContextVar doesn't work as expected except in the parent thread.  Repro steps:

```
from bugsnag.utils import ThreadContextVar
import threading
s = ThreadContextVar('bugsnag-session', default={})
def f():
    return s.get()

t = threading.Thread(target=f)
 t.start()
Exception in thread Thread-158:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "<ipython-input-3-7208fb1a20e2>", line 2, in f
    return s.get()
  File "/usr/local/lib/python3.6/dist-packages/bugsnag/utils.py", line 316, in get
    raise LookupError("No value for '{}'".format(self.name))
LookupError: No value for 'bugsnag-session'
```

As a result, any attempt to use the Bugsnag API from a child thread in Python 2.7 fails.

## Design

I wrote a unit test for the above failure, matching the expected behavior of ContextVar in Python 3+, and modified ThreadContextVar to pass the test.

## Changeset

I altered ThreadContextVar to store a `default` per-instance, rather than only in the parent thread, and to set a fresh copy of `default` in each thread where it's accessed.

## Testing

I tested with `py.test tests --ignore=tests/integrations`.  My new test of thread-safety passes with these modifications.