### PR TITLE
Add initial tests for caused by exceptions

### DIFF
--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,12 +1,11 @@
 # flake8: noqa
-try:
-    import sys; raise Exception("start")
-except Exception: start_of_file = sys.exc_info()
-# 4
-# 5
-# 6
-# 7
-# 8
-try:
-    import sys; raise Exception("end")
-except Exception: end_of_file = sys.exc_info()
+
+from .start_and_end_of_file import (
+    start_of_file,
+    end_of_file,
+)
+
+from .caused_by import (
+    exception_with_explicit_cause,
+    exception_with_implicit_cause,
+)

--- a/tests/fixtures/caused_by.py
+++ b/tests/fixtures/caused_by.py
@@ -1,0 +1,46 @@
+def a():
+    try:
+        b()
+    except Exception as cause:
+        raise NameError('a') from cause
+
+
+def b():
+    try:
+        c()
+    except Exception as cause:
+        raise ArithmeticError('b') from cause
+
+
+def c():
+    raise Exception('c')
+
+
+try:
+    a()
+except Exception as exception:
+    exception_with_explicit_cause = exception
+
+
+def x():
+    try:
+        y()
+    except Exception:
+        raise NameError('x')
+
+
+def y():
+    try:
+        z()
+    except Exception:
+        raise ArithmeticError('y')
+
+
+def z():
+    raise Exception('z')
+
+
+try:
+    x()
+except Exception as exception:
+    exception_with_implicit_cause = exception

--- a/tests/fixtures/start_and_end_of_file.py
+++ b/tests/fixtures/start_and_end_of_file.py
@@ -1,0 +1,12 @@
+# flake8: noqa
+try:
+    import sys; raise Exception("start")
+except Exception: start_of_file = sys.exc_info()
+# 4
+# 5
+# 6
+# 7
+# 8
+try:
+    import sys; raise Exception("end")
+except Exception: end_of_file = sys.exc_info()


### PR DESCRIPTION
## Goal

This PR adds some initial tests for caused by exceptions (#299)

This covers implicit (`exception.__context__`) and explicit (`exception.__cause__`) chaining, but does not cover the `raise exception from None` form[^1] — that requires some additional code changes, which will be done in a separate PR

I've added fixtures for these tests as this lets us assert against the stacktrace more easily

[^1]: The [Python `raise` docs](https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement) have a good explanation of each type of caused by exception