### PR TITLE
Support breadcrumbs in Tornado apps

### DIFF
--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -74,6 +74,7 @@ class BugsnagRequestHandler(RequestHandler):
         middleware = bugsnag.configure().internal_middleware
         bugsnag.configure().runtime_versions['tornado'] = tornado.version
         middleware.before_notify(self.add_tornado_request_to_notification)
+        bugsnag.configure()._breadcrumbs.create_copy_for_context()
 
         if bugsnag.configuration.auto_capture_sessions:
             bugsnag.start_session()

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -3,7 +3,9 @@ from tornado.web import RequestHandler, HTTPError
 from tornado.wsgi import WSGIContainer
 from typing import Dict, Any
 from urllib.parse import parse_qs
+from bugsnag.breadcrumbs import BreadcrumbType
 from bugsnag.utils import is_json_content_type
+from bugsnag.legacy import _auto_leave_breadcrumb
 import bugsnag
 import json
 
@@ -76,8 +78,25 @@ class BugsnagRequestHandler(RequestHandler):
         middleware.before_notify(self.add_tornado_request_to_notification)
         bugsnag.configure()._breadcrumbs.create_copy_for_context()
 
+        _auto_leave_breadcrumb(
+            'http request',
+            self._get_breadcrumb_metadata(),
+            BreadcrumbType.NAVIGATION
+        )
+
         if bugsnag.configuration.auto_capture_sessions:
             bugsnag.start_session()
+
+    def _get_breadcrumb_metadata(self) -> Dict[str, str]:
+        if not hasattr(self, 'request'):
+            return {}
+
+        metadata = {'to': self.request.path}
+
+        if 'Referer' in self.request.headers:
+            metadata['from'] = self.request.headers['Referer']
+
+        return metadata
 
     def _get_context(self):
         return "%s %s" % (self.request.method, self.request.uri.split("?")[0])

--- a/tests/integrations/test_tornado.py
+++ b/tests/integrations/test_tornado.py
@@ -1,5 +1,6 @@
 import bugsnag
 import json
+from bugsnag.breadcrumbs import BreadcrumbType
 from tests.utils import IntegrationTest
 from tornado.testing import AsyncHTTPTestCase
 from tests.fixtures.tornado import server
@@ -15,7 +16,8 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
                           api_key='3874876376238728937',
                           notify_release_stages=['dev'],
                           release_stage='dev',
-                          asynchronous=False)
+                          asynchronous=False,
+                          max_breadcrumbs=25)
 
     def test_notify(self):
         response = self.fetch('/notify', method="GET")
@@ -32,6 +34,13 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
             'POST': {},
             'GET': {}
         })
+
+        breadcrumbs = event['breadcrumbs']
+
+        assert len(breadcrumbs) == 1
+        assert breadcrumbs[0]['name'] == 'http request'
+        assert breadcrumbs[0]['metaData'] == {'to': '/notify'}
+        assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
 
     def test_notify_get(self):
         response = self.fetch('/notify?test=get', method="GET")
@@ -50,6 +59,13 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
             'GET': {'test': ['get']}
         })
 
+        breadcrumbs = event['breadcrumbs']
+
+        assert len(breadcrumbs) == 1
+        assert breadcrumbs[0]['name'] == 'http request'
+        assert breadcrumbs[0]['metaData'] == {'to': '/notify'}
+        assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
+
     def test_notify_post(self):
         response = self.fetch('/notify', method="POST", body="test=post")
         self.assertEqual(response.code, 200)
@@ -65,6 +81,13 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
             'POST': {'test': ['post']},
             'GET': {}
         })
+
+        breadcrumbs = event['breadcrumbs']
+
+        assert len(breadcrumbs) == 1
+        assert breadcrumbs[0]['name'] == 'http request'
+        assert breadcrumbs[0]['metaData'] == {'to': '/notify'}
+        assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
 
     def test_notify_json_post(self):
         body = json.dumps({'test': 'json_post'})
@@ -83,6 +106,13 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
             'POST': {'test': 'json_post'},
             'GET': {}
         })
