### PR TITLE
Stop ASGI breadcrumbs leaking between requests

### DIFF
--- a/bugsnag/asgi.py
+++ b/bugsnag/asgi.py
@@ -109,6 +109,7 @@ class BugsnagMiddleware:
         stack.before_notify(add_request_info)
 
     async def __call__(self, scope, receive, send):
+        bugsnag.configure()._breadcrumbs.create_copy_for_context()
         bugsnag.configure_request(asgi_scope=scope)
         try:
             if bugsnag.configuration.auto_capture_sessions:


### PR DESCRIPTION
This could happen depending on the libraries used to run the ASGI app, e.g. it doesn't happen with our simple ASGI example but does happen with a Starlette app using Uvicorn

Unfortunately we can't test this using Starlette's TestClient as it doesn't run requests in separate contexts, so this has to be manually tested for now