### PR TITLE
Extract sub-exceptions from Exception Groups

### DIFF
--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -18,4 +18,5 @@ from .caused_by import (
 if sys.version_info >= (3, 11):
     from .exception_groups import (
         exception_group_with_no_cause,
+        base_exception_group_subclass,
     )

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -19,4 +19,5 @@ if sys.version_info >= (3, 11):
     from .exception_groups import (
         exception_group_with_no_cause,
         base_exception_group_subclass,
+        exception_group_with_nested_group,
     )

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+import sys
 
 from .start_and_end_of_file import (
     start_of_file,
@@ -13,3 +14,8 @@ from .caused_by import (
     exception_with_no_cause,
     raise_exception_with_no_cause,
 )
+
+if sys.version_info >= (3, 11):
+    from .exception_groups import (
+        exception_group_with_no_cause,
+    )

--- a/tests/fixtures/exception_groups.py
+++ b/tests/fixtures/exception_groups.py
@@ -1,0 +1,27 @@
+# flake8: noqa
+
+# this creates an exception with a very small __traceback__, so it's easier to
+# assert against in tests
+def generate_exception(exception_class, message):
+    try:
+        raise exception_class(message)
+    except Exception as exception:
+        return exception
+
+
+def raise_exception_group_with_no_cause():
+    raise ExceptionGroup(
+        'the message of the group',
+        [
+            generate_exception(Exception, 'exception #1'),
+            generate_exception(ArithmeticError, 'exception #2'),
+            generate_exception(NameError, 'exception #3'),
+            generate_exception(AssertionError, 'exception #4'),
+        ]
+    )
+
+
+try:
+    raise_exception_group_with_no_cause()
+except BaseExceptionGroup as exception_group:
+    exception_group_with_no_cause = exception_group

--- a/tests/fixtures/exception_groups.py
+++ b/tests/fixtures/exception_groups.py
@@ -46,3 +46,22 @@ try:
     raise_base_exception_group_subclass_with_no_cause()
 except BaseExceptionGroup as exception_group:
     base_exception_group_subclass = exception_group
+
+
+def raise_exception_group_with_nested_group():
+    raise ExceptionGroup(
+        'the message of the group',
+        [
+            generate_exception(Exception, 'exception #1'),
+            exception_group_with_no_cause,
+            generate_exception(ArithmeticError, 'exception #3')
+        ]
+    )
+
+
+try:
+    raise_exception_group_with_nested_group()
+except BaseExceptionGroup as exception_group:
+    exception_group_with_nested_group = exception_group
+
+

--- a/tests/fixtures/exception_groups.py
+++ b/tests/fixtures/exception_groups.py
@@ -5,7 +5,7 @@
 def generate_exception(exception_class, message):
     try:
         raise exception_class(message)
-    except Exception as exception:
+    except BaseException as exception:
         return exception
 
 
@@ -25,3 +25,24 @@ try:
     raise_exception_group_with_no_cause()
 except BaseExceptionGroup as exception_group:
     exception_group_with_no_cause = exception_group
+
+
+class MyExceptionGroup(BaseExceptionGroup):
+    pass
+
+
+def raise_base_exception_group_subclass_with_no_cause():
+    raise MyExceptionGroup(
+        'my very easy method just speeds up (n)making exception groups',
+        [
+            generate_exception(GeneratorExit, 'exception #1'),
+            generate_exception(ReferenceError, 'exception #2'),
+            generate_exception(NotImplementedError, 'exception #3'),
+        ]
+    )
+
+
+try:
+    raise_base_exception_group_subclass_with_no_cause()
+except BaseExceptionGroup as exception_group:
+    base_exception_group_subclass = exception_group


### PR DESCRIPTION
## Goal

Python 3.11 added Exception Groups ([see PEP 654](https://peps.python.org/pep-0654/)) as a way of aggregating several unrelated exceptions into a single Exception-compatible object

bugsnag-python currently supports reporting Exception Groups, but there's no visibility of the sub-exceptions contained within the group. This is problematic as often the group won't contain enough information to debug the problems that caused it — the contained exceptions should be unrelated, so it's difficult to go from the group &rarr; its sub-exceptions

This PR extracts the sub-exceptions from Exception Groups, so that they are reported to bugsnag along with the group. This is very similar to how we report `AggregateExceptions` in the .NET notifier

## Design

In order to avoid truly _gigantic_ lists of errors in the dashboard, we don't recurse into sub-exception groups or their cause/context. The error reporting API also doesn't support tree-shaped hierarchies of errors, so this structure would be difficult to deal with in bugsnag anyway

For example, this exception group:

![image](https://user-images.githubusercontent.com/282732/216573647-49b3ec88-6a11-43ac-8c03-0121f560bbaf.png)

will be reported as:

![image](https://user-images.githubusercontent.com/282732/216573678-176ea101-d220-4152-a1e4-69db4c3be2f6.png)

This should still contain enough information to debug the errors and, if not, the exceptions can be reported separately by catching the `ExceptionGroup` itself