+
+        breadcrumbs = event['breadcrumbs']
+
+        assert len(breadcrumbs) == 1
+        assert breadcrumbs[0]['name'] == 'http request'
+        assert breadcrumbs[0]['metaData'] == {'to': '/notify'}
+        assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
 
     def test_notify_json_subtype_post(self):
         body = {
@@ -113,6 +143,13 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
             'GET': {}
         })
 
+        breadcrumbs = event['breadcrumbs']
+
+        assert len(breadcrumbs) == 1
+        assert breadcrumbs[0]['name'] == 'http request'
+        assert breadcrumbs[0]['metaData'] == {'to': '/notify'}
+        assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
+
     def test_unhandled(self):
         response = self.fetch('/crash', method="GET")
         self.assertEqual(response.code, 500)
@@ -131,6 +168,13 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
         })
         assert 'environment' not in payload['events'][0]['metaData']
 
+        breadcrumbs = event['breadcrumbs']
+
+        assert len(breadcrumbs) == 1
+        assert breadcrumbs[0]['name'] == 'http request'
+        assert breadcrumbs[0]['metaData'] == {'to': '/crash'}
+        assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
+
     def test_unhandled_post(self):
         response = self.fetch('/crash', method="POST", body="test=post")
         self.assertEqual(response.code, 500)
@@ -147,6 +191,13 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
             'POST': {'test': ['post']},
             'GET': {}
         })
+
+        breadcrumbs = event['breadcrumbs']
+
+        assert len(breadcrumbs) == 1
+        assert breadcrumbs[0]['name'] == 'http request'
+        assert breadcrumbs[0]['metaData'] == {'to': '/crash'}
+        assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
 
     def test_unhandled_json_post(self):
         body = json.dumps({'test': 'json_post'})
@@ -167,6 +218,13 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
             'GET': {}
         })
 
+        breadcrumbs = event['breadcrumbs']
+
+        assert len(breadcrumbs) == 1
+        assert breadcrumbs[0]['name'] == 'http request'
+        assert breadcrumbs[0]['metaData'] == {'to': '/crash'}
+        assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
+
     def test_ignored_http_error(self):
         response = self.fetch('/unknown_endpoint')
         self.assertEqual(response.code, 404)
@@ -183,6 +241,13 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
         self.assertEqual(event['metaData']['environment']['REQUEST_METHOD'],
                          'POST')
 
+        breadcrumbs = event['breadcrumbs']
+
+        assert len(breadcrumbs) == 1
+        assert breadcrumbs[0]['name'] == 'http request'
+        assert breadcrumbs[0]['metaData'] == {'to': '/notify'}
+        assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
+
     def test_read_request_in_callback(self):
         self.fetch('/crash_with_callback?user_id=foo')
         assert len(self.server.received) == 1
@@ -190,3 +255,25 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
         payload = self.server.received[0]['json_body']
         event = payload['events'][0]
         assert event['user']['id'] == 'foo'
+
+        breadcrumbs = event['breadcrumbs']
+
+        assert len(breadcrumbs) == 1
+        assert breadcrumbs[0]['name'] == 'http request'
+        assert breadcrumbs[0]['metaData'] == {'to': '/crash_with_callback'}
+        assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
+
+    def test_bugsnag_request_handler_leaves_breadcrumb_with_referer(self):
+        self.fetch('/crash', headers={'Referer': '/abc/xyz'})
+        assert len(self.server.received) == 1
+
+        payload = self.server.received[0]['json_body']
+        breadcrumbs = payload['events'][0]['breadcrumbs']
+
+        assert len(breadcrumbs) == 1
+        assert breadcrumbs[0]['name'] == 'http request'
+        assert breadcrumbs[0]['metaData'] == {
+            'to': '/crash',
+            'from': '/abc/xyz'
+        }
+        assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value


### PR DESCRIPTION
## Goal

Previously the breadcrumb context var would "leak" between requests because Tornado doesn't use threads or copy the context automatically. By explicitly copying the breadcrumb list (using the existing `create_copy_for_context` method) each request is isolated and can leave breadcrumbs without affecting other requests

This PR also adds the navigation breadcrumb for Tornado, to match the other integrations (see https://github.com/bugsnag/bugsnag-python/pull/276)

## Testing

Manually tested on Tornado 4, 5 & 6 + unit tests