### PR TITLE
Move internal Bugsnag logger to the Configuration class

### DIFF
--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -1,6 +1,3 @@
-import sys
-import logging
-
 from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.notification import Notification
 from bugsnag.event import Event
@@ -8,19 +5,10 @@ from bugsnag.client import Client
 from bugsnag.legacy import (configuration, configure, configure_request,
                             add_metadata_tab, clear_request_config, notify,
                             auto_notify, before_notify, start_session,
-                            auto_notify_exc_info)
+                            auto_notify_exc_info, logger)
 
 __all__ = ('Client', 'Event', 'Configuration', 'RequestConfiguration',
            'configuration', 'configure', 'configure_request',
            'add_metadata_tab', 'clear_request_config', 'notify',
            'auto_notify', 'before_notify', 'start_session',
-           'auto_notify_exc_info',
-           'Notification')
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
-handler = logging.StreamHandler(sys.stderr)
-formatter = logging.Formatter(
-    '%(asctime)s - [%(name)s] %(levelname)s - %(message)s')
-handler.setFormatter(formatter)
-logger.addHandler(handler)
+           'auto_notify_exc_info', 'Notification', 'logger')

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -9,6 +9,7 @@ import bugsnag
 
 default_client = Client()
 configuration = default_client.configuration
+logger = configuration.logger
 ExcInfoType = Tuple[Type, Exception, types.TracebackType]
 
 


### PR DESCRIPTION
## Goal

We have a logger that's used internally when various error conditions happen, e.g. when delivery fails. Currently this is exposed as `bugsnag.logger`

This has been moved to the Configuration class, in order to be more inline with notifiers for other platforms and to allow for logging to use configuration options in future

A logger can be passed to the Configuration constructor and `configure` method:

```python
config = Configuration(logger=some_logger)
config.configure(logger=some_other_logger)
```

Logging can be disabled by passing `None` instead of a logger instance

Any value other than a `logging.Logger` or `None` will raise a warning and use the default logger

`bugsnag.logger` is still available for backwards compatibility using the global configuration instance's logger