### PR TITLE
Use the Configuration logger instead of `bugsnag.logger`

### DIFF
--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -9,9 +9,6 @@ from bugsnag.event import Event
 from bugsnag.handlers import BugsnagHandler
 from bugsnag.sessiontracker import SessionTracker
 
-import bugsnag
-
-
 __all__ = ('Client',)
 
 
@@ -157,9 +154,12 @@ class Client:
                     options = {'asynchronous': asynchronous}
 
                 if event.api_key is None:
-                    bugsnag.logger.warning(
-                        "No API key configured, couldn't notify")
+                    self.configuration.logger.warning(
+                        "No API key configured, couldn't notify"
+                    )
+
                     return
+
                 if initial_severity != event.severity:
                     event.severity_reason = {
                         'type': 'userCallbackSetSeverity'
@@ -171,7 +171,11 @@ class Client:
                     self.configuration.delivery.deliver(self.configuration,
                                                         payload, options)
                 except Exception as e:
-                    bugsnag.logger.exception('Notifying Bugsnag failed %s', e)
+                    self.configuration.logger.exception(
+                        'Notifying Bugsnag failed %s',
+                        e
+                    )
+
                 # Trigger session delivery
                 self.session_tracker.send_sessions()
 

--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -12,7 +12,6 @@ from urllib.request import (
     build_opener
 )
 
-import bugsnag
 from bugsnag.event import Event
 
 try:
@@ -117,8 +116,9 @@ class UrllibDelivery(Delivery):
             else:
                 success = 200
             if status != success:
-                bugsnag.logger.warning(
-                    'Delivery to %s failed, status %d' % (uri, status))
+                config.logger.warning(
+                    'Delivery to %s failed, status %d' % (uri, status)
+                )
 
         self.queue_request(request, config, options)
 
@@ -150,7 +150,8 @@ class RequestsDelivery(Delivery):
                 success = requests.codes.ok
 
             if status != success:
-                bugsnag.logger.warning(
-                    'Delivery to %s failed, status %d' % (uri, status))
+                config.logger.warning(
+                    'Delivery to %s failed, status %d' % (uri, status)
+                )
 
         self.queue_request(request, config, options)

--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -44,7 +44,7 @@ def add_django_request_to_notification(event):
                 username = str(request.user.get_username())
                 event.set_user(id=username, email=email, name=name)
             except Exception:
-                bugsnag.logger.exception('Could not get user data')
+                event.config.logger.exception('Could not get user data')
     else:
         event.set_user(id=request.META['REMOTE_ADDR'])
 

--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -72,21 +72,28 @@ def add_django_request_to_notification(event):
 
 
 def configure():
+    config = bugsnag.configure()
+
     # default to development if in DEBUG mode
     if getattr(settings, 'DEBUG'):
-        bugsnag.configure(release_stage='development')
-
-    request_started.connect(__track_session)
-    got_request_exception.connect(__handle_request_exception)
+        config.configure(release_stage='development')
 
     # Import Bugsnag settings from settings.py
     django_bugsnag_settings = getattr(settings, 'BUGSNAG', {})
-    bugsnag.configure(**django_bugsnag_settings)
+    config.configure(**django_bugsnag_settings)
 
-    middleware = bugsnag.configure().internal_middleware
+    middleware = config.internal_middleware
     middleware.before_notify(add_django_request_to_notification)
 
-    bugsnag.configure().runtime_versions['django'] = django.__version__
+    config.runtime_versions['django'] = django.__version__
+
+    request_started.connect(__track_session)
+    got_request_exception.connect(
+        __handle_request_exception(config.logger),
+        weak=False
+    )
+
+    return config
 
 
 def __track_session(sender, **extra):
@@ -94,14 +101,19 @@ def __track_session(sender, **extra):
         bugsnag.start_session()
 
 
-def __handle_request_exception(sender, **kwargs):
-    request = kwargs.get('request', None)
-    if request is not None:
-        bugsnag.configure_request(django_request=request)
-    try:
-        bugsnag.auto_notify_exc_info(severity_reason={
-            "type": "unhandledExceptionMiddleware",
-            "attributes": {"framework": "Django"}
-        })
-    except Exception:
-        bugsnag.logger.exception("Error in exception middleware")
+def __handle_request_exception(logger):
+    def inner(sender, **kwargs):
+        request = kwargs.get('request', None)
+
+        if request is not None:
+            bugsnag.configure_request(django_request=request)
+
+        try:
+            bugsnag.auto_notify_exc_info(severity_reason={
+                "type": "unhandledExceptionMiddleware",
+                "attributes": {"framework": "Django"}
+            })
+        except Exception:
+            logger.exception("Error in exception middleware")
+
+    return inner

--- a/bugsnag/django/middleware.py
+++ b/bugsnag/django/middleware.py
@@ -9,7 +9,7 @@ import bugsnag.django
 
 class BugsnagMiddleware(MiddlewareMixin):
     def __init__(self, get_response=None):
-        bugsnag.django.configure()
+        self.config = bugsnag.django.configure()
         super(BugsnagMiddleware, self).__init__(get_response)
 
     # pylint: disable-msg=R0201
@@ -37,7 +37,7 @@ class BugsnagMiddleware(MiddlewareMixin):
             )
 
         except Exception:
