### PR TITLE
Prevent duplicate events in Django integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Allow preventing an exception from being reported to Bugsnag by setting the `skip_bugsnag` attr to `True`
   [#325](https://github.com/bugsnag/bugsnag-python/pull/325)
 
+* Prevent duplicate events from being notified in the Django integration
+  [#326](https://github.com/bugsnag/bugsnag-python/pull/326)
+
 ## v4.2.1 (2022-05-16)
 
 ### Bug fixes

--- a/bugsnag/django/middleware.py
+++ b/bugsnag/django/middleware.py
@@ -48,6 +48,10 @@ class BugsnagMiddleware(MiddlewareMixin):
                 }
             )
 
+            # ensure the 'got_request_exception' signal doesn't also notify
+            # this exception
+            setattr(exception, 'skip_bugsnag', True)
+
         except Exception:
             self.config.logger.exception("Error in exception middleware")
 

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -52,6 +52,9 @@ def test_notify(bugsnag_server, django_client):
     assert response.status_code == 200
 
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
@@ -102,6 +105,9 @@ def test_enable_environment(bugsnag_server, django_client):
     assert response.status_code == 200
 
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
     assert event['metaData']['environment']['REQUEST_METHOD'] == 'GET'
@@ -110,6 +116,9 @@ def test_enable_environment(bugsnag_server, django_client):
 def test_notify_custom_info(bugsnag_server, django_client):
     django_client.get('/notes/handled-exception-custom/')
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
 
@@ -126,6 +135,9 @@ def test_notify_post_body(bugsnag_server, django_client):
     assert response.status_code == 200
 
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
@@ -168,6 +180,9 @@ def test_unhandled_exception(bugsnag_server, django_client):
         django_client.get('/notes/unhandled-crash/')
 
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
@@ -213,6 +228,9 @@ def test_unhandled_exception_chain(bugsnag_server, django_client):
         django_client.get('/notes/unhandled-crash-chain/')
 
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
@@ -258,6 +276,9 @@ def test_unhandled_exception_in_template(bugsnag_server, django_client):
         django_client.get('/notes/unhandled-template-crash/')
 
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
@@ -289,7 +310,7 @@ def test_ignores_http404(bugsnag_server, django_client):
     with pytest.raises(MissingRequestError):
         bugsnag_server.wait_for_request()
 
-    assert len(bugsnag_server.received) == 0
+    assert bugsnag_server.sent_report_count == 0
 
 
 def test_report_error_from_http404handler(bugsnag_server, django_client):
@@ -297,6 +318,9 @@ def test_report_error_from_http404handler(bugsnag_server, django_client):
         django_client.get('/notes/poorly-handled-404')
 
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
@@ -342,6 +366,9 @@ def test_notify_appends_user_data(bugsnag_server, django_client):
     assert response.status_code == 200
 
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
@@ -386,6 +413,9 @@ def test_crash_appends_user_data(bugsnag_server, django_client):
         django_client.get('/notes/unhandled-crash/')
 
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
@@ -431,6 +461,9 @@ def test_read_request_in_callback(bugsnag_server, django_client):
         django_client.get('/notes/crash-with-callback/?user_id=foo')
 
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
     assert event['context'] == 'foo'
@@ -448,6 +481,9 @@ def test_bugsnag_middleware_leaves_breadcrumb_with_referer(
     assert response.status_code == 200
 
     bugsnag_server.wait_for_request()
+
+    assert bugsnag_server.sent_report_count == 1
+
     payload = bugsnag_server.received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,7 +43,7 @@ class IntegrationTest(unittest.TestCase):
 
     @property
     def sent_report_count(self) -> int:
-        return len(self.server.received)
+        return self.server.sent_report_count
 
 
 class FakeBugsnagServer(object):
@@ -107,6 +107,10 @@ class FakeBugsnagServer(object):
                 raise MissingRequestError("No request received before timeout")
 
             time.sleep(0.25)
+
+    @property
+    def sent_report_count(self) -> int:
+        return len(self.received)
 
 
 class ScaryException(Exception):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -109,6 +109,10 @@ class FakeBugsnagServer(object):
 
             time.sleep(0.25)
 
+        # sleep for the time remaining until 'timeout' to allow more requests
+        # to arrive
+        time.sleep(time.time() - start)
+
     @property
     def sent_report_count(self) -> int:
         return len(self.received)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -99,6 +99,7 @@ class FakeBugsnagServer(object):
         self.server.shutdown()
         self.thread.join()
         self.server.server_close()
+        self.received = []
 
     def wait_for_request(self, timeout=2):
         start = time.time()


### PR DESCRIPTION
## Goal

We use both a middleware and signal handler to catch exceptions in Django applications, but both can be called for the same exception which causes a duplicate event to be reported

Using the new `skip_bugsnag` attr, we can prevent this by stopping the signal handler from notifying any exception that has already been handled by the middleware. The signal handler is still necessary as some exception happen outside of the middleware stack

## Changeset

- The signal handler is no longer marked as `weak=True`. This was causing issues when asserting on the number of events delivered in the tests because it was persisting between tests. This wasn't reproducible in a real app though as a real app won't start Django multiple times
- Our Django middleware now sets `skip_bugsnag` on exceptions it handles. The middleware runs before the signal handler so this prevents the signal handler from also notifying of the same exceptions

## Testing

- FakeBugsnagServer now clears received events between tests to allow asserting on only the number of requests delivered in an individual test
- FakeBugsnagServer always waits for the entire duration of its `timeout` so that excess requests have a chance to be delivered. This causes tests to run longer, but it's not a huge impact (total time is still ~1-3 mins)
- The Django tests now assert that only 1 event is reported. Doing this on `next` fails as both the signal handler and middleware report the same exception in some tests (even with the other testing changes)