### PR TITLE
Apply `params_filters` to URLs in request metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Apply `params_filters` to URLs in request metadata
+  [#318](https://github.com/bugsnag/bugsnag-python/pull/318)
+
 ## v4.2.0 (2022-02-18)
 
 ### Enhancements

--- a/bugsnag/asgi.py
+++ b/bugsnag/asgi.py
@@ -4,7 +4,7 @@ from typing import Any, List, Dict, Union, Optional
 import bugsnag
 from bugsnag.breadcrumbs import BreadcrumbType
 from bugsnag.legacy import _auto_leave_breadcrumb
-from bugsnag.utils import sanitize_url
+from bugsnag.utils import remove_query_from_url
 
 __all__ = ('BugsnagMiddleware',)
 
@@ -137,7 +137,7 @@ def _get_breadcrumb_metadata(scope) -> Dict[str, str]:
     referer = _get_referer_header(scope)
 
     if referer:
-        metadata['from'] = sanitize_url(referer)
+        metadata['from'] = remove_query_from_url(referer)
 
     return metadata
 

--- a/bugsnag/asgi.py
+++ b/bugsnag/asgi.py
@@ -4,7 +4,7 @@ from typing import Any, List, Dict, Union, Optional
 import bugsnag
 from bugsnag.breadcrumbs import BreadcrumbType
 from bugsnag.legacy import _auto_leave_breadcrumb
-from bugsnag.utils import remove_query_from_url
+from bugsnag.utils import remove_query_from_url, sanitize_url
 
 __all__ = ('BugsnagMiddleware',)
 
@@ -103,7 +103,10 @@ class BugsnagMiddleware:
                         request[prop.metadata_key] = scope[item]
                         break
 
-            request['url'] = parse_url(request, server)
+            request['url'] = sanitize_url(
+                parse_url(request, server),
+                event.config
+            )
 
             event.add_tab("request", request)
             if bugsnag.configure().send_environment:

--- a/bugsnag/django/__init__.py
+++ b/bugsnag/django/__init__.py
@@ -8,8 +8,8 @@ except ImportError:
     from django.urls import resolve, Resolver404
 
 import bugsnag
-from bugsnag.utils import is_json_content_type
 import json
+from bugsnag.utils import is_json_content_type, sanitize_url
 
 
 def add_django_request_to_notification(event):
@@ -50,14 +50,16 @@ def add_django_request_to_notification(event):
 
     if getattr(request, "session", None):
         event.add_tab("session", dict(request.session))
+
     request_tab = {
         'method': request.method,
         'path': request.path,
         'encoding': request.encoding,
         'GET': dict(request.GET),
         'POST': dict(request.POST),
-        'url': request.build_absolute_uri(),
+        'url': sanitize_url(request.build_absolute_uri(), event.config)
     }
+
     try:
         is_json = is_json_content_type(request.META.get('CONTENT_TYPE', ''))
         if is_json and request_tab["method"] == "POST":

--- a/bugsnag/django/middleware.py
+++ b/bugsnag/django/middleware.py
@@ -9,7 +9,7 @@ import bugsnag
 import bugsnag.django
 from bugsnag.legacy import _auto_leave_breadcrumb
 from bugsnag.breadcrumbs import BreadcrumbType
-from bugsnag.utils import sanitize_url
+from bugsnag.utils import remove_query_from_url
 
 
 class BugsnagMiddleware(MiddlewareMixin):
@@ -59,6 +59,8 @@ class BugsnagMiddleware(MiddlewareMixin):
         metadata = {'to': request.path}
 
         if 'HTTP_REFERER' in request.META:
-            metadata['from'] = sanitize_url(request.META['HTTP_REFERER'])
+            metadata['from'] = remove_query_from_url(
+                request.META['HTTP_REFERER']
+            )
 
         return metadata

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -5,7 +5,7 @@ import bugsnag
 from bugsnag.wsgi import request_path
 from bugsnag.legacy import _auto_leave_breadcrumb
 from bugsnag.breadcrumbs import BreadcrumbType
-from bugsnag.utils import sanitize_url
+from bugsnag.utils import remove_query_from_url
 
 
 __all__ = ('handle_exceptions',)
@@ -69,6 +69,6 @@ def _get_breadcrumb_metadata(request) -> Dict[str, str]:
     metadata = {'to': request_path(request.environ)}
 
     if 'referer' in request.headers:
-        metadata['from'] = sanitize_url(request.headers['referer'])
+        metadata['from'] = remove_query_from_url(request.headers['referer'])
 
     return metadata

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -4,7 +4,7 @@ from tornado.wsgi import WSGIContainer
 from typing import Dict, Any
 from urllib.parse import parse_qs
 from bugsnag.breadcrumbs import BreadcrumbType
-from bugsnag.utils import is_json_content_type, sanitize_url
+from bugsnag.utils import is_json_content_type, remove_query_from_url
 from bugsnag.legacy import _auto_leave_breadcrumb
 import bugsnag
 import json
@@ -94,7 +94,9 @@ class BugsnagRequestHandler(RequestHandler):
         metadata = {'to': self.request.path}
 
         if 'Referer' in self.request.headers:
-            metadata['from'] = sanitize_url(self.request.headers['Referer'])
+            metadata['from'] = remove_query_from_url(
+                self.request.headers['Referer']
+            )
 
         return metadata
 

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -4,7 +4,11 @@ from tornado.wsgi import WSGIContainer
 from typing import Dict, Any
 from urllib.parse import parse_qs
 from bugsnag.breadcrumbs import BreadcrumbType
-from bugsnag.utils import is_json_content_type, remove_query_from_url
+from bugsnag.utils import (
+    is_json_content_type,
+    remove_query_from_url,
+    sanitize_url
+)
 from bugsnag.legacy import _auto_leave_breadcrumb
 import bugsnag
 import json
@@ -21,7 +25,7 @@ class BugsnagRequestHandler(RequestHandler):
             'path': self.request.path,
             'GET': parse_qs(self.request.query),
             'POST': {},
-            'url': self.request.full_url(),
+            'url': sanitize_url(self.request.full_url(), event.config),
         }  # type: Dict[str, Any]
         try:
             if (len(self.request.body) > 0):