-            bugsnag.logger.exception("Error in exception middleware")
+            self.config.logger.exception("Error in exception middleware")
 
         bugsnag.clear_request_config()
 

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -238,9 +238,12 @@ class Event:
     def _payload(self):
         # Fetch the notifier version from the package
         notifier_version = package_version("bugsnag") or "unknown"
-        filters = self.config.params_filters
-        encoder = SanitizingJSONEncoder(separators=(',', ':'),
-                                        keyword_filters=filters)
+        encoder = SanitizingJSONEncoder(
+            self.config.logger,
+            separators=(',', ':'),
+            keyword_filters=self.config.params_filters
+        )
+
         # Construct the payload dictionary
         return encoder.encode({
             "apiKey": self.api_key,

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -155,7 +155,7 @@ class Event:
                     module_file = module_file[:-1]
                 exclude_module_paths.append(module_file)
             except Exception:
-                bugsnag.logger.exception(
+                self.config.logger.exception(
                     'Could not exclude module: %s' % repr(exclude_module))
 
         lib_root = self.config.lib_root

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -41,13 +41,16 @@ class BugsnagHandler(logging.Handler, object):
             }
         }
 
+        client = self.client or bugsnag.legacy.default_client
+
         for callback in self.callbacks:
             try:
                 callback(record, options)
             except Exception as e:
-                bugsnag.logger.error('Failed to run handler callback %s', e)
-
-        client = self.client or bugsnag.legacy.default_client
+                client.configuration.logger.error(
+                    'Failed to run handler callback %s',
+                    e
+                )
 
         if 'exception' in options:
             exception = options.pop('exception')

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -5,8 +5,6 @@ import sys
 from bugsnag.configuration import RequestConfiguration
 from bugsnag.client import Client
 
-import bugsnag
-
 default_client = Client()
 configuration = default_client.configuration
 logger = configuration.logger
@@ -71,8 +69,10 @@ def notify(exception: BaseException, **options):
             except Exception:
                 value = '[BADENCODING]'
 
-            bugsnag.logger.warning('Coercing invalid notify()'
-                                   ' value to RuntimeError: %s' % value)
+            default_client.configuration.logger.warning(
+                'Coercing invalid notify() value to RuntimeError: %s' % value
+            )
+
             exception = RuntimeError(value)
 
         default_client.notify(exception, **options)

--- a/bugsnag/middleware.py
+++ b/bugsnag/middleware.py
@@ -1,6 +1,5 @@
 from typing import Callable, Optional, Type, List
 
-import bugsnag
 from bugsnag.event import Event
 
 
@@ -57,7 +56,7 @@ class DefaultMiddleware:
                 event.add_tab(name, dictionary)
 
         event.add_tab("request", config.get("request_data"))
-        if bugsnag.configure().send_environment:
+        if event.config.send_environment:
             event.add_tab("environment", config.get("environment_data"))
         event.add_tab("session", config.get("session_data"))
         event.add_tab("extraData", config.get("extra_data"))
@@ -158,6 +157,9 @@ class MiddlewareStack:
         try:
             to_call(event)
         except Exception:
-            bugsnag.logger.exception('Error in exception middleware')
+            event.config.logger.exception(
+                'Error in exception middleware'
+            )
+
             # still notify if middleware crashes before event
             finish(event)

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -13,7 +13,6 @@ except ImportError:
     # flake8: noqa
     _session_info = ThreadContextVar('bugsnag-session', default={})  # type: ignore
 
-import bugsnag
 from bugsnag.utils import package_version, FilterDict, SanitizingJSONEncoder
 from bugsnag.event import Event
 
@@ -97,15 +96,17 @@ class SessionTracker:
 
     def __deliver(self, sessions: List[Dict]):
         if not sessions:
-            bugsnag.logger.debug("No sessions to deliver")
+            self.config.logger.debug("No sessions to deliver")
             return
 
         if not self.config.api_key:
-            bugsnag.logger.debug("Not delivering due to an invalid api_key")
+            self.config.logger.debug(
+                "Not delivering due to an invalid api_key"
+            )
             return
 
         if not self.config.should_notify():
-            bugsnag.logger.debug("Not delivering due to release_stages")
+            self.config.logger.debug("Not delivering due to release_stages")
             return
 
         notifier_version = package_version('bugsnag') or 'unknown'
@@ -134,7 +135,7 @@ class SessionTracker:
             encoded_payload = encoder.encode(payload)
             self.config.delivery.deliver_sessions(self.config, encoded_payload)
         except Exception as e:
-            bugsnag.logger.exception('Sending sessions failed %s', e)
+            self.config.logger.exception('Sending sessions failed %s', e)
 
 
 class SessionMiddleware:

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -129,9 +129,12 @@ class SessionTracker:
         }
 
         try:
