### PR TITLE
Add Breadcrumbs class to manage breadcrumbs

### DIFF
--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -2,7 +2,7 @@ from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.notification import Notification
 from bugsnag.event import Event
 from bugsnag.client import Client
-from bugsnag.breadcrumbs import BreadcrumbType, Breadcrumb
+from bugsnag.breadcrumbs import BreadcrumbType, Breadcrumb, Breadcrumbs
 from bugsnag.legacy import (configuration, configure, configure_request,
                             add_metadata_tab, clear_request_config, notify,
                             auto_notify, before_notify, start_session,
@@ -13,4 +13,4 @@ __all__ = ('Client', 'Event', 'Configuration', 'RequestConfiguration',
            'add_metadata_tab', 'clear_request_config', 'notify',
            'auto_notify', 'before_notify', 'start_session',
            'auto_notify_exc_info', 'Notification', 'logger',
-           'BreadcrumbType', 'Breadcrumb')
+           'BreadcrumbType', 'Breadcrumb', 'Breadcrumbs')

--- a/bugsnag/breadcrumbs.py
+++ b/bugsnag/breadcrumbs.py
@@ -1,6 +1,26 @@
 from enum import Enum, unique
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+from collections import deque
+
 from bugsnag.utils import FilterDict
+
+# Deque is not present in 'typing' until 3.5.4, so we can't use it directly
+if TYPE_CHECKING:
+    from typing import Deque
+
+# The _breadcrumbs context var contains None or a deque of Breadcrumb instances
+try:
+    from contextvars import ContextVar
+    _breadcrumbs = ContextVar(
+        'bugsnag-breadcrumbs',
+        default=None
+    )  # type: ContextVar[Optional[Deque[Breadcrumb]]]
+except ImportError:
+    from bugsnag.utils import ThreadContextVar
+    _breadcrumbs = ThreadContextVar('bugsnag-breadcrumbs', default=None)  # type: ignore  # noqa: E501
+
+
+__all__ = ('BreadcrumbType', 'Breadcrumb', 'Breadcrumbs')
 
 
 @unique
@@ -40,3 +60,47 @@ class Breadcrumb:
             'type': self.type.value,
             'metaData': FilterDict(self.metadata)
         }
+
+
+class Breadcrumbs:
+    def __init__(self, max_breadcrumbs: int):
+        self._max_breadcrumbs = max_breadcrumbs
+
+        # Calling resize is important for tests as we make many Breadcrumbs
+        # instances but they all have to share a ContextVar, so the size can
+        # leak between tests
+        self.resize(max_breadcrumbs)
+
+    def append(self, breadcrumb: Breadcrumb) -> None:
+        self._breadcrumbs.append(breadcrumb)
+
+    # Resize the list of breadcrumbs if configuration.max_breadcrumbs changes
+    def resize(self, new_max: int) -> None:
+        old_breadcrumbs = self._breadcrumbs
+        new_breadcrumbs = deque(old_breadcrumbs, maxlen=new_max)
+
+        _breadcrumbs.set(new_breadcrumbs)
+        self._max_breadcrumbs = new_max
+
+    # Create a copy of the current list of breadcrumbs for this context
+    def create_copy_for_context(self) -> None:
+        # Resizing will create a new deque and store it in the ContextVar,
+        # which will give the current context a new copy of the list
+        self.resize(self._max_breadcrumbs)
+
+    def to_list(self) -> List[Breadcrumb]:
+        return list(self._breadcrumbs)
+
+    @property
+    def _breadcrumbs(self):
+        # type: () -> Deque[Breadcrumb]
+        try:
+            breadcrumbs = _breadcrumbs.get()
+        except LookupError:
+            breadcrumbs = None
+
+        if breadcrumbs is None:
+            breadcrumbs = deque(maxlen=self._max_breadcrumbs)
+            _breadcrumbs.set(breadcrumbs)
+
+        return breadcrumbs

