### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -4,7 +4,9 @@ on: [push, pull_request]
 
 jobs:
   license-audit:
-    runs-on: ubuntu-latest
+    # TODO: a GH action update broke the 'ubuntu-latest' image
+    #       when it's fixed, we should switch back
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install coveralls tox tox-factor
+        python -m pip install coveralls 'tox<4.0.0' tox-factor
 
     - name: Run tests
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,8 +4,10 @@ on: [ push, pull_request ]
 
 jobs:
   test:
+    # TODO: a GH action update broke the 'ubuntu-latest' image
+    #       when it's fixed, we should switch back
+    runs-on: ubuntu-20.04
 
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -13,18 +15,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install coveralls tox tox-factor
+
     - name: Run tests
       run: |
         pyversion=${{ matrix.python-version }}
         TOXFACTOR=${pyversion//.0-*/}
         tox -f py${TOXFACTOR//./} --parallel --quiet
+
     - name: Upload code coverage data
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bugsnag/breadcrumbs.py
+++ b/bugsnag/breadcrumbs.py
@@ -1,12 +1,12 @@
 from enum import Enum, unique
-from typing import Any, Dict, List, Optional, Union, Callable, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Union, Callable, TYPE_CHECKING  # noqa
 from collections import deque
 
 from bugsnag.utils import FilterDict
 
 # Deque is not present in 'typing' until 3.5.4, so we can't use it directly
 if TYPE_CHECKING:
-    from typing import Deque
+    from typing import Deque  # noqa
 
 # The _breadcrumbs context var contains None or a deque of Breadcrumb instances
 try:

--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -207,7 +207,10 @@ class Client:
 
         return True
 
-    def log_handler(self, extra_fields: List[str] = None) -> BugsnagHandler:
+    def log_handler(
+        self,
+        extra_fields: Optional[List[str]] = None
+    ) -> BugsnagHandler:
         return BugsnagHandler(client=self, extra_fields=extra_fields)
 
     @property

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Optional, List  # noqa
 import linecache
 import logging
 import os

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Tuple, Type
+from typing import Dict, Any, Tuple, Type, Optional
 import types
 import sys
 
@@ -102,7 +102,7 @@ def auto_notify(exception: BaseException, **options):
         )
 
 
-def auto_notify_exc_info(exc_info: ExcInfoType = None, **options):
+def auto_notify_exc_info(exc_info: Optional[ExcInfoType] = None, **options):
     """
     Notify bugsnag of a exc_info tuple if auto_notify is enabled
     """

--- a/bugsnag/middleware.py
+++ b/bugsnag/middleware.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Type, List
+from typing import Callable, Optional, Type, List  # noqa
 
 from bugsnag.event import Event
 

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -1,7 +1,7 @@
 import tornado
 from tornado.web import RequestHandler, HTTPError
 from tornado.wsgi import WSGIContainer
-from typing import Dict, Any
+from typing import Dict, Any  # noqa
 from urllib.parse import parse_qs
 from bugsnag.breadcrumbs import BreadcrumbType
 from bugsnag.utils import (

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,7 @@
 twine
 wheel
 
-tox
+tox<4.0.0
 pytest
 flake8
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,9 +2,7 @@ twine
 wheel
 
 tox
-tox-factor
-pytest-cov
-coveralls
+pytest
 flake8
 
 --index-url https://pypi.python.org/simple/

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ testpaths = tests
 addopts   = --cov=bugsnag --cov-report html --cov-append --cov-report term
 
 [testenv]
-passenv = TRAVIS TRAVIS_*
 setenv  =
     PYTHONPATH = {toxinidir}
     COVERAGE_FILE=.coverage.{envname}


### PR DESCRIPTION
## Goal

A few issues cropped up recently breaking our CI:

- the `ubuntu-latest` image on GH Actions [fails to install 3.5 or 3.6](https://github.com/bugsnag/bugsnag-python/actions/runs/3912338657/jobs/6686846434). Using `ubuntu-20.04` fixes this for now
- tox v4 was released, which breaks the tox-factor plugin. tox-factor's functionality is built into tox v4, but v4 only runs on Python 3.7+ so we still need to use tox v3 & tox-factor some of the time. Additionally some of our tests fail on v4, so I've pinned to v3 for now — we'll need to look into this further but need CI unblocked so we can work on other things
- a mypy update broke our linting in two ways:
    1. imports that are only used in comments are now called out as "unused", but are required for type checking on Python 3.5. I've ignored these errors to fix this
    2. the "no implicit optional" rule is now on by default. We had two functions that relied on this, so I've changed them to explicitly be optional