### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,7 @@ jobs:
         COVERALLS_PARALLEL: true
       run: |
         coverage combine
-        coveralls
+        coveralls --service github
 
   coveralls:
     name: Finish Coveralls processing
@@ -43,6 +43,6 @@ jobs:
     - name: Send request
       run: |
         pip3 install --upgrade coveralls
-        coveralls --finish
+        coveralls --service github --finish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands =
     pytest --doctest-modules bugsnag --doctest-ignore-import-errors
     test: pytest --ignore=tests/integrations
     asynctest: pytest tests/integrations/test_async_asgi.py tests/integrations/test_async_request.py
-    threadtest: pytest tests/integrations/test_thread_excepthook.py
+    threadtest: pytest -p no:threadexception tests/integrations/test_thread_excepthook.py
     requests: pytest --ignore=tests/integrations tests tests/integrations/test_requests_delivery.py
     bottle: pytest tests/integrations/test_bottle.py
     celery{4,5}: pytest tests/integrations/test_celery.py


### PR DESCRIPTION
## Goal

Two recent unrelated updates broke CI:

1. The default Coveralls "service" changed from `github` to `github-actions`. This stops it from picking up the `GITHUB_TOKEN`, so we have to manually specify `--service github` — https://github.com/TheKevJames/coveralls-python/issues/252
2. pytest 6.2 introduced warnings for uncaught thread exceptions. This is nice but broke our tests for uncaught thread exceptions, so I've disable this module for the thread excepthook tests ([pytest docs](https://docs.pytest.org/en/stable/usage.html#warning-about-unraisable-exceptions-and-unhandled-thread-exceptions))