### PR TITLE
Make sure you filter values that are not strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ htmlcov
 #IDE files
 .vscode
 my_env
+venv
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Apply filtering with `params_filters` to bytes, not just strings
+  [Matt Bachmann](https://github.com/Bachmann1234)
+  [#267](https://github.com/bugsnag/bugsnag-python/pull/267)
+
 ## 4.0.3 (2021-04-28)
 
 ### Bug fixes

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -35,7 +35,7 @@ class SanitizingJSONEncoder(JSONEncoder):
 
     def __init__(self, keyword_filters=None, **kwargs):
         self.filters = list(map(str.lower, keyword_filters or []))
-        self.bytes_filters = [x.lower().encode('utf-8') for x in keyword_filters or []]
+        self.bytes_filters = [x.encode('utf-8') for x in self.filters]
         super(SanitizingJSONEncoder, self).__init__(**kwargs)
 
     def encode(self, obj):
@@ -71,10 +71,7 @@ class SanitizingJSONEncoder(JSONEncoder):
 
             clean_dict = {}
             for key, value in obj.items():
-                is_string = isinstance(key, str)
-                is_bytes = isinstance(key, bytes)
-                if ((is_string and any(f in key.lower() for f in self.filters)) or
-                        (is_bytes and any(f in key.lower() for f in self.bytes_filters))):
+                if self._should_filter(key):
                     clean_dict[key] = self.filtered_value
                 else:
                     clean_dict[key] = self.filter_string_values(
@@ -173,6 +170,17 @@ class SanitizingJSONEncoder(JSONEncoder):
             self._sanitize_dict_key_value(clean_dict, key, clean_value)
 
         return clean_dict
+
+    def _should_filter(self, key):
+        if isinstance(key, str):
+            key_lower = key.lower()
+            return any(f in key_lower for f in self.filters)
+
+        if isinstance(key, bytes):
+            key_lower = key.lower()
+            return any(f in key_lower for f in self.bytes_filters)
+
+        return False
 
 
 class FilterDict(dict):

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -35,6 +35,7 @@ class SanitizingJSONEncoder(JSONEncoder):
 
     def __init__(self, keyword_filters=None, **kwargs):
         self.filters = list(map(str.lower, keyword_filters or []))
+        self.bytes_filters = [x.lower().encode('utf-8') for x in keyword_filters or []]
         super(SanitizingJSONEncoder, self).__init__(**kwargs)
 
     def encode(self, obj):
@@ -71,7 +72,9 @@ class SanitizingJSONEncoder(JSONEncoder):
             clean_dict = {}
             for key, value in obj.items():
                 is_string = isinstance(key, str)
-                if is_string and any(f in key.lower() for f in self.filters):
+                is_bytes = isinstance(key, bytes)
+                if ((is_string and any(f in key.lower() for f in self.filters)) or
+                        (is_bytes and any(f in key.lower() for f in self.bytes_filters))):
                     clean_dict[key] = self.filtered_value
                 else:
                     clean_dict[key] = self.filter_string_values(

--- a/tests/integrations/test_asgi.py
+++ b/tests/integrations/test_asgi.py
@@ -78,6 +78,31 @@ class TestASGIMiddleware(IntegrationTest):
 
         self.assertEqual('/', environment['path'])
 
+    def test_headers_are_filtered(self):
+        bugsnag.configure()
+        app = Starlette()
+
+        async def other_func():
+            raise ScaryException('fell winds!')
+
+        @app.route('/')
+        async def index(req):
+            await other_func()
+            return PlainTextResponse('pineapple')
+
+        app = TestClient(BugsnagMiddleware(app))
+
+        self.assertRaises(
+            ScaryException,
+            lambda: app.get('/', headers={'Authorization': 'yes'})
+        )
+        self.assertSentReportCount(1)
+
+        payload = self.server.received[0]['json_body']
+        headers = payload['events'][0]['metaData']['request']['headers']
+
+        self.assertEqual('[FILTERED]', headers['authorization'])
+
     def test_boot_crash(self):
         async def app(scope, recv, send):
             raise ScaryException('forgot the map')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,16 @@ class TestUtils(unittest.TestCase):
                                      "password": "[FILTERED]",
                                      "cake": True})
 
+    def test_encode_filters_bytes(self):
+        data = FilterDict({b"credit_card": "123213213123", b"password": "456",
+                           "cake": True})
+        encoder = SanitizingJSONEncoder(keyword_filters=["credit_card",
+                                                         "password"])
+        sane_data = json.loads(encoder.encode(data))
+        self.assertEqual(sane_data, {"credit_card": "[FILTERED]",
+                                     "password": "[FILTERED]",
+                                     "cake": True})
+
     def test_sanitize_list(self):
         data = FilterDict({"list": ["carrots", "apples", "peas"],
                            "passwords": ["abc", "def"]})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,17 @@ class TestUtils(unittest.TestCase):
                                      "password": "[FILTERED]",
                                      "cake": True})
 
+    def test_encode_filters_object_key(self):
+        object_key = object()
+        data = FilterDict({"password": "456", object_key: True})
+
+        encoder = SanitizingJSONEncoder(keyword_filters=["password"])
+
+        actual = json.loads(encoder.encode(data))
+        expected = {"password": "[FILTERED]", str(object_key): True}
+
+        self.assertEqual(actual, expected)
+
     def test_encode_filters_bytes(self):
         data = FilterDict({b"credit_card": "123213213123", b"password": "456",
                            "cake": True})


### PR DESCRIPTION
## Goal

I want to be able to filter out sensitive info even if they request payload is coming to you as bytes

## Design

Because it kept the literal changes minimal 

## Changeset

I copy the filters to encoded versions of those filters and then I handle bytes in the sensitive encoder

## Testing

I added a test