### PR TITLE
Add on breadcrumb callback type

### DIFF
--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -2,7 +2,12 @@ from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.notification import Notification
 from bugsnag.event import Event
 from bugsnag.client import Client
-from bugsnag.breadcrumbs import BreadcrumbType, Breadcrumb, Breadcrumbs
+from bugsnag.breadcrumbs import (
+    BreadcrumbType,
+    Breadcrumb,
+    Breadcrumbs,
+    OnBreadcrumbCallback
+)
 from bugsnag.legacy import (configuration, configure, configure_request,
                             add_metadata_tab, clear_request_config, notify,
                             auto_notify, before_notify, start_session,
@@ -13,4 +18,5 @@ __all__ = ('Client', 'Event', 'Configuration', 'RequestConfiguration',
            'add_metadata_tab', 'clear_request_config', 'notify',
            'auto_notify', 'before_notify', 'start_session',
            'auto_notify_exc_info', 'Notification', 'logger',
-           'BreadcrumbType', 'Breadcrumb', 'Breadcrumbs', 'leave_breadcrumb')
+           'BreadcrumbType', 'Breadcrumb', 'Breadcrumbs',
+           'OnBreadcrumbCallback', 'leave_breadcrumb')

--- a/bugsnag/breadcrumbs.py
+++ b/bugsnag/breadcrumbs.py
@@ -1,5 +1,5 @@
 from enum import Enum, unique
-from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Union, Callable, TYPE_CHECKING
 from collections import deque
 
 from bugsnag.utils import FilterDict
@@ -20,7 +20,12 @@ except ImportError:
     _breadcrumbs = ThreadContextVar('bugsnag-breadcrumbs', default=None)  # type: ignore  # noqa: E501
 
 
-__all__ = ('BreadcrumbType', 'Breadcrumb', 'Breadcrumbs')
+__all__ = (
+    'BreadcrumbType',
+    'Breadcrumb',
+    'Breadcrumbs',
+    'OnBreadcrumbCallback'
+)
 
 
 @unique
@@ -117,3 +122,6 @@ class Breadcrumbs:
             _breadcrumbs.set(breadcrumbs)
 
         return breadcrumbs
+
+
+OnBreadcrumbCallback = Callable[[Breadcrumb], Union[None, bool]]

--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -7,7 +7,11 @@ from datetime import datetime, timezone
 from functools import wraps
 from typing import Union, Tuple, Callable, Optional, List, Type, Dict, Any
 
-from bugsnag.breadcrumbs import Breadcrumb, BreadcrumbType
+from bugsnag.breadcrumbs import (
+    Breadcrumb,
+    BreadcrumbType,
+    OnBreadcrumbCallback
+)
 from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.event import Event
 from bugsnag.handlers import BugsnagHandler
@@ -206,10 +210,13 @@ class Client:
     def breadcrumbs(self) -> List[Breadcrumb]:
         return self.configuration.breadcrumbs
 
-    def add_on_breadcrumb(self, on_breadcrumb) -> None:
+    def add_on_breadcrumb(self, on_breadcrumb: OnBreadcrumbCallback) -> None:
         self.configuration.add_on_breadcrumb(on_breadcrumb)
 
-    def remove_on_breadcrumb(self, on_breadcrumb) -> None:
+    def remove_on_breadcrumb(
+        self,
+        on_breadcrumb: OnBreadcrumbCallback
+    ) -> None:
         self.configuration.remove_on_breadcrumb(on_breadcrumb)
 
     def leave_breadcrumb(

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -8,7 +8,12 @@ import warnings
 import logging
 from threading import Lock
 
-from bugsnag.breadcrumbs import BreadcrumbType, Breadcrumb, Breadcrumbs
+from bugsnag.breadcrumbs import (
+    BreadcrumbType,
+    Breadcrumb,
+    Breadcrumbs,
+    OnBreadcrumbCallback
+)
 from bugsnag.sessiontracker import SessionMiddleware
 from bugsnag.middleware import DefaultMiddleware, MiddlewareStack
 from bugsnag.utils import (fully_qualified_class_name, validate_str_setter,
@@ -478,11 +483,14 @@ class Configuration:
     def breadcrumbs(self) -> List[Breadcrumb]:
         return self._breadcrumbs.to_list()
 
-    def add_on_breadcrumb(self, on_breadcrumb) -> None:
+    def add_on_breadcrumb(self, on_breadcrumb: OnBreadcrumbCallback) -> None:
         with self._mutex:
             self._on_breadcrumbs.append(on_breadcrumb)
 
-    def remove_on_breadcrumb(self, on_breadcrumb) -> None:
+    def remove_on_breadcrumb(
+        self,
+        on_breadcrumb: OnBreadcrumbCallback
+    ) -> None:
         with self._mutex:
             try:
                 self._on_breadcrumbs.remove(on_breadcrumb)


### PR DESCRIPTION
## Goal

I noticed we don't type `on_breadcrumb` callbacks currently, but I'm not sure why I didn't add this originally

The type of `on_breadcrumb` callbacks is `Callable[[Breadcrumb], Union[None, bool]]`, i.e. a callable that takes a Breadcrumb and returns either None or a boolean (to allow returning boolean expressions, e.g. `breadcrumb.message == 'something'`)