### PR TITLE
Fix breadcrumb log filter when not passed a client

### DIFF
--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -158,14 +158,16 @@ class BugsnagHandler(logging.Handler, object):
         handler's level
         """
 
+        client = self.client or bugsnag.legacy.default_client
+
         # Only leave a breadcrumb if we aren't going to notify this log record
         # and its "bugsnag_create_breadcrumb" attribute isn't False
         if (
-            record.levelno >= self.client.configuration.breadcrumb_log_level
+            record.levelno >= client.configuration.breadcrumb_log_level
             and record.levelno < self.level
             and getattr(record, 'bugsnag_create_breadcrumb', True)
         ):
-            self.client._auto_leave_breadcrumb(
+            client._auto_leave_breadcrumb(
                 record.getMessage(),
                 {"logLevel": record.levelname},
                 BreadcrumbType.LOG


### PR DESCRIPTION
## Goal

The breadcrumb log filter was relying on a client property that may not always be set. For example, this snippet would crash when a breadcrumb was left by the filter:

```python
logger = logging.getLogger("test.logger")
handler = bugsnag.handlers.BugsnagHandler()
handler.setLevel(logging.WARNING)

logger.addHandler(handler)
logger.addFilter(handler.leave_breadcrumbs)
```

The way it's currently setup requires the handler to have a `Client` instance (by calling `Client.log_handler` or passing a `Client` in the `BugsnagHandler`'s constructor), but it should also work when constructed manually as this is how we've always documented the log handler

The unit tests didn't catch this as they always use `Client.log_handler`, so I've added a new test along the lines of the above snippet