-            filters = self.config.params_filters
-            encoder = SanitizingJSONEncoder(separators=(',', ':'),
-                                            keyword_filters=filters)
+            encoder = SanitizingJSONEncoder(
+                self.config.logger,
+                separators=(',', ':'),
+                keyword_filters=self.config.params_filters
+            )
+
             encoded_payload = encoder.encode(payload)
             self.config.delivery.deliver_sessions(self.config, encoded_payload)
         except Exception as e:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,8 @@
 import unittest
 
+import bugsnag
 from bugsnag.middleware import MiddlewareStack
+from bugsnag.configuration import RequestConfiguration
 
 
 class SampleMiddlewareClass(object):
@@ -39,6 +41,14 @@ class SampleMiddlewareReturning(object):
         return
 
 
+def create_event() -> bugsnag.Event:
+    return bugsnag.Event(
+        RuntimeError('oh no!'),
+        bugsnag.configure(),
+        RequestConfiguration.get_instance()
+    )
+
+
 class TestMiddleware(unittest.TestCase):
 
     def test_order_of_middleware(self):
@@ -53,7 +63,7 @@ class TestMiddleware(unittest.TestCase):
         m.after_notify(lambda _: a.append(4))
         m.after_notify(lambda _: a.append(3))
 
-        m.run(None, lambda: None)
+        m.run(create_event(), lambda: None)
 
         self.assertEqual(a, [1, 2, 3, 4])
 
@@ -66,7 +76,7 @@ class TestMiddleware(unittest.TestCase):
         m.before_notify(lambda _: False)
         m.before_notify(lambda _: a.append(1))
 
-        m.run(None, lambda: a.append(2))
+        m.run(create_event(), lambda: a.append(2))
 
         self.assertEqual(a, [])
 
@@ -76,7 +86,7 @@ class TestMiddleware(unittest.TestCase):
 
         m = MiddlewareStack()
         m.before_notify(lambda _: a.penned(1))
-        m.run(None, lambda: a.append(2))
+        m.run(create_event(), lambda: a.append(2))
 
         self.assertEqual(a, [2])
 
@@ -85,7 +95,7 @@ class TestMiddleware(unittest.TestCase):
 
         m = MiddlewareStack()
         m.after_notify(lambda _: a.penned(1))
-        m.run(None, lambda: a.append(2))
+        m.run(create_event(), lambda: a.append(2))
 
         self.assertEqual(a, [2])
 


### PR DESCRIPTION
## Goal

Following up from #263, this PR replaces calls to `bugsnag.logger` with the Configuration's logger

There are a couple of places where this wasn't totally trivial; the `SanitizingJSONEncoder` and the Django integration so these are done in separate commits to be easier to review