### PR TITLE
Leave breadcrumbs when handler's level is `NOTSET`

### DIFF
--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -162,9 +162,12 @@ class BugsnagHandler(logging.Handler, object):
 
         # Only leave a breadcrumb if we aren't going to notify this log record
         # and its "bugsnag_create_breadcrumb" attribute isn't False
+        # If the handler has no level (is NOTSET) then we will leave a
+        # breadcrumb because it's likely this means the handler has not been
+        # attached. Otherwise it would be notify-ing for every log call
         if (
             record.levelno >= client.configuration.breadcrumb_log_level
-            and record.levelno < self.level
+            and (record.levelno < self.level or self.level == logging.NOTSET)
             and getattr(record, 'bugsnag_create_breadcrumb', True)
         ):
             client._auto_leave_breadcrumb(


### PR DESCRIPTION
## Goal

Currently if the BugsnagHandler's level is never set, the breadcrumb filter will never leave breadcrumbs. This is because the `NOTSET` level is 0, which is below every other level constant

We should be leaving breadcrumbs in this case because it's likely this configuration means that the handler hasn't been attached to the logger, e.g:

```python
from bugsnag.handlers import BugsnagHandler

logger = logging.getLogger("test.logger")
handler = BugsnagHandler()

logger.addFilter(handler.leave_breadcrumbs)
```

This is a valid setup to get breadcrumbs for all log messages above `breadcrumb_log_level`, but won't leave any breadcrumbs at all currently

This PR adds a special case for the handler's level being `NOTSET` where the log filter will always leave a breadcrumb

There is one downside to this approach in that it's now possible to have both a notify call _and_ a breadcrumb for the same log messages. However, this would require the handler's level being `NOTSET` which would cause it to notify for every log message, including debug messages. This doesn't seem like it'd be as likely as wanting breadcrumbs but not notifications and can still be achieved by setting the handler's level to `DEBUG`