### PR TITLE
Automatic navigation breadcrumbs for integrations

### DIFF
--- a/bugsnag/breadcrumbs.py
+++ b/bugsnag/breadcrumbs.py
@@ -98,6 +98,9 @@ class Breadcrumbs:
         # which will give the current context a new copy of the list
         self.resize(self._max_breadcrumbs)
 
+    def clear(self) -> None:
+        self._breadcrumbs.clear()
+
     def to_list(self) -> List[Breadcrumb]:
         return list(self._breadcrumbs)
 

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -136,3 +136,11 @@ def leave_breadcrumb(
     type: Union[BreadcrumbType, str] = BreadcrumbType.MANUAL
 ) -> None:
     default_client.leave_breadcrumb(message, metadata, type)
+
+
+def _auto_leave_breadcrumb(
+    message: str,
+    metadata: Dict[str, Any],
+    type: BreadcrumbType
+) -> None:
+    default_client._auto_leave_breadcrumb(message, metadata, type)

--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -376,3 +376,26 @@ def test_the_breadcrumb_list_is_separate_on_different_async_contexts():
         loop.run_until_complete(test())
     finally:
         loop.close()
+
+
+def test_the_breadcrumb_list_can_be_cleared():
+    breadcrumbs = Breadcrumbs(max_breadcrumbs=5)
+
+    first_breadcrumb = Breadcrumb('hello', BreadcrumbType.ERROR, {}, 'time')
+    second_breadcrumb = Breadcrumb('hi', BreadcrumbType.REQUEST, {}, 'emit')
+    third_breadcrumb = Breadcrumb('howdy', BreadcrumbType.LOG, {}, 'now')
+
+    breadcrumbs.append(first_breadcrumb)
+    breadcrumbs.append(second_breadcrumb)
+    breadcrumbs.append(third_breadcrumb)
+
+    breadcrumb_list = breadcrumbs.to_list()
+
+    assert len(breadcrumb_list) == 3
+    assert breadcrumb_list[0] == first_breadcrumb
+    assert breadcrumb_list[1] == second_breadcrumb
+    assert breadcrumb_list[2] == third_breadcrumb
+
+    breadcrumbs.clear()
+
+    assert(len(breadcrumbs.to_list())) == 0


### PR DESCRIPTION
## Goal

This PR adds an automatic `navigation` breadcrumb for requests in each integration (ASGI, Django, Flask & WSGI)

Tornado doesn't separate contextvars per-request, so needs more work to support breadcrumbs. This will happen in a future PR

## Testing

Unit tests have been added and manual testing with the example apps