### PR TITLE
Add tests for chained exceptions in integrations

### DIFF
--- a/tests/fixtures/django1/notes/urls.py
+++ b/tests/fixtures/django1/notes/urls.py
@@ -4,6 +4,7 @@ from . import views
 urlpatterns = [
     url(r'^$', views.index),
     url(r'unhandled-crash/', views.unhandled_crash, name='crash'),
+    url(r'unhandled-crash-chain/', views.unhandled_crash_chain),
     url(r'unhandled-template-crash/',
         views.unhandled_crash_in_template),
     url(r'handled-exception/', views.handle_notify),

--- a/tests/fixtures/django1/notes/views.py
+++ b/tests/fixtures/django1/notes/views.py
@@ -63,3 +63,10 @@ def handle_crash_callback(request):
 
 def terrible_event():
     raise RuntimeError('I did something wrong')
+
+
+def unhandled_crash_chain(request):
+    try:
+        unhandled_crash(request)
+    except RuntimeError as e:
+        raise Exception('corrupt timeline detected') from e

--- a/tests/fixtures/django30/notes/urls.py
+++ b/tests/fixtures/django30/notes/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('<int:pk>/', views.DetailView.as_view(), name='detail'),
     path('add/', views.add_note, name='add'),
     path('unhandled-crash/', views.unhandled_crash, name='crash'),
+    path('unhandled-crash-chain/', views.unhandled_crash_chain),
     path('unhandled-template-crash/', views.unhandled_crash_in_template),
     path('handled-exception/', views.handle_notify),
     path('crash-with-callback/', views.handle_crash_callback),

--- a/tests/fixtures/django30/notes/views.py
+++ b/tests/fixtures/django30/notes/views.py
@@ -63,3 +63,10 @@ def handle_crash_callback(request):
 
 def terrible_event():
     raise RuntimeError('I did something wrong')
+
+
+def unhandled_crash_chain(request):
+    try:
+        unhandled_crash(request)
+    except RuntimeError as e:
+        raise Exception('corrupt timeline detected') from e

--- a/tests/fixtures/django4/notes/urls.py
+++ b/tests/fixtures/django4/notes/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('<int:pk>/', views.DetailView.as_view(), name='detail'),
     path('add/', views.add_note, name='add'),
     path('unhandled-crash/', views.unhandled_crash, name='crash'),
+    path('unhandled-crash-chain/', views.unhandled_crash_chain),
     path('unhandled-template-crash/', views.unhandled_crash_in_template),
     path('handled-exception/', views.handle_notify),
     path('crash-with-callback/', views.handle_crash_callback),

--- a/tests/fixtures/django4/notes/views.py
+++ b/tests/fixtures/django4/notes/views.py
@@ -63,3 +63,10 @@ def handle_crash_callback(request):
 
 def terrible_event():
     raise RuntimeError('I did something wrong')
+
+
+def unhandled_crash_chain(request):
+    try:
+        unhandled_crash(request)
+    except RuntimeError as e:
+        raise Exception('corrupt timeline detected') from e

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps=
     pytest-cov
     requests: requests
     wsgi: webtest==2.0.35
-    asgi: starlette==0.13.6
+    asgi: starlette==0.18.0
     asgi: requests
     bottle: webtest==2.0.35
     bottle: bottle==0.12.18


### PR DESCRIPTION
## Goal

This PR adds tests for chained exceptions in Starlette, Flask, Django and Celery for some extra coverage in "real world" scenarios

Starlette was using `from None` when re-raising exceptions, which suppresses the cause. This was fixed in [v0.15.0](https://github.com/encode/starlette/releases/tag/0.15.0), but our tests pass on the latest version (v0.18.0) so I bumped to that