@@ -46,7 +50,10 @@ class BugsnagRequestHandler(RequestHandler):
             "user": {"id": self.request.remote_ip},
             "context": self._get_context(),
             "request": {
-                "url": self.request.full_url(),
+                "url": sanitize_url(
+                    self.request.full_url(),
+                    bugsnag.configuration
+                ),
                 "method": self.request.method,
                 "arguments": self.request.arguments,
             },

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -331,23 +331,23 @@ class ThreadContextVar:
         setattr(ThreadContextVar.local_context(), self.name, new_value)
 
 
-def sanitize_url(url_to_sanitize: AnyStr) -> Optional[AnyStr]:
+def remove_query_from_url(url: AnyStr) -> Optional[AnyStr]:
     try:
-        parsed = urlparse(url_to_sanitize)
+        parsed = urlparse(url)
 
-        sanitized_url = urlunsplit(
+        url_without_query = urlunsplit(
             # urlunsplit always requires 5 elements in this tuple
             (parsed.scheme, parsed.netloc, parsed.path, None, None)
         ).strip()
     except Exception:
         return None
 
-    # If the sanitized url is empty then it did not have any of the components
+    # If the returned url is empty then it did not have any of the components
     # we are interested in, so return None to indicate failure
-    if not sanitized_url:
+    if not url_without_query:
         return None
 
-    return sanitized_url
+    return url_without_query
 
 
 # to_rfc3339: format a datetime instance to match to_rfc3339/iso8601 with

--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -6,7 +6,7 @@ import bugsnag
 from bugsnag.wsgi import request_path
 from bugsnag.breadcrumbs import BreadcrumbType
 from bugsnag.legacy import _auto_leave_breadcrumb
-from bugsnag.utils import sanitize_url
+from bugsnag.utils import remove_query_from_url
 
 # Attempt to import bottle for runtime version report, but only if already
 # in use in app
@@ -110,7 +110,7 @@ def _get_breadcrumb_metadata(environ) -> Dict[str, str]:
         metadata['to'] = environ['PATH_INFO']
 
     if 'HTTP_REFERER' in environ:
-        metadata['from'] = sanitize_url(environ['HTTP_REFERER'])
+        metadata['from'] = remove_query_from_url(environ['HTTP_REFERER'])
 
     return metadata
 

--- a/tests/integrations/test_asgi.py
+++ b/tests/integrations/test_asgi.py
@@ -232,12 +232,18 @@ class TestASGIMiddleware(IntegrationTest):
 
         app = TestClient(BugsnagMiddleware(app))
 
-        self.assertRaises(ScaryException, lambda: app.get('/path?page=6#top'))
+        self.assertRaises(
+            ScaryException,
+            lambda: app.get('/path?password=secret#top')
+        )
         self.assertSentReportCount(1)
 
         payload = self.server.received[0]['json_body']
         request = payload['events'][0]['metaData']['request']
-        self.assertEqual('http://testserver/path?page=6', request['url'])
+        self.assertEqual(
+            'http://testserver/path?password=[FILTERED]',
+            request['url']
+        )
 
         breadcrumbs = payload['events'][0]['breadcrumbs']
 

--- a/tests/integrations/test_bottle.py
+++ b/tests/integrations/test_bottle.py
@@ -25,7 +25,7 @@ class TestBottle(IntegrationTest):
         app.catchall = False
         app = TestApp(BugsnagMiddleware(app))
 
-        self.assertRaises(Exception, lambda: app.get('/beans'))
+        self.assertRaises(Exception, lambda: app.get('/beans?password=123'))
         self.assertEqual(1, len(self.server.received))
         payload = self.server.received[0]['json_body']
         event = payload['events'][0]
@@ -36,6 +36,11 @@ class TestBottle(IntegrationTest):
         runtime_versions = event['device']['runtimeVersions']
         self.assertEqual(runtime_versions['bottle'], '0.12.18')
         assert 'environment' not in event['metaData']
+
+        assert event['metaData']['request']['url'] == 'http://localhost/beans'
+        assert event['metaData']['request']['params'] == {
+            'password': '[FILTERED]'
+        }
 
     def test_enable_environment(self):
         bugsnag.configure(send_environment=True)

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -43,7 +43,12 @@ def django_client():
 
 
 def test_notify(bugsnag_server, django_client):
-    response = django_client.get('/notes/handled-exception/?foo=strawberry')
+    bugsnag.configure(params_filters=['bar'])
+
+    response = django_client.get(
+        '/notes/handled-exception/?bar=apple'
+    )
+
     assert response.status_code == 200
 
     bugsnag_server.wait_for_request()
@@ -58,11 +63,11 @@ def test_notify(bugsnag_server, django_client):
     assert 'environment' not in payload['events'][0]['metaData']
     assert event['metaData']['request'] == {
         'method': 'GET',
-        'url': 'http://testserver/notes/handled-exception/?foo=strawberry',
+        'url': 'http://testserver/notes/handled-exception/?bar=[FILTERED]',
         'path': '/notes/handled-exception/',
         'POST': {},
         'encoding': None,
-        'GET': {'foo': ['strawberry']}
+        'GET': {'bar': '[FILTERED]'}
     }
     assert event['user'] == {}
     assert exception['errorClass'] == 'KeyError'

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -44,15 +44,15 @@ class TestFlask(IntegrationTest):
             raise SentinelError("oops")
 
         handle_exceptions(app)
-        app.test_client().get('/hello')
+        app.test_client().get('/hello?password=secret')
 
         self.assertEqual(1, len(self.server.received))
         payload = self.server.received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['exceptions'][0]['errorClass'],
                          'test_flask.SentinelError')
