### PR TITLE
Avoid capturing query parameters in referer header

### DIFF
--- a/bugsnag/asgi.py
+++ b/bugsnag/asgi.py
@@ -4,6 +4,7 @@ from typing import Any, List, Dict, Union, Optional
 import bugsnag
 from bugsnag.breadcrumbs import BreadcrumbType
 from bugsnag.legacy import _auto_leave_breadcrumb
+from bugsnag.utils import sanitize_url
 
 __all__ = ('BugsnagMiddleware',)
 
@@ -132,7 +133,7 @@ def _get_breadcrumb_metadata(scope) -> Dict[str, str]:
     referer = _get_referer_header(scope)
 
     if referer:
-        metadata['from'] = referer
+        metadata['from'] = sanitize_url(referer)
 
     return metadata
 

--- a/bugsnag/django/middleware.py
+++ b/bugsnag/django/middleware.py
@@ -9,6 +9,7 @@ import bugsnag
 import bugsnag.django
 from bugsnag.legacy import _auto_leave_breadcrumb
 from bugsnag.breadcrumbs import BreadcrumbType
+from bugsnag.utils import sanitize_url
 
 
 class BugsnagMiddleware(MiddlewareMixin):
@@ -58,6 +59,6 @@ class BugsnagMiddleware(MiddlewareMixin):
         metadata = {'to': request.path}
 
         if 'HTTP_REFERER' in request.META:
-            metadata['from'] = request.META['HTTP_REFERER']
+            metadata['from'] = sanitize_url(request.META['HTTP_REFERER'])
 
         return metadata

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -5,6 +5,7 @@ import bugsnag
 from bugsnag.wsgi import request_path
 from bugsnag.legacy import _auto_leave_breadcrumb
 from bugsnag.breadcrumbs import BreadcrumbType
+from bugsnag.utils import sanitize_url
 
 
 __all__ = ('handle_exceptions',)
@@ -65,9 +66,9 @@ def _on_request_started(sender, **extra):
 
 
 def _get_breadcrumb_metadata(request) -> Dict[str, str]:
-    metadata = {'to': request_path(flask.request.environ)}
+    metadata = {'to': request_path(request.environ)}
 
     if 'referer' in request.headers:
-        metadata['from'] = request.headers['referer']
+        metadata['from'] = sanitize_url(request.headers['referer'])
 
     return metadata

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -4,7 +4,7 @@ from tornado.wsgi import WSGIContainer
 from typing import Dict, Any
 from urllib.parse import parse_qs
 from bugsnag.breadcrumbs import BreadcrumbType
-from bugsnag.utils import is_json_content_type
+from bugsnag.utils import is_json_content_type, sanitize_url
 from bugsnag.legacy import _auto_leave_breadcrumb
 import bugsnag
 import json
@@ -94,7 +94,7 @@ class BugsnagRequestHandler(RequestHandler):
         metadata = {'to': self.request.path}
 
         if 'Referer' in self.request.headers:
-            metadata['from'] = self.request.headers['Referer']
+            metadata['from'] = sanitize_url(self.request.headers['Referer'])
 
         return metadata
 

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -2,7 +2,7 @@ from functools import wraps, partial
 import inspect
 from json import JSONEncoder
 from threading import local as threadlocal
-from typing import Tuple, Optional, Union
+from typing import Tuple, Optional
 import warnings
 import copy
 import logging
@@ -320,7 +320,7 @@ class ThreadContextVar:
         setattr(ThreadContextVar.local_context(), self.name, new_value)
 
 
-def sanitize_url(url_to_sanitize: str) -> Union[str, None]:
+def sanitize_url(url_to_sanitize: str) -> Optional[str]:
     try:
         parsed = urlparse(url_to_sanitize)
     except Exception:

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -6,6 +6,7 @@ import bugsnag
 from bugsnag.wsgi import request_path
 from bugsnag.breadcrumbs import BreadcrumbType
 from bugsnag.legacy import _auto_leave_breadcrumb
