### PR TITLE
Match our Python version to LicenceFinder's in license audit

### DIFF
--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -12,7 +12,8 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        # License Finder's Docker image uses Python 3.5
+        python-version: 3.5
 
     - name: Fetch decisions.yml
       run: curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o decisions.yml


### PR DESCRIPTION
## Goal

The license audit action has started failing because Click v8.0.0 was released yesterday which no longer supports Python 3.5, but the LicenseFinder Docker image uses Python 3.5. We gather the package requirements using Python 3.9, which creates a requirements.txt that's incompatible with Python 3.5

This PR switches the requirements gathering to use Python 3.5 so that it matches LicenseFinder's version. Ideally we'd run the entire process in LicenseFinder's Docker image, but this causes extra system packages to find their way into the requirements file and `pip freeze --exclude` doesn't actually exclude them 😕