### PR TITLE
Release v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## v4.2.0 (2022-02-18)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Report the entire exception chain by traversing the `__cause__` and `__context__` of exceptions to provides greater context into the cause of exceptions
+  [#299](https://github.com/bugsnag/bugsnag-python/pull/299)
+  [Diego Restrepo Mesa](https://github.com/drestrepom)
+  [#314](https://github.com/bugsnag/bugsnag-python/pull/314)
+* Use the `__traceback__` attribute in Python 3 exception objects to improve stacktraces for handled errors
+  [#313](https://github.com/bugsnag/bugsnag-python/pull/313)
+
+**Note:** The use of `__traceback__` for the  stacktraces of handled events means that the grouping of these errors on your Bugsnag dashboard will be affected when this attribute is available: it will now show the location of the exception and not the call to `notify`.
+
+
 ## 4.1.1 (2021-10-04)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changelog
 
 **Note:** The use of `__traceback__` for the  stacktraces of handled events means that the grouping of these errors on your Bugsnag dashboard will be affected when this attribute is available: it will now show the location of the exception and not the call to `notify`.
 
+### Bug fixes
+
+* Prevent async delivery errors from escaping their thread
+  [#303](https://github.com/bugsnag/bugsnag-python/pull/303)
 
 ## 4.1.1 (2021-10-04)
 

--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -16,7 +16,7 @@ from bugsnag.configuration import Configuration, RequestConfiguration
 from bugsnag.event import Event
 from bugsnag.handlers import BugsnagHandler
 from bugsnag.sessiontracker import SessionTracker
-from bugsnag.utils import to_rfc3339, fully_qualified_class_name as class_name
+from bugsnag.utils import to_rfc3339
 
 __all__ = ('Client',)
 
@@ -201,8 +201,8 @@ class Client:
         if not self.configuration.should_notify():
             return False
 
-        # Return early if we should ignore exceptions of this type
-        if self.configuration.should_ignore(event.exception):
+        # Return early if we should ignore these errors
+        if self.configuration.should_ignore(event.errors):
             return False
 
         return True
@@ -276,13 +276,13 @@ class Client:
             self.leave_breadcrumb(message, metadata, type)
 
     def _leave_breadcrumb_for_event(self, event: Event) -> None:
-        error_class = class_name(event.exception)
+        error_class = event.errors[0].error_class
 
         self._auto_leave_breadcrumb(
             error_class,
             {
                 'errorClass': error_class,
-                'message': str(event.exception),
+                'message': event.errors[0].error_message,
                 'unhandled': event.unhandled,
                 'severity': event.severity,
             },

--- a/bugsnag/error.py
+++ b/bugsnag/error.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict, List
+
+__all__ = ('Error',)
+
+
+class Error:
+    __slots__ = (
+        'error_class',
+        'error_message',
+        'stacktrace',
+        'type',
+    )
+
+    def __init__(
+        self,
+        error_class: str,
+        error_message: str,
+        stacktrace: List[Dict[str, Any]]
+    ):
+        self.error_class = error_class
+        self.error_message = error_message
+        self.stacktrace = stacktrace
+        self.type = 'python'
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'errorClass': self.error_class,
+            'message': self.error_message,
+            'stacktrace': self.stacktrace,
+            'type': self.type,
+        }

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='bugsnag',
-    version='4.1.1',
+    version='4.2.0',
     description='Automatic error monitoring for django, flask, etc.',
     long_description=__doc__,
     author='Simon Maynard',

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,12 +1,15 @@
 # flake8: noqa
-try:
-    import sys; raise Exception("start")
-except Exception: start_of_file = sys.exc_info()
-# 4
-# 5
-# 6
-# 7
-# 8
-try:
-    import sys; raise Exception("end")
-except Exception: end_of_file = sys.exc_info()
+
+from .start_and_end_of_file import (
+    start_of_file,
+    end_of_file,
+)
+
+from .caused_by import (
+    exception_with_explicit_cause,
+    raise_exception_with_explicit_cause,
+    exception_with_implicit_cause,
+    raise_exception_with_implicit_cause,
+    exception_with_no_cause,
+    raise_exception_with_no_cause,
+)

--- a/tests/fixtures/caused_by.py
+++ b/tests/fixtures/caused_by.py
@@ -1,0 +1,70 @@
+def raise_exception_with_explicit_cause():
+    try:
+        b()
+    except Exception as cause:
+        raise NameError('a') from cause
+
+
+def b():
+    try:
+        c()
+    except Exception as cause:
+        raise ArithmeticError('b') from cause
+
+
+def c():
+    raise Exception('c')
+
+
+try:
+    raise_exception_with_explicit_cause()
+except Exception as exception:
+    exception_with_explicit_cause = exception
+
+
+def raise_exception_with_implicit_cause():
+    try:
+        y()
+    except Exception:
+        raise NameError('x')
+
+
+def y():
+    try:
+        z()
+    except Exception:
+        raise ArithmeticError('y')
+
+
+def z():
+    raise Exception('z')
+
+
+try:
+    raise_exception_with_implicit_cause()
+except Exception as exception:
+    exception_with_implicit_cause = exception
+
+
+def raise_exception_with_no_cause():
+    try:
+        two()
+    except Exception:
+        raise NameError('one') from None
+
+
+def two():
+    try:
+        three()
+    except Exception:
+        raise ArithmeticError('two')
+
+
+def three():
+    raise Exception('three')
+
+
+try:
+    raise_exception_with_no_cause()
+except Exception as exception:
+    exception_with_no_cause = exception

--- a/tests/fixtures/django1/notes/urls.py
+++ b/tests/fixtures/django1/notes/urls.py
@@ -4,6 +4,7 @@ from . import views
 urlpatterns = [
     url(r'^$', views.index),
     url(r'unhandled-crash/', views.unhandled_crash, name='crash'),
+    url(r'unhandled-crash-chain/', views.unhandled_crash_chain),
     url(r'unhandled-template-crash/',
         views.unhandled_crash_in_template),
     url(r'handled-exception/', views.handle_notify),

--- a/tests/fixtures/django1/notes/views.py
+++ b/tests/fixtures/django1/notes/views.py
@@ -63,3 +63,10 @@ def handle_crash_callback(request):
 
 def terrible_event():
     raise RuntimeError('I did something wrong')
+
+
+def unhandled_crash_chain(request):
+    try:
+        unhandled_crash(request)
+    except RuntimeError as e:
+        raise Exception('corrupt timeline detected') from e

--- a/tests/fixtures/django30/notes/urls.py
+++ b/tests/fixtures/django30/notes/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('<int:pk>/', views.DetailView.as_view(), name='detail'),
     path('add/', views.add_note, name='add'),
     path('unhandled-crash/', views.unhandled_crash, name='crash'),
+    path('unhandled-crash-chain/', views.unhandled_crash_chain),
     path('unhandled-template-crash/', views.unhandled_crash_in_template),
     path('handled-exception/', views.handle_notify),
     path('crash-with-callback/', views.handle_crash_callback),

--- a/tests/fixtures/django30/notes/views.py
+++ b/tests/fixtures/django30/notes/views.py
@@ -63,3 +63,10 @@ def handle_crash_callback(request):
 
 def terrible_event():
     raise RuntimeError('I did something wrong')
+
+
+def unhandled_crash_chain(request):
+    try:
+        unhandled_crash(request)
+    except RuntimeError as e:
+        raise Exception('corrupt timeline detected') from e

--- a/tests/fixtures/django4/notes/urls.py
+++ b/tests/fixtures/django4/notes/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('<int:pk>/', views.DetailView.as_view(), name='detail'),
     path('add/', views.add_note, name='add'),
     path('unhandled-crash/', views.unhandled_crash, name='crash'),
+    path('unhandled-crash-chain/', views.unhandled_crash_chain),
     path('unhandled-template-crash/', views.unhandled_crash_in_template),
     path('handled-exception/', views.handle_notify),
     path('crash-with-callback/', views.handle_crash_callback),

--- a/tests/fixtures/django4/notes/views.py
+++ b/tests/fixtures/django4/notes/views.py
@@ -63,3 +63,10 @@ def handle_crash_callback(request):
 
 def terrible_event():
     raise RuntimeError('I did something wrong')
+
+
+def unhandled_crash_chain(request):
+    try:
+        unhandled_crash(request)
+    except RuntimeError as e:
+        raise Exception('corrupt timeline detected') from e

--- a/tests/fixtures/start_and_end_of_file.py
+++ b/tests/fixtures/start_and_end_of_file.py
@@ -1,0 +1,12 @@
+# flake8: noqa
+try:
+    import sys; raise Exception("start")
+except Exception: start_of_file = sys.exc_info()
+# 4
+# 5
+# 6
+# 7
+# 8
+try:
+    import sys; raise Exception("end")
+except Exception: end_of_file = sys.exc_info()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, ANY
+from tests import fixtures
 
 from bugsnag import (
     Client,
@@ -83,7 +84,16 @@ class ClientTest(IntegrationTest):
 
     def test_invalid_delivery(self):
         c = Configuration()
-        c.configure(delivery=44, api_key='abc')
+
+        with pytest.warns(RuntimeWarning) as records:
+            c.configure(delivery=44, api_key='abc')
+
+            assert len(records) == 1
+            assert str(records[0].message) == (
+                'delivery should implement Delivery interface, got int. This '
+                'will be an error in a future release.'
+            )
+
         client = Client(c)
         client.notify(Exception('Oh no'))
 
@@ -927,6 +937,524 @@ class ClientTest(IntegrationTest):
             'Notifying Bugsnag failed %s',
             ANY
         )
+
+    def test_chained_exceptions_with_explicit_cause(self):
+        self.client.notify(fixtures.exception_with_explicit_cause)
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 3
+
+        assert exceptions[0]['message'] == 'a'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+        assert exceptions[0]['stacktrace'] == [
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 5,
+                'method': 'raise_exception_with_explicit_cause',
+                'inProject': True,
+                'code': {
+                    '2': '    try:',
+                    '3': '        b()',
+                    '4': '    except Exception as cause:',
+                    '5': "        raise NameError('a') from cause",
+                    '6': '',
+                    '7': '',
+                    '8': 'def b():'
+                }
+            },
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 20,
+                'method': '<module>',
+                'inProject': True,
+                'code': {
+                    '17': '',
+                    '18': '',
+                    '19': 'try:',
+                    '20': '    raise_exception_with_explicit_cause()',
+                    '21': 'except Exception as exception:',
+                    '22': '    exception_with_explicit_cause = exception',
+                    '23': ''
+                }
+            }
+        ]
+
+        assert exceptions[1]['message'] == 'b'
+        assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
+        assert exceptions[1]['stacktrace'] == [
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 12,
+                'method': 'b',
+                'inProject': True,
+                'code': {
+                    '9': '    try:',
+                    '10': '        c()',
+                    '11': '    except Exception as cause:',
+                    '12': '        raise ArithmeticError(\'b\') from cause',
+                    '13': '',
+                    '14': '',
+                    '15': 'def c():'
+                }
+            },
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 3,
+                'method': 'raise_exception_with_explicit_cause',
+                'inProject': True,
+                'code': {
+                    '1': 'def raise_exception_with_explicit_cause():',
+                    '2': '    try:',
+                    '3': '        b()',
+                    '4': '    except Exception as cause:',
+                    '5': '        raise NameError(\'a\') from cause',
+                    '6': '',
+                    '7': ''
+                }
+            }
+        ]
+
+        assert exceptions[2]['message'] == 'c'
+        assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
+        assert exceptions[2]['stacktrace'] == [
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 16,
+                'method': 'c',
+                'inProject': True,
+                'code': {
+                    '13': '',
+                    '14': '',
+                    '15': 'def c():',
+                    '16': '    raise Exception(\'c\')',
+                    '17': '',
+                    '18': '',
+                    '19': 'try:'
+                }
+            },
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 10,
+                'method': 'b',
+                'inProject': True,
+                'code': {
+                    '7': '',
+                    '8': 'def b():',
+                    '9': '    try:',
+                    '10': '        c()',
+                    '11': '    except Exception as cause:',
+                    '12': '        raise ArithmeticError(\'b\') from cause',
+                    '13': ''
+                }
+            }
+        ]
+
+    def test_chained_exceptions_with_explicit_cause_using_capture_cm(self):
+        try:
+            with self.client.capture():
+                fixtures.raise_exception_with_explicit_cause()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 3
+
+        assert exceptions[0]['message'] == 'a'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_explicit_cause'
+
+        assert exceptions[1]['message'] == 'b'
+        assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
+
+        assert exceptions[2]['message'] == 'c'
+        assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
+
+    def test_chained_exceptions_explicit_cause_and_capture_decorator(self):
+        @self.client.capture
+        def foo():
+            fixtures.raise_exception_with_explicit_cause()
+
+        try:
+            foo()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 3
+
+        assert exceptions[0]['message'] == 'a'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_explicit_cause'
+
+        assert exceptions[1]['message'] == 'b'
+        assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
+
+        assert exceptions[2]['message'] == 'c'
+        assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
+
+    def test_chained_exceptions_with_implicit_cause(self):
+        self.client.notify(fixtures.exception_with_implicit_cause)
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 3
+
+        assert exceptions[0]['message'] == 'x'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+        assert exceptions[0]['stacktrace'] == [
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 29,
+                'method': 'raise_exception_with_implicit_cause',
+                'inProject': True,
+                'code': {
+                    '26': '    try:',
+                    '27': '        y()',
+                    '28': '    except Exception:',
+                    '29': "        raise NameError('x')",
+                    '30': '',
+                    '31': '',
+                    '32': 'def y():'
+                }
+            },
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 44,
+                'method': '<module>',
+                'inProject': True,
+                'code': {
+                    '41': '',
+                    '42': '',
+                    '43': 'try:',
+                    '44': '    raise_exception_with_implicit_cause()',
+                    '45': 'except Exception as exception:',
+                    '46': '    exception_with_implicit_cause = exception',
+                    '47': ''
+                }
+            }
+        ]
+
+        assert exceptions[1]['message'] == 'y'
+        assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
+        assert exceptions[1]['stacktrace'] == [
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 36,
+                'method': 'y',
+                'inProject': True,
+                'code': {
+                    '33': '    try:',
+                    '34': '        z()',
+                    '35': '    except Exception:',
+                    '36': '        raise ArithmeticError(\'y\')',
+                    '37': '',
+                    '38': '',
+                    '39': 'def z():'
+                }
+            },
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 27,
+                'method': 'raise_exception_with_implicit_cause',
+                'inProject': True,
+                'code': {
+                    '24': '',
+                    '25': 'def raise_exception_with_implicit_cause():',
+                    '26': '    try:',
+                    '27': '        y()',
+                    '28': '    except Exception:',
+                    '29': '        raise NameError(\'x\')',
+                    '30': ''
+                }
+            }
+        ]
+
+        assert exceptions[2]['message'] == 'z'
+        assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
+        assert exceptions[2]['stacktrace'] == [
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 40,
+                'method': 'z',
+                'inProject': True,
+                'code': {
+                    '37': '',
+                    '38': '',
+                    '39': 'def z():',
+                    '40': '    raise Exception(\'z\')',
+                    '41': '',
+                    '42': '',
+                    '43': 'try:'
+                }
+            },
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 34,
+                'method': 'y',
+                'inProject': True,
+                'code': {
+                    '31': '',
+                    '32': 'def y():',
+                    '33': '    try:',
+                    '34': '        z()',
+                    '35': '    except Exception:',
+                    '36': '        raise ArithmeticError(\'y\')',
+                    '37': ''
+                }
+            }
+        ]
+
+    def test_chained_exceptions_with_implicit_cause_using_capture_cm(self):
+        try:
+            with self.client.capture():
+                fixtures.raise_exception_with_implicit_cause()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 3
+
+        assert exceptions[0]['message'] == 'x'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_implicit_cause'
+
+        assert exceptions[1]['message'] == 'y'
+        assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
+
+        assert exceptions[2]['message'] == 'z'
+        assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
+
+    def test_chained_exceptions_implicit_cause_and_capture_decorator(self):
+        @self.client.capture
+        def foo():
+            fixtures.raise_exception_with_implicit_cause()
+
+        try:
+            foo()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 3
+
+        assert exceptions[0]['message'] == 'x'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_implicit_cause'
+
+        assert exceptions[1]['message'] == 'y'
+        assert exceptions[1]['errorClass'] == 'ArithmeticError'
+        assert exceptions[1]['type'] == 'python'
+
+        assert exceptions[2]['message'] == 'z'
+        assert exceptions[2]['errorClass'] == 'Exception'
+        assert exceptions[2]['type'] == 'python'
+
+    def test_chained_exceptions_with_no_cause(self):
+        self.client.notify(fixtures.exception_with_no_cause)
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 1
+
+        assert exceptions[0]['message'] == 'one'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+        assert exceptions[0]['stacktrace'] == [
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 53,
+                'method': 'raise_exception_with_no_cause',
+                'inProject': True,
+                'code': {
+                    '50': '    try:',
+                    '51': '        two()',
+                    '52': '    except Exception:',
+                    '53': "        raise NameError('one') from None",
+                    '54': '',
+                    '55': '',
+                    '56': 'def two():'
+                }
+            },
+            {
+                'file': 'fixtures/caused_by.py',
+                'lineNumber': 68,
+                'method': '<module>',
+                'inProject': True,
+                'code': {
+                    '64': "    raise Exception('three')",
+                    '65': '',
+                    '66': '',
+                    '67': 'try:',
+                    '68': '    raise_exception_with_no_cause()',
+                    '69': 'except Exception as exception:',
+                    '70': '    exception_with_no_cause = exception'
+                }
+            }
+        ]
+
+    def test_chained_exceptions_with_no_cause_using_capture_decorator(self):
+        @self.client.capture
+        def foo():
+            fixtures.raise_exception_with_no_cause()
+
+        try:
+            foo()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 1
+
+        assert exceptions[0]['message'] == 'one'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_no_cause'
+
+    def test_chained_exceptions_with_no_cause_using_capture_cm(self):
+        try:
+            with self.client.capture():
+                fixtures.raise_exception_with_no_cause()
+        except Exception:
+            pass
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 1
+
+        assert exceptions[0]['message'] == 'one'
+        assert exceptions[0]['errorClass'] == 'NameError'
+        assert exceptions[0]['type'] == 'python'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == \
+            'fixtures/caused_by.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'raise_exception_with_no_cause'
+
+    def test_notify_with_string(self):
+        """
+        Ensure passing a string to 'notify' doesn't crash
+        This isn't an intended use-case but, as it works, it's important to
+        test so we can preserve BC
+        """
+        self.client.notify('not an exception!')
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        assert len(exceptions) == 1
+
+        assert exceptions[0]['message'] == 'not an exception!'
+        assert exceptions[0]['errorClass'] == 'str'
+
+        assert exceptions[0]['stacktrace'][0]['file'] == 'test_client.py'
+        assert exceptions[0]['stacktrace'][0]['inProject']
+        assert exceptions[0]['stacktrace'][0]['method'] == \
+            'test_notify_with_string'
+
+    def test_ignore_classes_checks_exception_chain_with_explicit_cause(self):
+        self.client.configuration.ignore_classes = ['ArithmeticError']
+        self.client.notify(fixtures.exception_with_explicit_cause)
+
+        assert self.sent_report_count == 0
+
+        self.client.configuration.ignore_classes = []
+        self.client.notify(fixtures.exception_with_explicit_cause)
+
+        assert self.sent_report_count == 1
+
+    def test_ignore_classes_checks_exception_chain_with_implicit_cause(self):
+        self.client.configuration.ignore_classes = ['ArithmeticError']
+        self.client.notify(fixtures.exception_with_implicit_cause)
+
+        assert self.sent_report_count == 0
+
+        self.client.configuration.ignore_classes = []
+        self.client.notify(fixtures.exception_with_implicit_cause)
+
+        assert self.sent_report_count == 1
+
+    def test_ignore_classes_has_no_exception_chain_with_no_cause(self):
+        self.client.configuration.ignore_classes = ['ArithmeticError']
+        self.client.notify(fixtures.exception_with_no_cause)
+
+        assert self.sent_report_count == 1
 
 
 @pytest.mark.parametrize("metadata,type", [

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -232,6 +232,80 @@ class TestEvent(unittest.TestCase):
         first_traceback = exception['stacktrace'][0]
         self.assertEqual(first_traceback['file'], 'test_event.py')
 
+    def test_stacktrace_can_be_reassigned(self):
+        config = Configuration()
+        event = self.event_class(Exception("oops"), config, {})
+
+        expected_stacktrace = [
+            {
+                'file': '/a/b/c/one.py',
+                'lineNumber': 1234,
+                'method': 'do_stuff',
+                'inProject': True,
+                'code': {'1234': 'def do_stuff():'},
+            },
+            {
+                'file': '/a/b/c/two.py',
+                'lineNumber': 9876,
+                'method': 'do_other_stuff',
+                'inProject': False,
+                'code': {'9876': 'def do_other_stuff():'},
+            }
+        ]
+
+        with pytest.warns(DeprecationWarning) as records:
+            event.stacktrace = expected_stacktrace
+
+            assert len(records) == 1
+            assert str(records[0].message) == (
+                'The Event "stacktrace" property has been deprecated in favour'
+                ' of accessing the stacktrace of an error, for example '
+                '"errors[0].stacktrace"'
+            )
+
+        payload = json.loads(event._payload())
+        actual_stacktrace = payload['events'][0]['exceptions'][0]['stacktrace']
+
+        assert actual_stacktrace == expected_stacktrace
+
+    def test_stacktrace_can_be_mutated(self):
+        config = Configuration()
+        event = self.event_class(Exception('oops'), config, {})
+
+        with pytest.warns(DeprecationWarning) as records:
+            event.stacktrace[0]['file'] = '/abc/xyz.py'
+
+            assert len(records) == 1
+            assert str(records[0].message) == (
+                'The Event "stacktrace" property has been deprecated in favour'
+                ' of accessing the stacktrace of an error, for example '
+                '"errors[0].stacktrace"'
+            )
+
+        payload = json.loads(event._payload())
+        stacktrace = payload['events'][0]['exceptions'][0]['stacktrace']
+
+        assert stacktrace[0]['file'] == '/abc/xyz.py'
+
+    def test_original_exception_can_be_reassigned(self):
+        config = Configuration()
+        event = self.event_class(Exception('oops'), config, {})
+
+        with pytest.warns(DeprecationWarning) as records:
+            event.exception = KeyError('ahhh')
+
+            assert len(records) == 1
+            assert str(records[0].message) == (
+                'Setting the Event "exception" property has been deprecated, '
+                'update the "errors" list instead'
+            )
+
+        payload = json.loads(event._payload())
+        exception = payload['events'][0]['exceptions'][0]
+
+        assert exception['message'] == "'ahhh'"
+        assert exception['errorClass'] == 'KeyError'
+
     def test_device_data(self):
         """
             It should include device data

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -519,7 +519,7 @@ class HandlersTest(IntegrationTest):
         assert self.sent_report_count == 0
         assert len(handler.client.configuration.breadcrumbs) == 0
 
-        logger.warn('Everything might be fine')
+        logger.warning('Everything might be fine')
 
         assert self.sent_report_count == 0
         assert len(handler.client.configuration.breadcrumbs) == 1

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps=
     pytest-cov
     requests: requests
     wsgi: webtest==2.0.35
-    asgi: starlette==0.13.6
+    asgi: starlette==0.18.0
     asgi: requests
     bottle: webtest==2.0.35
     bottle: bottle==0.12.18


### PR DESCRIPTION
## v4.2.0 (2022-02-18)

* Report the entire exception chain by traversing the `__cause__` and `__context__` of exceptions to provides greater context into the cause of exceptions
  [#299](https://github.com/bugsnag/bugsnag-python/pull/299)
  [Diego Restrepo Mesa](https://github.com/drestrepom)
  [#314](https://github.com/bugsnag/bugsnag-python/pull/314)
* Use the `__traceback__` attribute in Python 3 exception objects to improve stacktraces for handled errors
  [#313](https://github.com/bugsnag/bugsnag-python/pull/313)

**Note:** The use of `__traceback__` for the  stacktraces of handled events means that the grouping of these errors on your Bugsnag dashboard will be affected when this attribute is available: it will now show the location of the exception and not the call to `notify`.
