### PR TITLE
Exclude bugsnag from pip freeze in license audit action

### DIFF
--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up requirements.txt for License Finder
       run: |
         pip3 install '.[flask]'
-        pip3 freeze --local | tee requirements.txt
+        pip3 freeze --local --exclude bugsnag | tee requirements.txt
 
     - name: Run License Finder
       # for some reason license finder doesn't run without a login shell (-l)


### PR DESCRIPTION
## Goal

The new license audit action has to use a workaround to get bugsnag's dependencies because License Finder only supports requirements.txt files, which we don't use

The workaround installs the dependencies with pip and uses `pip --freeze` to write them to this file. However, this also includes the bugsnag package itself

At the time this didn't seem like a problem, but when we bump the version number for a new release, License Finder gets upset because the new version isn't on PyPI yet

To fix this, this PR excludes `bugsnag` from the `pip --freeze` so License Finder won't try to find unreleased versions