### PR TITLE
Refactor caused by exceptions to match other platforms

### DIFF
--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -16,7 +16,7 @@ from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.event import Event
 from bugsnag.handlers import BugsnagHandler
 from bugsnag.sessiontracker import SessionTracker
-from bugsnag.utils import to_rfc3339, fully_qualified_class_name as class_name
+from bugsnag.utils import to_rfc3339
 
 __all__ = ('Client',)
 
@@ -202,7 +202,7 @@ class Client:
             return False
 
         # Return early if we should ignore exceptions of this type
-        if self.configuration.should_ignore(event.exception):
+        if self.configuration.should_ignore(event.original_error):
             return False
 
         return True
@@ -276,13 +276,13 @@ class Client:
             self.leave_breadcrumb(message, metadata, type)
 
     def _leave_breadcrumb_for_event(self, event: Event) -> None:
-        error_class = class_name(event.exception)
+        error_class = event.errors[0].error_class
 
         self._auto_leave_breadcrumb(
             error_class,
             {
                 'errorClass': error_class,
-                'message': str(event.exception),
+                'message': event.errors[0].error_message,
                 'unhandled': event.unhandled,
                 'severity': event.severity,
             },

--- a/bugsnag/error.py
+++ b/bugsnag/error.py
@@ -26,5 +26,6 @@ class Error:
         return {
             'errorClass': self.error_class,
             'message': self.error_message,
-            'stacktrace': self.stacktrace
+            'stacktrace': self.stacktrace,
+            'type': self.type,
         }

--- a/bugsnag/error.py
+++ b/bugsnag/error.py
@@ -1,0 +1,30 @@
+from typing import Any, Dict, List
+
+__all__ = ('Error',)
+
+
+class Error:
+    __slots__ = (
+        'error_class',
+        'error_message',
+        'stacktrace',
+        'type',
+    )
+
+    def __init__(
+        self,
+        error_class: str,
+        error_message: str,
+        stacktrace: List[Dict[str, Any]]
+    ):
+        self.error_class = error_class
+        self.error_message = error_message
+        self.stacktrace = stacktrace
+        self.type = 'python'
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'errorClass': self.error_class,
+            'message': self.error_message,
+            'stacktrace': self.stacktrace
+        }

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -132,19 +132,53 @@ class Event:
 
     @property
     def stacktrace(self) -> List[Dict[str, Any]]:
+        warnings.warn(
+            (
+                'The Event "stacktrace" property has been deprecated in favour'
+                ' of accessing the stacktrace of an error, for example '
+                '"errors[0].stacktrace"'
+            ),
+            DeprecationWarning
+        )
+
         return self._stacktrace
 
     @stacktrace.setter
     def stacktrace(self, value: List[Dict[str, Any]]) -> None:
+        warnings.warn(
+            (
+                'The Event "stacktrace" property has been deprecated in favour'
+                ' of accessing the stacktrace of an error, for example '
+                '"errors[0].stacktrace"'
+            ),
+            DeprecationWarning
+        )
+
         self._stacktrace = value
         self._errors[0].stacktrace = value
 
     @property
     def exception(self) -> BaseException:
+        warnings.warn(
+            (
+                'The Event "exception" property has been replaced with '
+                '"original_error"'
+            ),
+            DeprecationWarning
+        )
+
         return self._exception
 
     @exception.setter
     def exception(self, value: BaseException) -> None:
