### PR TITLE
Add tests for caused by exceptions using the capture decorator/context manager

### DIFF
--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -7,6 +7,9 @@ from .start_and_end_of_file import (
 
 from .caused_by import (
     exception_with_explicit_cause,
+    raise_exception_with_explicit_cause,
     exception_with_implicit_cause,
+    raise_exception_with_implicit_cause,
     exception_with_no_cause,
+    raise_exception_with_no_cause,
 )

--- a/tests/fixtures/caused_by.py
+++ b/tests/fixtures/caused_by.py
@@ -1,4 +1,4 @@
-def a():
+def raise_exception_with_explicit_cause():
     try:
         b()
     except Exception as cause:
@@ -17,12 +17,12 @@ def c():
 
 
 try:
-    a()
+    raise_exception_with_explicit_cause()
 except Exception as exception:
     exception_with_explicit_cause = exception
 
 
-def x():
+def raise_exception_with_implicit_cause():
     try:
         y()
     except Exception:
@@ -41,12 +41,12 @@ def z():
 
 
 try:
-    x()
+    raise_exception_with_implicit_cause()
 except Exception as exception:
     exception_with_implicit_cause = exception
 
 
-def one():
+def raise_exception_with_no_cause():
     try:
         two()
     except Exception:
@@ -65,6 +65,6 @@ def three():
 
 
 try:
-    one()
+    raise_exception_with_no_cause()
 except Exception as exception:
     exception_with_no_cause = exception

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1033,6 +1033,73 @@ class ClientTest(IntegrationTest):
             }
         ]
 
+    def test_chained_exceptions_with_explicit_cause_using_capture_cm(self):
+        try:
+            with self.client.capture():
+                fixtures.raise_exception_with_explicit_cause()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 3
+
+        assert exceptions[0]['message'] == 'a'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_explicit_cause'
+
+        assert exceptions[1]['message'] == 'b'
+        assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
+
+        assert exceptions[2]['message'] == 'c'
+        assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
+
+    def test_chained_exceptions_explicit_cause_and_capture_decorator(self):
+        @self.client.capture
+        def foo():
+            fixtures.raise_exception_with_explicit_cause()
+
+        try:
+            foo()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 3
+
+        assert exceptions[0]['message'] == 'a'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_explicit_cause'
+
+        assert exceptions[1]['message'] == 'b'
+        assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
+
+        assert exceptions[2]['message'] == 'c'
+        assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
+
     def test_chained_exceptions_with_implicit_cause(self):
         self.client.notify(fixtures.exception_with_implicit_cause)
 
@@ -1128,6 +1195,73 @@ class ClientTest(IntegrationTest):
             }
         ]
 
+    def test_chained_exceptions_with_implicit_cause_using_capture_cm(self):
+        try:
+            with self.client.capture():
+                fixtures.raise_exception_with_implicit_cause()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 3
+
+        assert exceptions[0]['message'] == 'x'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_implicit_cause'
+
+        assert exceptions[1]['message'] == 'y'
+        assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
+
+        assert exceptions[2]['message'] == 'z'
+        assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
+
+    def test_chained_exceptions_implicit_cause_and_capture_decorator(self):
+        @self.client.capture
+        def foo():
+            fixtures.raise_exception_with_implicit_cause()
+
+        try:
+            foo()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 3
+
+        assert exceptions[0]['message'] == 'x'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_implicit_cause'
+
+        assert exceptions[1]['message'] == 'y'
+        assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
+
+        assert exceptions[2]['message'] == 'z'
+        assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
+
     def test_chained_exceptions_with_no_cause(self):
         self.client.notify(fixtures.exception_with_no_cause)
 
@@ -1150,6 +1284,57 @@ class ClientTest(IntegrationTest):
         assert exceptions[0]['stacktrace'][0]['inProject']
         assert exceptions[0]['stacktrace'][0]['method'] == \
             'test_chained_exceptions_with_no_cause'
+
+    def test_chained_exceptions_with_no_cause_using_capture_decorator(self):
+        @self.client.capture
+        def foo():
+            fixtures.raise_exception_with_no_cause()
+
+        try:
+            foo()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 1
+
+        assert exceptions[0]['message'] == 'one'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_no_cause'
+
+    def test_chained_exceptions_with_no_cause_using_capture_cm(self):
+        try:
+            with self.client.capture():
+                fixtures.raise_exception_with_no_cause()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 1
+
+        assert exceptions[0]['message'] == 'one'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_no_cause'
 
     def test_notify_with_string(self):
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -983,10 +983,10 @@ class ClientTest(IntegrationTest):
             {
                 'file': 'fixtures/caused_by.py',
                 'lineNumber': 3,
-                'method': 'a',
+                'method': 'raise_exception_with_explicit_cause',
                 'inProject': True,
                 'code': {
-                    '1': 'def a():',
+                    '1': 'def raise_exception_with_explicit_cause():',
                     '2': '    try:',
                     '3': '        b()',
                     '4': '    except Exception as cause:',
@@ -1078,11 +1078,11 @@ class ClientTest(IntegrationTest):
             {
                 'file': 'fixtures/caused_by.py',
                 'lineNumber': 27,
-                'method': 'x',
+                'method': 'raise_exception_with_implicit_cause',
                 'inProject': True,
                 'code': {
                     '24': '',
-                    '25': 'def x():',
+                    '25': 'def raise_exception_with_implicit_cause():',
                     '26': '    try:',
                     '27': '        y()',
                     '28': '    except Exception:',


### PR DESCRIPTION
## Goal

Adds coverage of the capture decorator/context manager with caused by exceptions. These tests are essentially the same as those that manually call `notify`, except the first exception's stacktrace is improved due to the `traceback` & `source_func` parameters that `capture` passes to the Event