### PR TITLE
Fix error in ASGI middleware if the ASGI `client` is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix error in ASGI middleware if the ASGI `client` is None
+  [#296](https://github.com/bugsnag/bugsnag-python/pull/296)
+
 ## 4.1.0 (2021-06-23)
 
 ### Enhancements

--- a/bugsnag/asgi.py
+++ b/bugsnag/asgi.py
@@ -87,8 +87,11 @@ class BugsnagMiddleware:
             scope = event.request_config.asgi_scope
             request = dict()
             server = []
-            if 'client' in scope and len(scope['client']) > 0:
+
+            client = scope.get('client')
+            if client is not None and len(client) > 0:
                 request['clientIp'] = scope['client'][0]
+
             if 'server' in scope and type(scope['server']) in [list, tuple]:
                 server = scope['server']
             if 'headers' in scope:

--- a/tests/async_utils.py
+++ b/tests/async_utils.py
@@ -52,9 +52,9 @@ class ASGITestClient:
         await self.app(scope, receive, send)
         return received
 
-    async def request(self, path: str, query: str = '', method: str = 'GET'):
+    async def request(self, path: str, query: str = '', **kwargs):
         return await self.invoke({
-            'method': method,
+            'method': 'GET',
             'path': path,
             'query_string': query.encode(),
             'scheme': 'http',
@@ -64,6 +64,7 @@ class ASGITestClient:
             'headers': [
                 [b'user-agent', b'testclient'],
             ],
+            **kwargs
         })
 
     async def websocket_request(self, path: str):


### PR DESCRIPTION
## Goal

Our ASGI middleware assumes that the `client` in the ASGI scope cannot be None, but this isn't the case:

> client (Iterable[Unicode string, int]) – A two-item iterable of [host, port], where host is the remote host’s IPv4 or IPv6 address, and port is the remote port as an integer. **Optional; if missing defaults to None.**
> https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope

This PR adds a guard to avoid an error if there is a `client` but it is `None`

See https://github.com/bugsnag/bugsnag-python/issues/295

## Testing

Added a unit test that runs an ASGI app with the `client` set to `None`. This fails in master but passes in this branch

I also manually tested with Uvicorn on a unix socket (https://github.com/bugsnag/bugsnag-python/issues/295#issuecomment-920061096)