### PR TITLE
Fix mypy failing on ci

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+
+[mypy-tornado.*]
+ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,10 @@ deps=
     django{22,3}: pytest-django
     lint: flake8
     lint: mypy
+    lint: types-pkg_resources
+    lint: types-requests
+    lint: types-Flask
+    lint: types-contextvars
 
 commands =
     pytest --doctest-modules bugsnag --doctest-ignore-import-errors


### PR DESCRIPTION
## Goal

mypy 0.900 now requires type packages (which were previously bundled with mypy) to be installed manually. See the release notes https://mypy-lang.blogspot.com/2021/06/mypy-0900-released.html

We have to ignore the Tornado types because they are [only available for Python 2](https://github.com/python/typeshed/blob/c601d5cf3d8968f3dc1fe792bc1da5b43c6a9ed9/stubs/tornado/METADATA.toml#L2-L3)