### PR TITLE
Fix error breadcrumbs ignoring `enabled_breadcrumb_types`

### DIFF
--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -278,7 +278,7 @@ class Client:
     def _leave_breadcrumb_for_event(self, event: Event) -> None:
         error_class = class_name(event.exception)
 
-        self.leave_breadcrumb(
+        self._auto_leave_breadcrumb(
             error_class,
             {
                 'errorClass': error_class,


### PR DESCRIPTION
## Goal

Breadcrumbs for errors (`notify` & except hooks) were ignoring the `enabled_breadcrumb_types` option and unconditionally leaving breadcrumbs, so there was no way to prevent them

They now correctly check `enabled_breadcrumb_types` before adding the breadcrumb