### PR TITLE
Add `Client.leave_breadcrumb`

### DIFF
--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -6,11 +6,11 @@ from bugsnag.breadcrumbs import BreadcrumbType, Breadcrumb, Breadcrumbs
 from bugsnag.legacy import (configuration, configure, configure_request,
                             add_metadata_tab, clear_request_config, notify,
                             auto_notify, before_notify, start_session,
-                            auto_notify_exc_info, logger)
+                            auto_notify_exc_info, logger, leave_breadcrumb)
 
 __all__ = ('Client', 'Event', 'Configuration', 'RequestConfiguration',
            'configuration', 'configure', 'configure_request',
            'add_metadata_tab', 'clear_request_config', 'notify',
            'auto_notify', 'before_notify', 'start_session',
            'auto_notify_exc_info', 'Notification', 'logger',
-           'BreadcrumbType', 'Breadcrumb', 'Breadcrumbs')
+           'BreadcrumbType', 'Breadcrumb', 'Breadcrumbs', 'leave_breadcrumb')

--- a/bugsnag/breadcrumbs.py
+++ b/bugsnag/breadcrumbs.py
@@ -34,6 +34,16 @@ class BreadcrumbType(Enum):
     ERROR = 'error'
     MANUAL = 'manual'
 
+    @staticmethod
+    def from_string(string: str) -> 'BreadcrumbType':
+        if not isinstance(string, str):
+            return BreadcrumbType.MANUAL
+
+        try:
+            return BreadcrumbType[string.upper()]
+        except KeyError:
+            return BreadcrumbType.MANUAL
+
 
 class Breadcrumb:
     def __init__(

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -1,7 +1,8 @@
-from typing import Dict, Any, Tuple, Type
+from typing import Dict, Any, Tuple, Type, Union
 import types
 import sys
 
+from bugsnag.breadcrumbs import BreadcrumbType
 from bugsnag.configuration import RequestConfiguration
 from bugsnag.client import Client
 
@@ -13,7 +14,7 @@ ExcInfoType = Tuple[Type, Exception, types.TracebackType]
 
 __all__ = ('configure', 'configure_request', 'add_metadata_tab',
            'clear_request_config', 'notify', 'start_session', 'auto_notify',
-           'auto_notify_exc_info', 'before_notify')
+           'auto_notify_exc_info', 'before_notify', 'leave_breadcrumb')
 
 
 def configure(**options):
