### PR TITLE
Add `on_breadcrumb` functions to legacy.py

### DIFF
--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -11,7 +11,8 @@ from bugsnag.breadcrumbs import (
 from bugsnag.legacy import (configuration, configure, configure_request,
                             add_metadata_tab, clear_request_config, notify,
                             auto_notify, before_notify, start_session,
-                            auto_notify_exc_info, logger, leave_breadcrumb)
+                            auto_notify_exc_info, logger, leave_breadcrumb,
+                            add_on_breadcrumb, remove_on_breadcrumb)
 
 __all__ = ('Client', 'Event', 'Configuration', 'RequestConfiguration',
            'configuration', 'configure', 'configure_request',
@@ -19,4 +20,5 @@ __all__ = ('Client', 'Event', 'Configuration', 'RequestConfiguration',
            'auto_notify', 'before_notify', 'start_session',
            'auto_notify_exc_info', 'Notification', 'logger',
            'BreadcrumbType', 'Breadcrumb', 'Breadcrumbs',
-           'OnBreadcrumbCallback', 'leave_breadcrumb')
+           'OnBreadcrumbCallback', 'leave_breadcrumb', 'add_on_breadcrumb',
+           'remove_on_breadcrumb')

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -2,7 +2,7 @@ from typing import Dict, Any, Tuple, Type, Union
 import types
 import sys
 
-from bugsnag.breadcrumbs import BreadcrumbType
+from bugsnag.breadcrumbs import BreadcrumbType, OnBreadcrumbCallback
 from bugsnag.configuration import RequestConfiguration
 from bugsnag.client import Client
 
@@ -136,6 +136,22 @@ def leave_breadcrumb(
     type: Union[BreadcrumbType, str] = BreadcrumbType.MANUAL
 ) -> None:
     default_client.leave_breadcrumb(message, metadata, type)
+
+
+def add_on_breadcrumb(on_breadcrumb: OnBreadcrumbCallback) -> None:
+    """
+    Add a callback to be called each time a breadcrumb is left
+
+    This can be used to alter the breadcrumb, or discard it by returning False
+    """
+    default_client.add_on_breadcrumb(on_breadcrumb)
+
+
+def remove_on_breadcrumb(on_breadcrumb: OnBreadcrumbCallback) -> None:
+    """
+    Remove an existing on_breadcrumb callback
+    """
+    default_client.remove_on_breadcrumb(on_breadcrumb)
 
 
 def _auto_leave_breadcrumb(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -419,6 +419,28 @@ class ClientTest(IntegrationTest):
         client.remove_on_breadcrumb(lambda: None)
         assert client.configuration._on_breadcrumbs == []
 
+    def test_legacy_on_breadcrumb_callbacks_can_be_added_and_removed(self):
+        client = legacy.default_client
+        config = client.configuration
+        assert config._on_breadcrumbs == []
+
+        def on_breadcrumb():
+            pass
+
+        on_breadcrumb_2 = lambda: None  # noqa: E731
+
+        client.add_on_breadcrumb(on_breadcrumb)
+        assert config._on_breadcrumbs == [on_breadcrumb]
+
+        client.add_on_breadcrumb(on_breadcrumb_2)
+        assert config._on_breadcrumbs == [on_breadcrumb, on_breadcrumb_2]
+
+        client.remove_on_breadcrumb(on_breadcrumb)
+        assert config._on_breadcrumbs == [on_breadcrumb_2]
+
+        client.remove_on_breadcrumb(on_breadcrumb_2)
+        assert config._on_breadcrumbs == []
+
     def test_legacy_leave_breadcrumb_defaults(self):
         client = legacy.default_client
         assert len(client.configuration.breadcrumbs) == 0


### PR DESCRIPTION
## Goal

Adds forwarding methods for `client.add_on_breadcrumb` and `client.remove_on_breadcrumb` to legacy.py. This makes `on_breadcrumb` callbacks much nicer to use when an app doesn't have a direct reference to a client