### PR TITLE
Add Breadcrumb class and BreadcrumbType enum

### DIFF
--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -2,6 +2,7 @@ from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.notification import Notification
 from bugsnag.event import Event
 from bugsnag.client import Client
+from bugsnag.breadcrumbs import BreadcrumbType
 from bugsnag.legacy import (configuration, configure, configure_request,
                             add_metadata_tab, clear_request_config, notify,
                             auto_notify, before_notify, start_session,
@@ -11,4 +12,5 @@ __all__ = ('Client', 'Event', 'Configuration', 'RequestConfiguration',
            'configuration', 'configure', 'configure_request',
            'add_metadata_tab', 'clear_request_config', 'notify',
            'auto_notify', 'before_notify', 'start_session',
-           'auto_notify_exc_info', 'Notification', 'logger')
+           'auto_notify_exc_info', 'Notification', 'logger',
+           'BreadcrumbType')

--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -2,7 +2,7 @@ from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.notification import Notification
 from bugsnag.event import Event
 from bugsnag.client import Client
-from bugsnag.breadcrumbs import BreadcrumbType
+from bugsnag.breadcrumbs import BreadcrumbType, Breadcrumb
 from bugsnag.legacy import (configuration, configure, configure_request,
                             add_metadata_tab, clear_request_config, notify,
                             auto_notify, before_notify, start_session,
@@ -13,4 +13,4 @@ __all__ = ('Client', 'Event', 'Configuration', 'RequestConfiguration',
            'add_metadata_tab', 'clear_request_config', 'notify',
            'auto_notify', 'before_notify', 'start_session',
            'auto_notify_exc_info', 'Notification', 'logger',
-           'BreadcrumbType')
+           'BreadcrumbType', 'Breadcrumb')

--- a/bugsnag/breadcrumbs.py
+++ b/bugsnag/breadcrumbs.py
@@ -1,4 +1,6 @@
 from enum import Enum, unique
+from typing import Any, Dict, Union
+from bugsnag.utils import FilterDict
 
 
 @unique
@@ -11,3 +13,30 @@ class BreadcrumbType(Enum):
     STATE = 'state'
     ERROR = 'error'
     MANUAL = 'manual'
+
+
+class Breadcrumb:
+    def __init__(
+        self,
+        message: str,
+        type: BreadcrumbType,
+        metadata: Dict[str, Any],
+        timestamp: str
+    ):
+        self.message = message
+        self.type = type
+        self.metadata = metadata
+        self._timestamp = timestamp
+
+    @property
+    def timestamp(self) -> str:
+        return self._timestamp
+
+    # Convert this breadcrumb into a dict for use when JSON encoding
+    def to_dict(self) -> Dict[str, Union[str, FilterDict]]:
+        return {
+            'timestamp': self._timestamp,
+            'name': self.message,
+            'type': self.type.value,
+            'metaData': FilterDict(self.metadata)
+        }

--- a/bugsnag/breadcrumbs.py
+++ b/bugsnag/breadcrumbs.py
@@ -1,0 +1,13 @@
+from enum import Enum, unique
+
+
+@unique
+class BreadcrumbType(Enum):
+    NAVIGATION = 'navigation'
+    REQUEST = 'request'
+    PROCESS = 'process'
+    LOG = 'log'
+    USER = 'user'
+    STATE = 'state'
+    ERROR = 'error'
+    MANUAL = 'manual'

--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -1,0 +1,14 @@
+from bugsnag import BreadcrumbType
+
+
+def test_breadcrumb_types():
+    assert len(BreadcrumbType) == 8
+
+    assert BreadcrumbType.NAVIGATION.value == 'navigation'
+    assert BreadcrumbType.REQUEST.value == 'request'
+    assert BreadcrumbType.PROCESS.value == 'process'
+    assert BreadcrumbType.LOG.value == 'log'
+    assert BreadcrumbType.USER.value == 'user'
+    assert BreadcrumbType.STATE.value == 'state'
+    assert BreadcrumbType.ERROR.value == 'error'
+    assert BreadcrumbType.MANUAL.value == 'manual'

--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -1,4 +1,5 @@
-from bugsnag import BreadcrumbType
+from bugsnag import BreadcrumbType, Breadcrumb
+from bugsnag.utils import FilterDict
 
 
 def test_breadcrumb_types():
@@ -12,3 +13,55 @@ def test_breadcrumb_types():
     assert BreadcrumbType.STATE.value == 'state'
     assert BreadcrumbType.ERROR.value == 'error'
     assert BreadcrumbType.MANUAL.value == 'manual'
+
+
+def test_breadcrumb_properties():
+    breadcrumb = Breadcrumb(
+        'This is a test breadcrumb',
+        BreadcrumbType.REQUEST,
+        {'a': 1, 'b': 2, 'c': 3, 'xyz': 456},
+        '1234-56-78T12:34:56.789+00:00'
+    )
+
+    assert breadcrumb.message == 'This is a test breadcrumb'
+    assert breadcrumb.type == BreadcrumbType.REQUEST
+    assert breadcrumb.metadata == {'a': 1, 'b': 2, 'c': 3, 'xyz': 456}
+    assert breadcrumb.timestamp == '1234-56-78T12:34:56.789+00:00'
+
+
+def test_breadcrumb_properties_with_keyword_params():
+    breadcrumb = Breadcrumb(
+        timestamp='9876-54-32T12:34:56.789+00:00',
+        metadata={'a': 1, 'b': 2, 'c': 3, 'xyz': 456},
+        type=BreadcrumbType.PROCESS,
+        message='This is a second test breadcrumb'
+    )
+
+    assert breadcrumb.message == 'This is a second test breadcrumb'
+    assert breadcrumb.type == BreadcrumbType.PROCESS
+    assert breadcrumb.metadata == {'a': 1, 'b': 2, 'c': 3, 'xyz': 456}
+    assert breadcrumb.timestamp == '9876-54-32T12:34:56.789+00:00'
+
+
+def test_breadcrumb_to_dict():
+    breadcrumb = Breadcrumb(
+        'This is another test breadcrumb',
+        BreadcrumbType.ERROR,
+        {'abc': 123, 'xyz': 'fourfivesix'},
+        '1234-56-78T12:34:56.789+00:00'
+    )
+
+    breadcrumb_dict = breadcrumb.to_dict()
+
+    expected = {
+        'name': 'This is another test breadcrumb',
+        'type': BreadcrumbType.ERROR.value,
+        'metaData': FilterDict({'abc': 123, 'xyz': 'fourfivesix'}),
+        'timestamp': '1234-56-78T12:34:56.789+00:00'
+    }
+
+    assert breadcrumb_dict == expected
+
+    # pytest allows the previous assertion to pass when metadata is not a
+    # FilterDict, so explicitly check for this as it's necessary for redaction
+    assert isinstance(breadcrumb_dict['metaData'], FilterDict)


### PR DESCRIPTION
## Goal

Adds the basic building blocks of breadcrumbs — the BreadcrumbType enum and Breadcrumb class

At the moment these aren't connected to anything, but will be used in future PRs

## Testing

Unit tests have been added, though these additions don't really have any behaviour by themselves (more useful tests depend on future additions)