### PR TITLE
Fix for Bugsnag-Python to support multiple threads in bugsnag-python v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fixed an issue with `ContextVar` backport for Python 3.5 and 3.6
+  [Michael J.T. O'Kelly](https://github.com/mokelly)
+  [#254](https://github.com/bugsnag/bugsnag-python/pull/254)
+
 ## 4.0.2 (2020-12-03)
 
 ### Bug fixes

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -298,6 +298,7 @@ class ThreadContextVar:
         if hasattr(local, self.name):
             return getattr(local, self.name)
         elif self.default is not None:
+            # Make a deep copy so that each thread starts with a fresh default
             result = copy.deepcopy(self.default)
             self.set(result)
             return result

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -287,21 +287,28 @@ class ThreadContextVar:
             ThreadContextVar.LOCALS = threadlocal()
         return ThreadContextVar.LOCALS
 
-    def __init__(self, name, default=None):
+    def __init__(self, name, **kwargs):
         self.name = name
-        self.default = default
-        # Make a deep copy so that each thread starts with a fresh default
-        self.set(copy.deepcopy(default))
+
+        # Mimic the behaviour of ContextVar - if a default has been explicitly
+        # passed then we will use it, otherwise don't set an initial value
+        # This allows 'get' to know when to raise a LookupError
+        if 'default' in kwargs:
+            self.default = kwargs['default']
+            # Make a deep copy so this thread starts with a fresh default
+            self.set(copy.deepcopy(self.default))
 
     def get(self):
         local = ThreadContextVar.local_context()
         if hasattr(local, self.name):
             return getattr(local, self.name)
-        elif self.default is not None:
+
+        if hasattr(self, 'default'):
             # Make a deep copy so that each thread starts with a fresh default
             result = copy.deepcopy(self.default)
             self.set(result)
             return result
+
         raise LookupError("No value for '{}'".format(self.name))
 
     def set(self, new_value):

--- a/tests/test_sessionmiddleware.py
+++ b/tests/test_sessionmiddleware.py
@@ -1,4 +1,5 @@
 import unittest
+import threading
 
 from bugsnag.sessiontracker import SessionTracker, SessionMiddleware
 from bugsnag.configuration import Configuration
@@ -42,3 +43,27 @@ class TestSessionMiddleware(unittest.TestCase):
         # Session counts should not change for events already handled
         assert event.session['events']['unhandled'] == 0
         assert event.session['events']['handled'] == 1
+
+    def test_it_does_nothing_if_no_session_exists(self):
+        def run_session_middleware():
+            def next_callable(event):
+                pass
+
+            try:
+                thread.exc_info = None
+                middleware = SessionMiddleware(next_callable)
+
+                event = Event(Exception('shucks'), self.config, None)
+                middleware(event)
+
+                assert event.session is None
+            except Exception:
+                import sys
+                thread.exc_info = sys.exc_info()
+
+        thread = threading.Thread(target=run_session_middleware)
+        thread.start()
+        thread.join()
+
+        # ensure there was no exception in the thread
+        self.assertEqual(None, thread.exc_info, thread.exc_info)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -85,16 +85,21 @@ class TestUtils(unittest.TestCase):
         sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data, data)
 
-    def test_thread_context_vars_default(self):
+    def test_thread_context_vars_get_raises_if_no_default(self):
         token = ThreadContextVar(str(uuid.uuid4()))
-        self.assertEqual(None, token.get())  # default value is none
+        self.assertRaises(LookupError, token.get)
 
-    def test_thread_context_vars_set_default_value(self):
-        token = ThreadContextVar(str(uuid.uuid4()), {'pips': 3})
+    def test_thread_context_vars_returns_default_value_from_get(self):
+        token = ThreadContextVar(str(uuid.uuid4()), default={'pips': 3})
         self.assertEqual({'pips': 3}, token.get())
 
+    def test_thread_context_vars_set_new_value_with_no_default(self):
+        token = ThreadContextVar(str(uuid.uuid4()))
+        token.set({'peas': 'maybe'})
+        self.assertEqual({'peas': 'maybe'}, token.get())
+
     def test_thread_context_vars_set_new_value(self):
-        token = ThreadContextVar(str(uuid.uuid4()), {'pips': 3})
+        token = ThreadContextVar(str(uuid.uuid4()), default={'pips': 3})
         token.set({'carrots': 'no'})
         self.assertEqual({'carrots': 'no'}, token.get())
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,26 +102,35 @@ class TestUtils(unittest.TestCase):
         Verify that ThreadContextVar backport has correct behavior
         inside a new thread.
         """
-        # TODO: Tokens are a different class, not yet emulated
-        # (https://docs.python.org/3/library/contextvars.html#contextvars.contextvars.Token)
         token = ThreadContextVar('TEST_contextvars', default={'pips': 3})
         token.set({'pips': 4})
 
         def thread_worker():
-            result = token.get()
-            # Test that we got a new, unmodified copy of the default
-            self.assertEqual({'pips': 3}, result)
-            result['pips'] = 5
-            result2 = token.get()
-            # Test that local modifications are persistent
-            self.assertEqual({'pips': 5}, result2)
+            try:
+                thread.exc_info = None
+
+                result = token.get()
+
+                # Test that we got a new, unmodified copy of the default
+                self.assertEqual({'pips': 3}, result)
+
+                result['pips'] = 5
+
+                # Test that local modifications are persistent
+                self.assertEqual({'pips': 5}, token.get())
+            except Exception:
+                import sys
+                thread.exc_info = sys.exc_info()
 
         thread = threading.Thread(target=thread_worker)
         thread.start()
         thread.join()
-        result3 = token.get()
+
+        # ensure exceptions in the thread_worker fail the test
+        self.assertEqual(None, thread.exc_info, thread.exc_info)
+
         # Test that non-local changes don't leak through
-        self.assertEqual({'pips': 4}, result3)
+        self.assertEqual({'pips': 4}, token.get())
 
     def test_encoding_recursive(self):
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import sys
 import datetime
 import re
 import threading
+import uuid
 
 from bugsnag.utils import (SanitizingJSONEncoder, FilterDict,
                            is_json_content_type, parse_content_type,
@@ -85,15 +86,15 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(sane_data, data)
 
     def test_thread_context_vars_default(self):
-        token = ThreadContextVar("TEST_contextvars")
+        token = ThreadContextVar(str(uuid.uuid4()))
         self.assertEqual(None, token.get())  # default value is none
 
     def test_thread_context_vars_set_default_value(self):
-        token = ThreadContextVar("TEST_contextvars", {'pips': 3})
+        token = ThreadContextVar(str(uuid.uuid4()), {'pips': 3})
         self.assertEqual({'pips': 3}, token.get())
 
     def test_thread_context_vars_set_new_value(self):
-        token = ThreadContextVar("TEST_contextvars", {'pips': 3})
+        token = ThreadContextVar(str(uuid.uuid4()), {'pips': 3})
         token.set({'carrots': 'no'})
         self.assertEqual({'carrots': 'no'}, token.get())
 
@@ -102,7 +103,7 @@ class TestUtils(unittest.TestCase):
         Verify that ThreadContextVar backport has correct behavior
         inside a new thread.
         """
-        token = ThreadContextVar('TEST_contextvars', default={'pips': 3})
+        token = ThreadContextVar(str(uuid.uuid4()), default={'pips': 3})
         token.set({'pips': 4})
 
         def thread_worker():


### PR DESCRIPTION
## Goal

This is a rebased https://github.com/bugsnag/bugsnag-python/pull/254 with some extra tests and further improved handling of default values to more closely mimic the ContextVar API

i.e. When a ContextVar is created with no default, calling `get` before `set` will raise. When a ContextVar is created with `None` as the default, calling `get` will return `None`. This is now also the behaviour of `ThreadContextVar`

We'll also need to backport this fix to v3 — I'll do that after review feedback