### PR TITLE
fix: Fixes setup.py PEP440 version compliance.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email='simon@bugsnag.com',
     url='https://bugsnag.com/',
     license='MIT',
-    python_requires='>=3.5.*, <4',
+    python_requires='>=3.5, <4',
     packages=find_packages(include=['bugsnag', 'bugsnag.*']),
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
## Goal

Some tools (e.g. poetry) require setup.py to specify a valid [PEP440](https://www.python.org/dev/peps/pep-0440/) version.

## Design

`>=3.5.*` specifies all versions greater equal than `3.5`. The PEP440 compliant version clause therefore is: `>=3.5`

## Changeset

Fixes the python version clause in setup.py to PEP440 compliance

## Testing

Local unit tests and github test pipelines