### PR TITLE
Don't allow strings as breadcrumb types

### DIFF
--- a/bugsnag/breadcrumbs.py
+++ b/bugsnag/breadcrumbs.py
@@ -39,16 +39,6 @@ class BreadcrumbType(Enum):
     ERROR = 'error'
     MANUAL = 'manual'
 
-    @staticmethod
-    def from_string(string: str) -> 'BreadcrumbType':
-        if not isinstance(string, str):
-            return BreadcrumbType.MANUAL
-
-        try:
-            return BreadcrumbType[string.upper()]
-        except KeyError:
-            return BreadcrumbType.MANUAL
-
 
 class Breadcrumb:
     def __init__(

--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -227,7 +227,7 @@ class Client:
         self,
         message: str,
         metadata: Dict[str, Any] = {},
-        type: Union[BreadcrumbType, str] = BreadcrumbType.MANUAL
+        type: BreadcrumbType = BreadcrumbType.MANUAL
     ) -> None:
         # Don't create breadcrumbs if the max_breadcrumbs is 0 as they would
         # be immediately discarded anyway
@@ -235,9 +235,7 @@ class Client:
             return
 
         if not isinstance(type, BreadcrumbType):
-            # Coerce the "type" into a valid BreadcrumbType, this will default
-            # to "MANUAL" if the given type is invalid
-            type = BreadcrumbType.from_string(type)
+            type = BreadcrumbType.MANUAL
 
         if not isinstance(metadata, dict):
             warning_message = 'breadcrumb metadata must be a dict, got {}'
@@ -274,10 +272,7 @@ class Client:
         metadata: Dict[str, Any],
         type: BreadcrumbType
     ) -> None:
-        if (
-            type in self.configuration.enabled_breadcrumb_types
-            or type.value in self.configuration.enabled_breadcrumb_types
-        ):
+        if type in self.configuration.enabled_breadcrumb_types:
             self.leave_breadcrumb(message, metadata, type)
 
     def _leave_breadcrumb_for_event(self, event: Event) -> None:

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Tuple, Type, Union
+from typing import Dict, Any, Tuple, Type
 import types
 import sys
 
@@ -133,7 +133,7 @@ def before_notify(callback):
 def leave_breadcrumb(
     message: str,
     metadata: Dict[str, Any] = {},
-    type: Union[BreadcrumbType, str] = BreadcrumbType.MANUAL
+    type: BreadcrumbType = BreadcrumbType.MANUAL
 ) -> None:
     default_client.leave_breadcrumb(message, metadata, type)
 

--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -22,35 +22,6 @@ def test_breadcrumb_types():
     assert BreadcrumbType.MANUAL.value == 'manual'
 
 
-@pytest.mark.parametrize('string, expected', [
-    ('navigation', BreadcrumbType.NAVIGATION),
-    ('NAVIGATION', BreadcrumbType.NAVIGATION),
-    ('request', BreadcrumbType.REQUEST),
-    ('REQUEST', BreadcrumbType.REQUEST),
-    ('process', BreadcrumbType.PROCESS),
-    ('PROCESS', BreadcrumbType.PROCESS),
-    ('log', BreadcrumbType.LOG),
-    ('LOG', BreadcrumbType.LOG),
-    ('user', BreadcrumbType.USER),
-    ('USER', BreadcrumbType.USER),
-    ('state', BreadcrumbType.STATE),
-    ('STATE', BreadcrumbType.STATE),
-    ('error', BreadcrumbType.ERROR),
-    ('ERROR', BreadcrumbType.ERROR),
-    ('manual', BreadcrumbType.MANUAL),
-    ('MANUAL', BreadcrumbType.MANUAL),
-    ('mAnUaL', BreadcrumbType.MANUAL),
-    ('MaNuAl', BreadcrumbType.MANUAL),
-    # invalid strings should result in a manual breadcrumb type
-    ('not a breadcrumb type', BreadcrumbType.MANUAL),
-    ('NOPE', BreadcrumbType.MANUAL),
-    (12345, BreadcrumbType.MANUAL),
-    ([1, 2, 3], BreadcrumbType.MANUAL),
-])
-def test_breadcrumb_type_from_string(string, expected):
-    assert BreadcrumbType.from_string(string) == expected
-
-
 def test_breadcrumb_properties():
     breadcrumb = Breadcrumb(
         'This is a test breadcrumb',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -557,20 +557,6 @@ class ClientTest(IntegrationTest):
         assert breadcrumb.type == BreadcrumbType.MANUAL
         assert is_valid_timestamp(breadcrumb.timestamp)
 
-    def test_leave_breadcrumb_with_string_type(self):
-        client = Client()
-        assert len(client.configuration.breadcrumbs) == 0
-
-        client.leave_breadcrumb('abcxyz', type='log')
-        assert len(client.configuration.breadcrumbs) == 1
-
-        breadcrumb = client.configuration.breadcrumbs[0]
-
-        assert breadcrumb.message == 'abcxyz'
-        assert breadcrumb.metadata == {}
-        assert breadcrumb.type == BreadcrumbType.LOG
-        assert is_valid_timestamp(breadcrumb.timestamp)
-
     def test_leave_breadcrumb_does_nothing_when_max_breadcrumbs_is_0(self):
         client = Client()
         client.configuration.configure(max_breadcrumbs=0)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -598,20 +598,6 @@ class HandlersTest(IntegrationTest):
         assert breadcrumb.type == BreadcrumbType.LOG
         assert breadcrumb.metadata == {'logLevel': 'INFO'}
 
-        handler.client.configuration.configure(
-            enabled_breadcrumb_types=['log']
-        )
-
-        logger.info('Everything is fine')
-
-        assert self.sent_report_count == 0
-        assert len(handler.client.configuration.breadcrumbs) == 2
-
-        breadcrumb = handler.client.configuration.breadcrumbs[1]
-        assert breadcrumb.message == 'Everything is fine'
-        assert breadcrumb.type == BreadcrumbType.LOG
-        assert breadcrumb.metadata == {'logLevel': 'INFO'}
-
     def test_log_filter_leaves_breadcrumbs_when_manually_constructed(self):
         default_client.configuration.max_breadcrumbs = 25
 


### PR DESCRIPTION
## Goal

Require a `BreadcrumbType`, not a `string`, as the `type` parameter to `leave_breadcrumbs`

When writing the docs for breadcrumbs this was confusing and it has the potential to cause issues with 'enabled_breadcrumb_types' if there is a mix of strings & `BreadcrumbType`