+from bugsnag.utils import sanitize_url
 
 # Attempt to import bottle for runtime version report, but only if already
 # in use in app
@@ -109,7 +110,7 @@ def _get_breadcrumb_metadata(environ) -> Dict[str, str]:
         metadata['to'] = environ['PATH_INFO']
 
     if 'HTTP_REFERER' in environ:
-        metadata['from'] = environ['HTTP_REFERER']
+        metadata['from'] = sanitize_url(environ['HTTP_REFERER'])
 
     return metadata
 

--- a/tests/integrations/test_asgi.py
+++ b/tests/integrations/test_asgi.py
@@ -231,7 +231,7 @@ class TestASGIMiddleware(IntegrationTest):
             return PlainTextResponse('pineapple')
 
         app = TestClient(BugsnagMiddleware(app))
-        headers = {'referer': 'https://example.com/abc/xyz'}
+        headers = {'referer': 'http://testserver/abc/xyz?password=hunter2'}
 
         self.assertRaises(
             ScaryException,
@@ -259,6 +259,6 @@ class TestASGIMiddleware(IntegrationTest):
         assert breadcrumbs[0]['name'] == 'http request'
         assert breadcrumbs[0]['metaData'] == {
             'to': '/',
-            'from': 'https://example.com/abc/xyz'
+            'from': 'http://testserver/abc/xyz'
         }
         assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -392,7 +392,7 @@ def test_bugsnag_middleware_leaves_breadcrumb_with_referer(
 ):
     response = django_client.get(
         '/notes/handled-exception/?foo=strawberry',
-        HTTP_REFERER='/notes/top-10-dogs.txt'
+        HTTP_REFERER='http://testserver/notes/top-10-dogs.txt?password=hunter2'
     )
 
     assert response.status_code == 200
@@ -440,6 +440,6 @@ def test_bugsnag_middleware_leaves_breadcrumb_with_referer(
     assert breadcrumbs[0]['name'] == 'http request'
     assert breadcrumbs[0]['metaData'] == {
         'to': '/notes/handled-exception/',
-        'from': '/notes/top-10-dogs.txt'
+        'from': 'http://testserver/notes/top-10-dogs.txt'
     }
     assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -299,7 +299,7 @@ class TestFlask(IntegrationTest):
             raise SentinelError("oops")
 
         handle_exceptions(app)
-        headers = {'referer': '/hi'}
+        headers = {'referer': 'http://localhost/hi?password=hunter2'}
         app.test_client().get('/hello', headers=headers)
 
         self.assertEqual(1, len(self.server.received))
@@ -317,6 +317,6 @@ class TestFlask(IntegrationTest):
         assert breadcrumbs[0]['name'] == 'http request'
         assert breadcrumbs[0]['metaData'] == {
             'to': '/hello',
-            'from': '/hi'
+            'from': 'http://localhost/hi'
         }
         assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value

--- a/tests/integrations/test_tornado.py
+++ b/tests/integrations/test_tornado.py
@@ -264,7 +264,11 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
         assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
 
     def test_bugsnag_request_handler_leaves_breadcrumb_with_referer(self):
-        self.fetch('/crash', headers={'Referer': '/abc/xyz'})
+        referer = 'http://127.0.0.1:{}/abc/xyz?password=hunter2'.format(
+            self.get_http_port()
+        )
+
+        self.fetch('/crash', headers={'Referer': referer})
         assert len(self.server.received) == 1
 
         payload = self.server.received[0]['json_body']
@@ -274,6 +278,6 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
         assert breadcrumbs[0]['name'] == 'http request'
         assert breadcrumbs[0]['metaData'] == {
             'to': '/crash',
-            'from': '/abc/xyz'
+            'from': 'http://127.0.0.1:{}/abc/xyz'.format(self.get_http_port())
         }
         assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value

--- a/tests/integrations/test_wsgi.py
+++ b/tests/integrations/test_wsgi.py
@@ -284,7 +284,7 @@ class TestWSGI(IntegrationTest):
                 raise SentinelError("oops")
 
         app = TestApp(BugsnagMiddleware(CrashOnStartApp))
-        headers = {'referer': '/toast'}
+        headers = {'referer': 'http://localhost/toast?password=hunter2'}
 
         self.assertRaises(
             SentinelError,
@@ -303,6 +303,6 @@ class TestWSGI(IntegrationTest):
         assert breadcrumbs[0]['name'] == 'http request'
         assert breadcrumbs[0]['metaData'] == {
             'to': '/beans',
-            'from': '/toast'
+            'from': 'http://localhost/toast'
         }
         assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -452,7 +452,7 @@ def test_to_rfc3339(dt: datetime, expected: str):
 
 
 @pytest.mark.parametrize("url_to_sanitize, expected", [
-    ('https://example.com', 'https://example.com/'),
+    ('https://example.com', 'https://example.com'),
     ('https://example.com/', 'https://example.com/'),
     ('https://example.com/a/b/c', 'https://example.com/a/b/c'),
     ('https://example.com/abc?xyz=123', 'https://example.com/abc'),
@@ -460,19 +460,41 @@ def test_to_rfc3339(dt: datetime, expected: str):
     ('https://example.com/abc?xyz=123', 'https://example.com/abc'),
     ('https://example.com/abc;x=1;y=2;z=3', 'https://example.com/abc'),
     ('https://example.com:8000/abc?xyz=123', 'https://example.com:8000/abc'),
+    (b'https://example.com', b'https://example.com'),
+    (b'https://example.com/', b'https://example.com/'),
+    (b'https://example.com/a/b/c', b'https://example.com/a/b/c'),
+    (b'https://example.com/abc?xyz=123', b'https://example.com/abc'),
+    (b'https://example.com/a/b/c', b'https://example.com/a/b/c'),
+    (b'https://example.com/abc?xyz=123', b'https://example.com/abc'),
+    (b'https://example.com/abc;x=1;y=2;z=3', b'https://example.com/abc'),
+    (b'https://example.com:8000/abc?xyz=123', b'https://example.com:8000/abc'),
 
     ('wss://example.com/abc?xyz=123', 'wss://example.com/abc'),
     ('ftp://example.com/abc?xyz=123', 'ftp://example.com/abc'),
+    (b'wss://example.com/abc?xyz=123', b'wss://example.com/abc'),
+    (b'ftp://example.com/abc?xyz=123', b'ftp://example.com/abc'),
 
-    ('xyz', None),
-    ('///', None),
-    ('///', None),
-    ('/a/b/c', None),
-    ('/a/b/c', None),
-    ('example.com/<<<<', None),
-    ('->example.com<-', None),
+    ('xyz', 'xyz'),
+    ('///', '/'),
+    ('/a/b/c', '/a/b/c'),
+    ('example.com/<<<<', 'example.com/<<<<'),
+    ('->example.com<-', '->example.com<-'),
+    (b'xyz', b'xyz'),
+    (b'///', b'/'),
+    (b'/a/b/c', b'/a/b/c'),
+    (b'example.com/<<<<', b'example.com/<<<<'),
+    (b'->example.com<-', b'->example.com<-'),
+
     ('', None),
-    ('', None),
+    (b'', None),
+    ('  ', None),
+    (b'  ', None),
+    (None, None),
+    (123, None),
+    ([1, 2, 3], None),
+    ({'a': 1, b'b': 2, 'c': 3}, None),
+    (object(), None),
+    (lambda: 'example.com', None),
 ])
 def test_sanitize_url(url_to_sanitize, expected):
     assert sanitize_url(url_to_sanitize) == expected


### PR DESCRIPTION
## Goal

Currently we use the raw `Referer` header as the `from` value in navigation breadcrumbs. This has the potential to leak sensitive information, e.g. if a query parameter contains a password

This PR adds `bugsnag.utils.sanitize_url`, which parses the given URL and returns the scheme, domain & path, and uses it on the `Referer` header when recording navigation breadcrumbs