-        self.assertEqual(event['metaData']['request']['url'],
-                         'http://localhost/hello')
+        assert event['metaData']['request']['url'] == 'http://localhost/hello'
+        assert event['metaData']['request']['params'] == {}
         assert 'environment' not in event['metaData']
 
         breadcrumbs = payload['events'][0]['breadcrumbs']

--- a/tests/integrations/test_tornado.py
+++ b/tests/integrations/test_tornado.py
@@ -43,20 +43,22 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
         assert breadcrumbs[0]['type'] == BreadcrumbType.NAVIGATION.value
 
     def test_notify_get(self):
-        response = self.fetch('/notify?test=get', method="GET")
+        response = self.fetch('/notify?password=asdf', method="GET")
         self.assertEqual(response.code, 200)
         self.assertEqual(len(self.server.received), 1)
 
         payload = self.server.received[0]['json_body']
         event = payload['events'][0]
         p = self.get_http_port()
-        expectedUrl = 'http://127.0.0.1:{}/notify?test=get'.format(p)
+        expectedUrl = \
+            'http://127.0.0.1:{}/notify?password=[FILTERED]'.format(p)
+
         self.assertEqual(event['metaData']['request'], {
             'method': 'GET',
             'url': expectedUrl,
             'path': '/notify',
             'POST': {},
-            'GET': {'test': ['get']}
+            'GET': {'password': '[FILTERED]'}
         })
 
         breadcrumbs = event['breadcrumbs']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 
 from bugsnag.utils import (SanitizingJSONEncoder, FilterDict,
                            is_json_content_type, parse_content_type,
-                           ThreadContextVar, to_rfc3339, sanitize_url)
+                           ThreadContextVar, to_rfc3339, remove_query_from_url)
 
 logger = logging.getLogger(__name__)
 
@@ -478,7 +478,7 @@ def test_to_rfc3339(dt: datetime, expected: str):
     assert to_rfc3339(dt) == expected
 
 
-@pytest.mark.parametrize("url_to_sanitize, expected", [
+@pytest.mark.parametrize("url, expected", [
     ('https://example.com', 'https://example.com'),
     ('https://example.com/', 'https://example.com/'),
     ('https://example.com/a/b/c', 'https://example.com/a/b/c'),
@@ -523,5 +523,5 @@ def test_to_rfc3339(dt: datetime, expected: str):
     (object(), None),
     (lambda: 'example.com', None),
 ])
-def test_sanitize_url(url_to_sanitize, expected):
-    assert sanitize_url(url_to_sanitize) == expected
+def test_remove_query_from_url(url, expected):
+    assert remove_query_from_url(url) == expected


### PR DESCRIPTION
## Goal

As part of our integration with web frameworks, we record the request URL in metadata. Some integrations only record the domain and path, but others also include the query string. However we weren't applying `params_filters` to the query string parameters and so could leak sensitive information if passed in the query string

This PR applies `params_filters` to URLs in request metadata for the following integrations:

- ASGI
- Django
- Tornado
- WSGI