+        warnings.warn(
+            (
+                'Setting the Event "exception" property has been deprecated, '
+                'update the "errors" list instead'
+            ),
+            DeprecationWarning
+        )
+
         self._exception = value
         self._errors[0] = Error(
             class_name(value),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -950,6 +950,7 @@ class ClientTest(IntegrationTest):
 
         assert exceptions[0]['message'] == 'a'
         assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
 
         # TODO: this stacktrace is generated using 'sys.exc_info()', so starts
         #       where we construct the Event
@@ -962,6 +963,7 @@ class ClientTest(IntegrationTest):
 
         assert exceptions[1]['message'] == 'b'
         assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
         assert exceptions[1]['stacktrace'] == [
             {
                 'file': 'fixtures/caused_by.py',
@@ -997,6 +999,7 @@ class ClientTest(IntegrationTest):
 
         assert exceptions[2]['message'] == 'c'
         assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
         assert exceptions[2]['stacktrace'] == [
             {
                 'file': 'fixtures/caused_by.py',
@@ -1049,11 +1052,13 @@ class ClientTest(IntegrationTest):
         #       it will use the traceback from 'exception_with_explicit_cause'
         assert exceptions[0]['stacktrace'][0]['file'] == 'test_client.py'
         assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['type'] == 'python'
         assert exceptions[0]['stacktrace'][0]['method'] == \
             'test_chained_exceptions_with_implicit_cause'
 
         assert exceptions[1]['message'] == 'y'
         assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
         assert exceptions[1]['stacktrace'] == [
             {
                 'file': 'fixtures/caused_by.py',
@@ -1089,6 +1094,7 @@ class ClientTest(IntegrationTest):
 
         assert exceptions[2]['message'] == 'z'
         assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
         assert exceptions[2]['stacktrace'] == [
             {
                 'file': 'fixtures/caused_by.py',
@@ -1134,6 +1140,7 @@ class ClientTest(IntegrationTest):
 
         assert exceptions[0]['message'] == 'one'
         assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
 
         # TODO: this stacktrace is generated using 'sys.exc_info()', so starts
         #       where we construct the Event

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,7 +84,16 @@ class ClientTest(IntegrationTest):
 
     def test_invalid_delivery(self):
         c = Configuration()
-        c.configure(delivery=44, api_key='abc')
+
+        with pytest.warns(RuntimeWarning) as records:
+            c.configure(delivery=44, api_key='abc')
+
+            assert len(records) == 1
+            assert str(records[0].message) == (
+                'delivery should implement Delivery interface, got int. This '
+                'will be an error in a future release.'
+            )
+
         client = Client(c)
         client.notify(Exception('Oh no'))
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -253,7 +253,15 @@ class TestEvent(unittest.TestCase):
             }
         ]
 
-        event.stacktrace = expected_stacktrace
+        with pytest.warns(DeprecationWarning) as records:
+            event.stacktrace = expected_stacktrace
+
+            assert len(records) == 1
+            assert str(records[0].message) == (
+                'The Event "stacktrace" property has been deprecated in favour'
+                ' of accessing the stacktrace of an error, for example '
+                '"errors[0].stacktrace"'
+            )
 
         payload = json.loads(event._payload())
         actual_stacktrace = payload['events'][0]['exceptions'][0]['stacktrace']
@@ -264,7 +272,15 @@ class TestEvent(unittest.TestCase):
         config = Configuration()
         event = self.event_class(Exception('oops'), config, {})
 
-        event.stacktrace[0]['file'] = '/abc/xyz.py'
+        with pytest.warns(DeprecationWarning) as records:
+            event.stacktrace[0]['file'] = '/abc/xyz.py'
+
+            assert len(records) == 1
+            assert str(records[0].message) == (
+                'The Event "stacktrace" property has been deprecated in favour'
+                ' of accessing the stacktrace of an error, for example '
+                '"errors[0].stacktrace"'
+            )
 
         payload = json.loads(event._payload())
         stacktrace = payload['events'][0]['exceptions'][0]['stacktrace']
@@ -275,7 +291,14 @@ class TestEvent(unittest.TestCase):
         config = Configuration()
         event = self.event_class(Exception('oops'), config, {})
 
-        event.exception = KeyError('ahhh')
+        with pytest.warns(DeprecationWarning) as records:
+            event.exception = KeyError('ahhh')
+
+            assert len(records) == 1
+            assert str(records[0].message) == (
+                'Setting the Event "exception" property has been deprecated, '
+                'update the "errors" list instead'
+            )
 
         payload = json.loads(event._payload())
         exception = payload['events'][0]['exceptions'][0]

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -519,7 +519,7 @@ class HandlersTest(IntegrationTest):
         assert self.sent_report_count == 0
         assert len(handler.client.configuration.breadcrumbs) == 0
 
-        logger.warn('Everything might be fine')
+        logger.warning('Everything might be fine')
 
         assert self.sent_report_count == 0
         assert len(handler.client.configuration.breadcrumbs) == 1


### PR DESCRIPTION
## Goal

This PR refactors our implementation of caused by exceptions to match other platforms — the list of exceptions now lives on `Event.errors` and the original exception instance is now `Event.original_error`. For example, this matches [JavaScript](https://docs.bugsnag.com/platforms/javascript/customizing-error-reports/#errors) & [Ruby](https://docs.bugsnag.com/platforms/ruby/other/customizing-error-reports/#errors)

`Event.exception` and `Event.stacktrace` have been deprecated as they are somewhat ambiguous given there can be multiple exceptions with their own stacktraces

I've also fixed up our code to avoid triggering these deprecations internally and tidied up some tests that were leaking warnings