### PR TITLE
Fix typo in meta_data deprecation warning

### DIFF
--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -104,7 +104,7 @@ class Event:
 
         self.metadata = {}  # type: Dict[str, Dict[str, Any]]
         if 'meta_data' in options:
-            warnings.warn('The Event "metadata" argument has been replaced ' +
+            warnings.warn('The Event "meta_data" argument has been replaced ' +
                           'with "metadata"', DeprecationWarning)
             for name, tab in options.pop("meta_data").items():
                 self.add_tab(name, tab)
@@ -117,8 +117,8 @@ class Event:
 
     @property
     def meta_data(self) -> Dict[str, Dict[str, Any]]:
-        warnings.warn('The Event "metadata" property has been replaced ' +
-                      'with "meta_data".', DeprecationWarning)
+        warnings.warn('The Event "meta_data" property has been replaced ' +
+                      'with "metadata".', DeprecationWarning)
         return self.metadata
 
     @property

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -358,7 +358,7 @@ class TestEvent(unittest.TestCase):
 
             assert len(records) > 0
             i = len(records) - 1
-            assert str(records[i].message) == ('The Event "metadata" ' +
+            assert str(records[i].message) == ('The Event "meta_data" ' +
                                                'argument has been replaced ' +
                                                'with "metadata"')
             assert event.metadata['nuts']['almonds']

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -843,7 +843,7 @@ class TestBugsnag(IntegrationTest):
                            meta_data={'fruit': {'apples': 2}})
 
             assert len(records) == 1
-            assert str(records[0].message) == ('The Event "metadata" ' +
+            assert str(records[0].message) == ('The Event "meta_data" ' +
                                                'argument has been replaced ' +
                                                'with "metadata"')
 


### PR DESCRIPTION
## Goal

Fix typo in `meta_data` deprecation warning in order to resolve #321.