@@ -127,3 +128,11 @@ def before_notify(callback):
     This can be used to alter the event before sending it to Bugsnag.
     """
     configuration.middleware.before_notify(callback)
+
+
+def leave_breadcrumb(
+    message: str,
+    metadata: Dict[str, Any] = {},
+    type: Union[BreadcrumbType, str] = BreadcrumbType.MANUAL
+) -> None:
+    default_client.leave_breadcrumb(message, metadata, type)

--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -29,6 +29,35 @@ def test_breadcrumb_types():
     assert BreadcrumbType.MANUAL.value == 'manual'
 
 
+@pytest.mark.parametrize('string, expected', [
+    ('navigation', BreadcrumbType.NAVIGATION),
+    ('NAVIGATION', BreadcrumbType.NAVIGATION),
+    ('request', BreadcrumbType.REQUEST),
+    ('REQUEST', BreadcrumbType.REQUEST),
+    ('process', BreadcrumbType.PROCESS),
+    ('PROCESS', BreadcrumbType.PROCESS),
+    ('log', BreadcrumbType.LOG),
+    ('LOG', BreadcrumbType.LOG),
+    ('user', BreadcrumbType.USER),
+    ('USER', BreadcrumbType.USER),
+    ('state', BreadcrumbType.STATE),
+    ('STATE', BreadcrumbType.STATE),
+    ('error', BreadcrumbType.ERROR),
+    ('ERROR', BreadcrumbType.ERROR),
+    ('manual', BreadcrumbType.MANUAL),
+    ('MANUAL', BreadcrumbType.MANUAL),
+    ('mAnUaL', BreadcrumbType.MANUAL),
+    ('MaNuAl', BreadcrumbType.MANUAL),
+    # invalid strings should result in a manual breadcrumb type
+    ('not a breadcrumb type', BreadcrumbType.MANUAL),
+    ('NOPE', BreadcrumbType.MANUAL),
+    (12345, BreadcrumbType.MANUAL),
+    ([1, 2, 3], BreadcrumbType.MANUAL),
+])
+def test_breadcrumb_type_from_string(string, expected):
+    assert BreadcrumbType.from_string(string) == expected
+
+
 def test_breadcrumb_properties():
     breadcrumb = Breadcrumb(
         'This is a test breadcrumb',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,26 @@
 import os
+import re
 import sys
 import pytest
+import logging
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
 
-from bugsnag import Client, Configuration
+from bugsnag import Client, Configuration, BreadcrumbType, Breadcrumbs
 from tests.utils import IntegrationTest, ScaryException
+
+timestamp_regex = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(?:[+-]\d{2}:\d{2}|Z)'  # noqa: E501
+
+
+def is_valid_timestamp(timestamp: str) -> bool:
+    return bool(re.search(timestamp_regex, timestamp))
+
+
+# resize the breadcrumb list to 0 before each test to prevent tests from
+# interfering with eachother
+@pytest.fixture(autouse=True)
+def reset_breadcrumbs():
+    Breadcrumbs(0).resize(0)
 
 
 class ClientTest(IntegrationTest):
@@ -401,3 +418,197 @@ class ClientTest(IntegrationTest):
 
         client.remove_on_breadcrumb(lambda: None)
         assert client.configuration._on_breadcrumbs == []
+
+    def test_leave_breadcrumb_defaults(self):
+        client = Client()
+        assert len(client.configuration.breadcrumbs) == 0
+
+        client.leave_breadcrumb('abc')
+        assert len(client.configuration.breadcrumbs) == 1
+
+        breadcrumb = client.configuration.breadcrumbs[0]
+
+        assert breadcrumb.message == 'abc'
+        assert breadcrumb.metadata == {}
+        assert breadcrumb.type == BreadcrumbType.MANUAL
+        assert is_valid_timestamp(breadcrumb.timestamp)
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 7),
+        reason="requires datetime.fromisoformat (Python 3.7 or higher)"
+    )
+    def test_leave_breadcrumb_timestamp_is_close_to_now(self):
+        client = Client()
+        assert len(client.configuration.breadcrumbs) == 0
+
+        client.leave_breadcrumb('abc')
+        assert len(client.configuration.breadcrumbs) == 1
+
+        breadcrumb = client.configuration.breadcrumbs[0]
+
+        assert breadcrumb.message == 'abc'
+        assert breadcrumb.metadata == {}
+        assert breadcrumb.type == BreadcrumbType.MANUAL
+        assert is_valid_timestamp(breadcrumb.timestamp)
+
+        now = datetime.now(timezone.utc)
+        parsed_timestamp = datetime.fromisoformat(breadcrumb.timestamp)
+
+        difference = now - parsed_timestamp
+        assert difference < timedelta(seconds=5)
+
+    def test_leave_breadcrumb_with_metadata_and_type(self):
+        client = Client()
+        assert len(client.configuration.breadcrumbs) == 0
+
+        client.leave_breadcrumb('xyz', {'a': 2}, BreadcrumbType.LOG)
+        assert len(client.configuration.breadcrumbs) == 1
+
+        breadcrumb = client.configuration.breadcrumbs[0]
+
+        assert breadcrumb.message == 'xyz'
+        assert breadcrumb.metadata == {'a': 2}
+        assert breadcrumb.type == BreadcrumbType.LOG
+        assert is_valid_timestamp(breadcrumb.timestamp)
+
+    def test_leave_breadcrumb_with_invalid_type(self):
+        client = Client()
+        assert len(client.configuration.breadcrumbs) == 0
+
+        client.leave_breadcrumb('abcxyz', type='bad')
+        assert len(client.configuration.breadcrumbs) == 1
+
+        breadcrumb = client.configuration.breadcrumbs[0]
+
+        assert breadcrumb.message == 'abcxyz'
+        assert breadcrumb.metadata == {}
+        assert breadcrumb.type == BreadcrumbType.MANUAL
+        assert is_valid_timestamp(breadcrumb.timestamp)
+
+    def test_leave_breadcrumb_with_string_type(self):
+        client = Client()
+        assert len(client.configuration.breadcrumbs) == 0
+
+        client.leave_breadcrumb('abcxyz', type='log')
+        assert len(client.configuration.breadcrumbs) == 1
+
+        breadcrumb = client.configuration.breadcrumbs[0]
+
+        assert breadcrumb.message == 'abcxyz'
+        assert breadcrumb.metadata == {}
+        assert breadcrumb.type == BreadcrumbType.LOG
+        assert is_valid_timestamp(breadcrumb.timestamp)
+
+    def test_leave_breadcrumb_does_nothing_when_max_breadcrumbs_is_0(self):
+        client = Client()
+        client.configuration.configure(max_breadcrumbs=0)
+        assert len(client.configuration.breadcrumbs) == 0
+
+        client.leave_breadcrumb('abc')
+        assert len(client.configuration.breadcrumbs) == 0
+
+    def test_leave_breadcrumb_passes_breadcrumb_to_callbacks(self):
+        client = Client()
+        assert len(client.configuration.breadcrumbs) == 0
+
+        was_called = False
+
+        def on_breadcrumb(breadcrumb):
+            assert breadcrumb.message == 'oh no'
+            assert breadcrumb.metadata == {'bad?': 'yes, very'}
+            assert breadcrumb.type == BreadcrumbType.ERROR
+            assert is_valid_timestamp(breadcrumb.timestamp)
+
+            nonlocal was_called
+            was_called = True
+
+        client.add_on_breadcrumb(on_breadcrumb)
+
+        client.leave_breadcrumb(
+            'oh no',
+            type=BreadcrumbType.ERROR,
+            metadata={'bad?': 'yes, very'}
+        )
+
+        assert len(client.configuration.breadcrumbs) == 1
+        assert was_called
+
+    def test_leave_breadcrumb_calls_on_breadcrumb_callbacks_in_order(self):
+        client = Client()
+        assert len(client.configuration.breadcrumbs) == 0
+
+        calls = []
+
+        client.add_on_breadcrumb(lambda x: calls.append(1))
+        client.add_on_breadcrumb(lambda x: calls.append(2))
+        client.add_on_breadcrumb(lambda x: calls.append(3))
+        client.add_on_breadcrumb(lambda x: calls.append(4))
+
+        client.leave_breadcrumb('abc')
+
+        assert calls == [1, 2, 3, 4]
+
+        assert len(client.configuration.breadcrumbs) == 1
+
+        breadcrumb = client.configuration.breadcrumbs[0]
+
+        assert breadcrumb.message == 'abc'
+        assert breadcrumb.metadata == {}
+        assert breadcrumb.type == BreadcrumbType.MANUAL
+        assert is_valid_timestamp(breadcrumb.timestamp)
+
+    def test_leave_breadcrumb_stops_if_on_breadcrumb_callback_returns_false(self):  # noqa: E501
+        logger = Mock(logging.Logger)
+
+        client = Client()
+        client.configuration.configure(logger=logger)
+        assert len(client.configuration.breadcrumbs) == 0
+
+        calls = []
+
+        client.add_on_breadcrumb(lambda x: calls.append(1))
+        client.add_on_breadcrumb(lambda x: calls.append(2))
+        client.add_on_breadcrumb(lambda x: False)
+        client.add_on_breadcrumb(lambda x: calls.append(3))
+
+        client.leave_breadcrumb('abc')
+
+        assert calls == [1, 2]
+        assert len(client.configuration.breadcrumbs) == 0
+
+        logger.info.assert_called_once_with(
+            'Breadcrumb not attached due to on_breadcrumb callback'
+        )
+
+    def test_leave_breadcrumb_continues_if_on_breadcrumb_callback_raises(self):
+        logger = Mock(logging.Logger)
+
+        client = Client()
+        client.configuration.configure(logger=logger)
+        assert len(client.configuration.breadcrumbs) == 0
+
+        def raises(breadcrumb):
+            raise Exception('oh no')
+
+        calls = []
+
+        client.add_on_breadcrumb(lambda x: calls.append(1))
+        client.add_on_breadcrumb(lambda x: calls.append(2))
+        client.add_on_breadcrumb(raises)
+        client.add_on_breadcrumb(lambda x: calls.append(3))
+
+        client.leave_breadcrumb('xyz')
+
+        assert calls == [1, 2, 3]
+        assert len(client.configuration.breadcrumbs) == 1
+
+        breadcrumb = client.configuration.breadcrumbs[0]
+
+        assert breadcrumb.message == 'xyz'
+        assert breadcrumb.metadata == {}
+        assert breadcrumb.type == BreadcrumbType.MANUAL
+        assert is_valid_timestamp(breadcrumb.timestamp)
+
+        logger.exception.assert_called_once_with(
+            'Exception raised in on_breadcrumb callback'
+        )


### PR DESCRIPTION
## Goal

Adds `leave_breadcrumb` to the Client class, which calls `on_breadcrumb` callbacks and attaches the new breadcrumb to the list

`on_breadcrumb` callbacks can "cancel" the breadcrumb by returning `False`. Any exceptions raised in callbacks will be logged but won't prevent the breadcrumb from being recorded

A `leave_breadcrumb` function has also been added to `legacy.py`, which forwards the call on to the "default client"