### PR TITLE
Check the chain of exceptions for ignored classes

### DIFF
--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -201,8 +201,8 @@ class Client:
         if not self.configuration.should_notify():
             return False
 
-        # Return early if we should ignore exceptions of this type
-        if self.configuration.should_ignore(event.original_error):
+        # Return early if we should ignore these errors
+        if self.configuration.should_ignore(event.errors):
             return False
 
         return True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1174,6 +1174,34 @@ class ClientTest(IntegrationTest):
         assert exceptions[0]['stacktrace'][0]['method'] == \
             'test_notify_with_string'
 
+    def test_ignore_classes_checks_exception_chain_with_explicit_cause(self):
+        self.client.configuration.ignore_classes = ['ArithmeticError']
+        self.client.notify(fixtures.exception_with_explicit_cause)
+
+        assert self.sent_report_count == 0
+
+        self.client.configuration.ignore_classes = []
+        self.client.notify(fixtures.exception_with_explicit_cause)
+
+        assert self.sent_report_count == 1
+
+    def test_ignore_classes_checks_exception_chain_with_implicit_cause(self):
+        self.client.configuration.ignore_classes = ['ArithmeticError']
+        self.client.notify(fixtures.exception_with_implicit_cause)
+
+        assert self.sent_report_count == 0
+
+        self.client.configuration.ignore_classes = []
+        self.client.notify(fixtures.exception_with_implicit_cause)
+
+        assert self.sent_report_count == 1
+
+    def test_ignore_classes_has_no_exception_chain_with_no_cause(self):
+        self.client.configuration.ignore_classes = ['ArithmeticError']
+        self.client.notify(fixtures.exception_with_no_cause)
+
+        assert self.sent_report_count == 1
+
 
 @pytest.mark.parametrize("metadata,type", [
     (1234, 'int'),


### PR DESCRIPTION
## Goal

Currently the `ignore_classes` option only takes the first exception into account, but should be traversing the exception chain — if an exception is caused by an ignored exception then it should be ignored