### PR TITLE
Honour the `__suppress_context__` property

### DIFF
--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -162,6 +162,9 @@ class Event:
 
         exception = self.exception
 
+        if not isinstance(exception, BaseException):
+            return trace_exceptions
+
         while True:
             if exception.__cause__:
                 exception = exception.__cause__

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -159,20 +159,23 @@ class Event:
                 ),
             }
         ]
+
+        exception = self.exception
+
         while True:
-            _exception = getattr(
-                self.exception, "__cause__", None
-            ) or getattr(self.exception, "__context__", None)
-            if not _exception:
+            if exception.__cause__:
+                exception = exception.__cause__
+            elif exception.__context__ and not exception.__suppress_context__:
+                exception = exception.__context__
+            else:
                 break
 
-            self.exception = _exception
             trace_exceptions.append(
                 {
-                    "errorClass": class_name(self.exception),
-                    "message": self.exception,
+                    "errorClass": class_name(exception),
+                    "message": exception,
                     "stacktrace": self._generate_stacktrace(
-                        getattr(self.exception, "__traceback__", None),
+                        exception.__traceback__
                     ),
                 }
             )

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -8,4 +8,5 @@ from .start_and_end_of_file import (
 from .caused_by import (
     exception_with_explicit_cause,
     exception_with_implicit_cause,
+    exception_with_no_cause,
 )

--- a/tests/fixtures/caused_by.py
+++ b/tests/fixtures/caused_by.py
@@ -44,3 +44,27 @@ try:
     x()
 except Exception as exception:
     exception_with_implicit_cause = exception
+
+
+def one():
+    try:
+        two()
+    except Exception:
+        raise NameError('one') from None
+
+
+def two():
+    try:
+        three()
+    except Exception:
+        raise ArithmeticError('two')
+
+
+def three():
+    raise Exception('three')
+
+
+try:
+    one()
+except Exception as exception:
+    exception_with_no_cause = exception

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1135,6 +1135,29 @@ class ClientTest(IntegrationTest):
         assert exceptions[0]['stacktrace'][0]['method'] == \
             'test_chained_exceptions_with_no_cause'
 
+    def test_notify_with_string(self):
+        """
+        Ensure passing a string to 'notify' doesn't crash
+        This isn't an intended use-case but, as it works, it's important to
+        test so we can preserve BC
+        """
+        self.client.notify('not an exception!')
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 1
+
+        assert exceptions[0]['message'] == 'not an exception!'
+        assert exceptions[0]['errorClass'] == 'str'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == 'test_client.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'test_notify_with_string'
+
 
 @pytest.mark.parametrize("metadata,type", [
     (1234, 'int'),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1113,6 +1113,28 @@ class ClientTest(IntegrationTest):
             }
         ]
 
+    def test_chained_exceptions_with_no_cause(self):
+        self.client.notify(fixtures.exception_with_no_cause)
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 1
+
+        assert exceptions[0]['message'] == 'one'
+        assert exceptions[0]['errorClass'] == 'NameError'
+
+        # TODO: this stacktrace is generated using 'sys.exc_info()', so starts
+        #       where we construct the Event
+        #       switching to 'exception.__traceback__' should improve this as
+        #       it will use the traceback from 'exception_with_no_cause'
+        assert exceptions[0]['stacktrace'][0]['file'] == 'test_client.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'test_chained_exceptions_with_no_cause'
+
 
 @pytest.mark.parametrize("metadata,type", [
     (1234, 'int'),


### PR DESCRIPTION
## Goal

When using `raise x from None`, Python sets `x.__suppress_context__` to `True`. This is intended to tell anyone traversing the exception chain to ignore the `__context__` property, but we were ignoring this

This PR will stop traversing the exception chain when an exception has `__suppress_context__` set

This was added in [PEP 415](https://www.python.org/dev/peps/pep-0415/), with some background in [PEP 409](https://www.python.org/dev/peps/pep-0409/)

In this small refactor, I noticed we'd broken the case where `notify` is passed a string. This isn't really intended to be supported, but I've fixed it and added a test as it could be a BC break and was trivial to solve