### PR TITLE
Ensure breadcrumb metadata is a dict

### DIFF
--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -1,5 +1,7 @@
+import builtins
 import sys
 import threading
+import warnings
 
 from datetime import datetime, timezone
 from functools import wraps
@@ -225,6 +227,15 @@ class Client:
             # Coerce the "type" into a valid BreadcrumbType, this will default
             # to "MANUAL" if the given type is invalid
             type = BreadcrumbType.from_string(type)
+
+        if not isinstance(metadata, dict):
+            warning_message = 'breadcrumb metadata must be a dict, got {}'
+            warnings.warn(
+                warning_message.format(builtins.type(metadata).__name__),
+                RuntimeWarning
+            )
+
+            metadata = {}
 
         timestamp = to_rfc3339(datetime.now(timezone.utc))
         breadcrumb = Breadcrumb(message, type, metadata, timestamp)


### PR DESCRIPTION
## Goal

This is important because:

- metadata should always be a key/value mapping
- we convert the dict into a `FilterDict` which applies filters to the metadata. If we accept anything other than dict, we open the possibility of filtering not being applied

Without this change, an exception will be raised in the `breadcrumb.to_dict` method for types that are not iterable and possibly undefined behaviour occurs for iterable types