--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -1,5 +1,19 @@
-from bugsnag import BreadcrumbType, Breadcrumb
+import asyncio
+import random
+import time
+import sys
+import pytest
+from threading import Thread
+
+from bugsnag import BreadcrumbType, Breadcrumb, Breadcrumbs
 from bugsnag.utils import FilterDict
+
+
+# resize the breadcrumb list to 0 before each test to prevent tests from
+# interfering with eachother
+@pytest.fixture(autouse=True)
+def reset_breadcrumbs():
+    Breadcrumbs(0).resize(0)
 
 
 def test_breadcrumb_types():
@@ -65,3 +79,278 @@ def test_breadcrumb_to_dict():
     # pytest allows the previous assertion to pass when metadata is not a
     # FilterDict, so explicitly check for this as it's necessary for redaction
     assert isinstance(breadcrumb_dict['metaData'], FilterDict)
+
+
+def test_there_is_a_max_number_of_breadcrumbs():
+    breadcrumbs = Breadcrumbs(max_breadcrumbs=2)
+
+    first_breadcrumb = Breadcrumb('hello', BreadcrumbType.ERROR, {}, 'time')
+    second_breadcrumb = Breadcrumb('hi', BreadcrumbType.REQUEST, {}, 'emit')
+
+    breadcrumbs.append(first_breadcrumb)
+    breadcrumbs.append(second_breadcrumb)
+
+    breadcrumb_list = breadcrumbs.to_list()
+
+    assert len(breadcrumb_list) == 2
+    assert breadcrumb_list[0] == first_breadcrumb
+    assert breadcrumb_list[1] == second_breadcrumb
+
+    third_breadcrumb = Breadcrumb('howdy', BreadcrumbType.LOG, {}, 'now')
+    breadcrumbs.append(third_breadcrumb)
+
+    breadcrumb_list = breadcrumbs.to_list()
+
+    # the length should match the maximum number of breadcrumbs set earlier
+    assert len(breadcrumb_list) == 2
+    assert breadcrumb_list[0] == second_breadcrumb
+    assert breadcrumb_list[1] == third_breadcrumb
+
+
+def test_the_number_of_breadcrumbs_can_be_reduced():
+    breadcrumbs = Breadcrumbs(max_breadcrumbs=3)
+
+    first_breadcrumb = Breadcrumb('hello', BreadcrumbType.ERROR, {}, 'time')
+    second_breadcrumb = Breadcrumb('hi', BreadcrumbType.REQUEST, {}, 'emit')
+    third_breadcrumb = Breadcrumb('howdy', BreadcrumbType.LOG, {}, 'now')
+
+    breadcrumbs.append(first_breadcrumb)
+    breadcrumbs.append(second_breadcrumb)
+    breadcrumbs.append(third_breadcrumb)
+
+    breadcrumb_list = breadcrumbs.to_list()
+
+    assert len(breadcrumb_list) == 3
+    assert breadcrumb_list[0] == first_breadcrumb
+    assert breadcrumb_list[1] == second_breadcrumb
+    assert breadcrumb_list[2] == third_breadcrumb
+
+    breadcrumbs.resize(1)
+    breadcrumb_list = breadcrumbs.to_list()
+
+    assert len(breadcrumb_list) == 1
+    assert breadcrumb_list[0] == third_breadcrumb
+
+    breadcrumbs.resize(0)
+    breadcrumb_list = breadcrumbs.to_list()
+
+    assert len(breadcrumb_list) == 0
+
+
+def test_the_number_of_breadcrumbs_can_be_increased():
+    breadcrumbs = Breadcrumbs(max_breadcrumbs=1)
+
+    first_breadcrumb = Breadcrumb('hello', BreadcrumbType.ERROR, {}, 'time')
+
+    breadcrumbs.append(first_breadcrumb)
+
+    breadcrumb_list = breadcrumbs.to_list()
+
+    assert len(breadcrumb_list) == 1
+    assert breadcrumb_list[0] == first_breadcrumb
+
+    second_breadcrumb = Breadcrumb('hi', BreadcrumbType.REQUEST, {}, 'emit')
+    third_breadcrumb = Breadcrumb('howdy', BreadcrumbType.LOG, {}, 'now')
+
+    breadcrumbs.resize(5)
+
+    breadcrumbs.append(second_breadcrumb)
+    breadcrumbs.append(third_breadcrumb)
+
+    breadcrumb_list = breadcrumbs.to_list()
+
+    assert len(breadcrumb_list) == 3
+    assert breadcrumb_list[0] == first_breadcrumb
+    assert breadcrumb_list[1] == second_breadcrumb
+    assert breadcrumb_list[2] == third_breadcrumb
+
+    breadcrumbs.append(second_breadcrumb)
+    breadcrumbs.append(third_breadcrumb)
+
+    breadcrumb_list = breadcrumbs.to_list()
+
+    assert len(breadcrumb_list) == 5
+    assert breadcrumb_list[0] == first_breadcrumb
+    assert breadcrumb_list[1] == second_breadcrumb
+    assert breadcrumb_list[2] == third_breadcrumb
+    assert breadcrumb_list[3] == second_breadcrumb
+    assert breadcrumb_list[4] == third_breadcrumb
+
+
+def test_the_breadcrumb_list_is_separate_on_different_threads():
+    breadcrumbs = Breadcrumbs(max_breadcrumbs=5)
+
+    def append_breadcrumbs(id):
+        try:
+            thread.exception = None
+
+            first_breadcrumb = Breadcrumb(
+                'a' + id,
+                BreadcrumbType.ERROR,
+                {'a': id, 'b': 'xyz'},
+                'x'
+            )
+
+            second_breadcrumb = Breadcrumb(
+                'b' + id,
+                BreadcrumbType.USER,
+                {'b': id, 'c': 'xyz'},
+                'y'
+            )
+
+            third_breadcrumb = Breadcrumb(
+                'c' + id,
+                BreadcrumbType.STATE,
+                {'c': id, 'xyz': 'yes'},
+                'z'
+            )
+
+            breadcrumbs.append(first_breadcrumb)
+            breadcrumbs.append(second_breadcrumb)
+            breadcrumbs.append(third_breadcrumb)
+
+            # sleep for a bit to allow other threads time to interfere
+            time.sleep(random.randrange(0, 100) / 1000)
+
+            breadcrumb_list = breadcrumbs.to_list()
+
+            assert len(breadcrumb_list) == 3
+            assert breadcrumb_list[0] == first_breadcrumb
+            assert breadcrumb_list[1] == second_breadcrumb
+            assert breadcrumb_list[2] == third_breadcrumb
+
+            breadcrumbs.append(second_breadcrumb)
+            breadcrumbs.append(third_breadcrumb)
+
+            # sleep for a bit to allow other threads time to interfere
+            time.sleep(random.randrange(0, 100) / 1000)
+
+            breadcrumb_list = breadcrumbs.to_list()
+
+            assert len(breadcrumb_list) == 5
+            assert breadcrumb_list[0] == first_breadcrumb
+            assert breadcrumb_list[1] == second_breadcrumb
+            assert breadcrumb_list[2] == third_breadcrumb
+            assert breadcrumb_list[3] == second_breadcrumb
+            assert breadcrumb_list[4] == third_breadcrumb
+
+            breadcrumbs.resize(2)
+
+            # sleep for a bit to allow other threads time to interfere
+            time.sleep(random.randrange(0, 100) / 1000)
+
+            breadcrumb_list = breadcrumbs.to_list()
+
+            assert len(breadcrumb_list) == 2
+            assert breadcrumb_list[0] == second_breadcrumb
+            assert breadcrumb_list[1] == third_breadcrumb
+
+        except Exception as e:
+            thread.exception = e
+
+    threads = []
+    for i in range(5):
+        thread = Thread(target=append_breadcrumbs, args=[str(i)])
+        threads.append(thread)
+
+    # shuffle the list of threads so they don't run in a reliable order
+    random.shuffle(threads)
+
+    for thread in threads:
+        thread.start()
+
+    # shuffle the list of threads so they don't run in a reliable order
+    random.shuffle(threads)
+
+    for thread in threads:
+        thread.join(2)
+
+        assert not thread.is_alive()
+
+        # if an exception happened in the thread, raise it here instead
+        if thread.exception is not None:
+            raise thread.exception
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7),
+    reason="requires ContextVar support (Python 3.7 or higher)"
+)
+def test_the_breadcrumb_list_is_separate_on_different_async_contexts():
+    breadcrumbs = Breadcrumbs(max_breadcrumbs=5)
+
+    async def append_breadcrumbs(id):
+        # create a copy of the breadcrumbs for this context
+        breadcrumbs.create_copy_for_context()
+
+        first_breadcrumb = Breadcrumb(
+            'a' + id,
+            BreadcrumbType.ERROR,
+            {'a': id, 'b': 'xyz'},
+            'x'
+        )
+
+        second_breadcrumb = Breadcrumb(
+            'b' + id,
+            BreadcrumbType.USER,
+            {'b': id, 'c': 'xyz'},
+            'y'
+        )
+
+        third_breadcrumb = Breadcrumb(
+            'c' + id,
+            BreadcrumbType.STATE,
+            {'c': id, 'xyz': 'yes'},
+            'z'
+        )
+
+        breadcrumbs.append(first_breadcrumb)
+        breadcrumbs.append(second_breadcrumb)
+        breadcrumbs.append(third_breadcrumb)
+
+        await asyncio.sleep(random.randrange(0, 100) / 1000)
+
+        breadcrumb_list = breadcrumbs.to_list()
+
+        assert len(breadcrumb_list) == 3
+        assert breadcrumb_list[0] == first_breadcrumb
+        assert breadcrumb_list[1] == second_breadcrumb
+        assert breadcrumb_list[2] == third_breadcrumb
+
+        breadcrumbs.append(second_breadcrumb)
+        breadcrumbs.append(third_breadcrumb)
+
+        await asyncio.sleep(random.randrange(0, 100) / 1000)
+
+        breadcrumb_list = breadcrumbs.to_list()
+
+        assert len(breadcrumb_list) == 5
+        assert breadcrumb_list[0] == first_breadcrumb
+        assert breadcrumb_list[1] == second_breadcrumb
+        assert breadcrumb_list[2] == third_breadcrumb
+        assert breadcrumb_list[3] == second_breadcrumb
+        assert breadcrumb_list[4] == third_breadcrumb
+
+        breadcrumbs.resize(2)
+
+        await asyncio.sleep(random.randrange(0, 100) / 1000)
+
+        breadcrumb_list = breadcrumbs.to_list()
+
+        assert len(breadcrumb_list) == 2
+        assert breadcrumb_list[0] == second_breadcrumb
+        assert breadcrumb_list[1] == third_breadcrumb
+
+    async def test():
+        tasks = []
+        for i in range(5):
+            tasks.append(asyncio.ensure_future(append_breadcrumbs(str(i))))
+
+        await asyncio.gather(*tasks)
+
+    loop = asyncio.get_event_loop()
+
+    try:
+        loop.run_until_complete(test())
+    finally:
+        loop.close()


### PR DESCRIPTION
## Goal

This PR adds the `Breadcrumbs` class, which manages a `ContextVar` containing a `deque` of breadcrumbs. This allows many breadcrumbs to be added, but only the most recent 𝑥 breadcrumbs will be kept

With some async APIs the ContextVar has to be explicitly copied, otherwise it can be shared (e.g. in the async unit test) but in others this is unnecessary (e.g. `asyncio` servers). In a future PR, this will be handled much like per-request data is currently — the `create_copy_for_context` method will be called in various integration middlewares