### PR TITLE
Automatically reset Breadcrumbs between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from bugsnag import Breadcrumbs
+
+
+# resize the breadcrumb list to 0 before each test to prevent tests from
+# interfering with eachother
+@pytest.fixture(autouse=True)
+def reset_breadcrumbs():
+    Breadcrumbs(0).resize(0)

--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -9,13 +9,6 @@ from bugsnag import BreadcrumbType, Breadcrumb, Breadcrumbs
 from bugsnag.utils import FilterDict
 
 
-# resize the breadcrumb list to 0 before each test to prevent tests from
-# interfering with eachother
-@pytest.fixture(autouse=True)
-def reset_breadcrumbs():
-    Breadcrumbs(0).resize(0)
-
-
 def test_breadcrumb_types():
     assert len(BreadcrumbType) == 8
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,7 +10,6 @@ from bugsnag import (
     Client,
     Configuration,
     BreadcrumbType,
-    Breadcrumbs,
     Breadcrumb
 )
 
@@ -22,13 +21,6 @@ timestamp_regex = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(?:[+-]\d{2}:\d{2
 
 def is_valid_timestamp(timestamp: str) -> bool:
     return bool(re.search(timestamp_regex, timestamp))
-
-
-# resize the breadcrumb list to 0 before each test to prevent tests from
-# interfering with eachother
-@pytest.fixture(autouse=True)
-def reset_breadcrumbs():
-    Breadcrumbs(0).resize(0)
 
 
 class ClientTest(IntegrationTest):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -6,7 +6,7 @@ import sys
 import unittest
 
 import pytest
-from bugsnag.breadcrumbs import Breadcrumbs, Breadcrumb, BreadcrumbType
+from bugsnag.breadcrumbs import Breadcrumb, BreadcrumbType
 from bugsnag.configuration import Configuration
 from bugsnag.event import Event
 from tests import fixtures
@@ -14,11 +14,6 @@ from tests import fixtures
 
 class TestEvent(unittest.TestCase):
     event_class = Event
-
-    # resize the breadcrumb list to 0 before each test to prevent tests from
-    # interfering with eachother
-    def setUp(self):
-        Breadcrumbs(0).resize(0)
 
     def test_sanitize(self):
         """


### PR DESCRIPTION
## Goal

'conftest.py' will be executed by pytest and autouse fixtures will apply to every test in the module. Tests that interact with breadcrumbs no longer need to individually reset the ContextVar between tests

See https://docs.pytest.org/en/6.2.x/example/simple.html#package-directory-level-fixtures-setups