### PR TITLE
Allow preventing an exception from being reported to Bugsnag by setting the `skip_bugsnag` attr to `True`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Allow preventing an exception from being reported to Bugsnag by setting the `skip_bugsnag` attr to `True`
+  [#325](https://github.com/bugsnag/bugsnag-python/pull/325)
+
 ## v4.2.1 (2022-05-16)
 
 ### Bug fixes

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -15,7 +15,11 @@ from bugsnag.breadcrumbs import (
     OnBreadcrumbCallback
 )
 from bugsnag.sessiontracker import SessionMiddleware
-from bugsnag.middleware import DefaultMiddleware, MiddlewareStack
+from bugsnag.middleware import (
+    DefaultMiddleware,
+    MiddlewareStack,
+    skip_bugsnag_middleware
+)
 from bugsnag.utils import (fully_qualified_class_name, validate_str_setter,
                            validate_bool_setter, validate_iterable_setter,
                            validate_required_str_setter, validate_int_setter)
@@ -72,6 +76,7 @@ class Configuration:
         self.middleware = MiddlewareStack()
 
         self.internal_middleware = MiddlewareStack()
+        self.internal_middleware.before_notify(skip_bugsnag_middleware)
         self.internal_middleware.append(DefaultMiddleware)
         self.internal_middleware.append(SessionMiddleware)
 

--- a/bugsnag/middleware.py
+++ b/bugsnag/middleware.py
@@ -64,6 +64,15 @@ class DefaultMiddleware:
         self.bugsnag(event)
 
 
+def skip_bugsnag_middleware(event: Event):
+    """
+    A callback-based middleware that prevents notifying an event where the
+    'original_error' has a 'skip_bugsnag' attr set to 'True'.
+    """
+    if getattr(event.original_error, 'skip_bugsnag', False) is True:
+        return False
+
+
 class MiddlewareStack:
     """
     Manages a stack of Bugsnag middleware.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1456,6 +1456,43 @@ class ClientTest(IntegrationTest):
 
         assert self.sent_report_count == 1
 
+    def test_skip_bugsnag_attr_prevents_notify_when_true(self):
+        exception = Exception('Testing Notify')
+        self.client.notify(exception)
+
+        assert self.sent_report_count == 1
+
+        exception.skip_bugsnag = True
+        self.client.notify(exception)
+
+        assert self.sent_report_count == 1
+
+    def test_setting_skip_bugsnag_attr_to_false_allows_notify(self):
+        exception = Exception('Testing Notify')
+        exception.skip_bugsnag = True
+
+        self.client.notify(exception)
+
+        assert self.sent_report_count == 0
+
+        exception.skip_bugsnag = False
+        self.client.notify(exception)
+
+        assert self.sent_report_count == 1
+
+    def test_deleting_skip_bugsnag_attr_allows_notify(self):
+        exception = Exception('Testing Notify')
+        exception.skip_bugsnag = True
+
+        self.client.notify(exception)
+
+        assert self.sent_report_count == 0
+
+        delattr(exception, 'skip_bugsnag')
+        self.client.notify(exception)
+
+        assert self.sent_report_count == 1
+
 
 @pytest.mark.parametrize("metadata,type", [
     (1234, 'int'),

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -11,7 +11,7 @@ from threading import Thread
 from bugsnag.breadcrumbs import BreadcrumbType
 from bugsnag.configuration import Configuration
 from bugsnag.error import Error
-from bugsnag.middleware import DefaultMiddleware
+from bugsnag.middleware import DefaultMiddleware, SimpleMiddleware
 from bugsnag.sessiontracker import SessionMiddleware
 
 import pytest
@@ -85,9 +85,13 @@ class TestConfiguration(unittest.TestCase):
 
     def test_default_middleware_location(self):
         c = Configuration()
-        self.assertEqual(c.internal_middleware.stack,
-                         [DefaultMiddleware, SessionMiddleware])
-        self.assertEqual(len(c.middleware.stack), 0)
+
+        assert len(c.internal_middleware.stack) == 3
+        assert isinstance(c.internal_middleware.stack[0], SimpleMiddleware)
+        assert c.internal_middleware.stack[1] is DefaultMiddleware
+        assert c.internal_middleware.stack[2] is SessionMiddleware
+
+        assert len(c.middleware.stack) == 0
 
     def test_validate_api_key(self):
         c = Configuration()


### PR DESCRIPTION
## Goal

Sometimes it's useful to manually report an exception to Bugsnag but still re-raise it to allow other exception handlers to run. For example, if there is useful information available only to where the exception was raised, if you want to ensure an event is marked as 'handled' to avoid affecting stability score, etc&hellip;

This is something we have [support for in Bugsnag Ruby already](http://docs.bugsnag.com/platforms/ruby/other/#avoiding-re-notifying-exceptions) and this PR brings the same feature to Bugsnag Python

When you have an exception object, add a `skip_bugsnag` attr set to `True` to prevent Bugsnag from sending a new event with that exception, for example:

```python
try:
    raise Exception('oh no')
except exception:
    bugsnag.notify(exception)

    # prevent Bugsnag's global exception handler from also
    # notifying this exception
    exception.skip_bugsnag = True

    raise exception
```

If `skip_bugsnag` is missing or set to any value other than `True`, the exception will be notified as normal

## Changeset

- Add new `skip_bugsnag_middleware` middleware function
- Add `skip_bugsnag_middleware` to the internal middleware stack. It runs first so no other middleware will run if it prevents sending

## Testing

- Unit tests for the new middleware
- Unit tests for calling `notify` with `skip_bugsnag` and after removing/modifying the attr