### PR TITLE
Add leave_breadcrumbs log filter

### DIFF
--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -246,6 +246,18 @@ class Client:
 
         self.configuration._breadcrumbs.append(breadcrumb)
 
+    def _auto_leave_breadcrumb(
+        self,
+        message: str,
+        metadata: Dict[str, Any],
+        type: BreadcrumbType
+    ) -> None:
+        if (
+            type in self.configuration.enabled_breadcrumb_types
+            or type.value in self.configuration.enabled_breadcrumb_types
+        ):
+            self.leave_breadcrumb(message, metadata, type)
+
 
 class ClientContext:
     def __init__(self, client,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,6 +41,10 @@ class IntegrationTest(unittest.TestCase):
         exception = event['exceptions'][0]
         self.assertEqual(exception['errorClass'], name)
 
+    @property
+    def sent_report_count(self) -> int:
+        return len(self.server.received)
+
 
 class FakeBugsnagServer(object):
     """


### PR DESCRIPTION
## Goal

This leaves breadcrumbs for log records which will not be reported

e.g. the following will leave breadcrumbs for logs with a level of 'INFO' & 'WARNING' and will notify on logs with a level of 'ERROR' and above

```python
bugsnag.configure(breadcrumb_log_level=logging.INFO)

logger = logging.getLogger("abc")

handler = BugsnagHandler()
handler.setLevel(logging.ERROR)

logger.addHandler(handler)
logger.addFilter(handler.leave_breadcrumbs)
```