### PR TITLE
Allow setting the grouping hash when logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog
 
 ### Enhancements
 
-* Allows changing the grouping hash when using the logger methods and
+* Allows changing the grouping hash when using `BugsnagHandler` via the logger methods' `extra` keyword argument
   [#334](https://github.com/bugsnag/bugsnag-python/pull/334)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Allows changing the grouping hash when using the logger methods and
+  [#334](https://github.com/bugsnag/bugsnag-python/pull/334)
+
 ## v4.4.0 (2023-02-21)
 
 ### Enhancements

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -18,7 +18,8 @@ class BugsnagHandler(logging.Handler, object):
         self.custom_metadata_fields = extra_fields
         self.callbacks = [self.extract_default_metadata,
                           self.extract_custom_metadata,
-                          self.extract_severity]
+                          self.extract_severity,
+                          self.extract_grouping_hash]
 
     def emit(self, record: LogRecord):
         """
@@ -112,6 +113,13 @@ class BugsnagHandler(logging.Handler, object):
             options['severity'] = 'warning'
         else:
             options['severity'] = 'info'
+
+    def extract_grouping_hash(self, record: LogRecord, options: Dict):
+        """
+        Add the grouping_hash from a log record to the options
+        """
+        if 'groupingHash' in record.__dict__:
+            options['grouping_hash'] = record.__dict__['groupingHash']
 
     def extract_custom_metadata(self, record: LogRecord, options: Dict):
         """

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -458,6 +458,18 @@ class HandlersTest(IntegrationTest):
                          {'exception': 'metadata'})
 
     @use_client_logger
+    def test_logging_grouping_hash(self, handler, logger):
+        logger.info("This happened", extra={'groupingHash': '<hash value>'})
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+
+        self.assertEqual(exception['message'], 'This happened')
+        self.assertEqual(event['groupingHash'], '<hash value>')
+
+    @use_client_logger
     def test_log_filter_leaves_breadcrumbs_for_logs_below_report_level(
         self,
         handler,


### PR DESCRIPTION
## Goal

Allows changing the grouping hash when using the logger methods and the BugsnagHandler to send event, in order to close #253.

## Changeset

An `extract_grouping_hash` was added to the logging handler to allow the grouping hash to be sent to the `client.notify` function.

## Testing

The `test_logging_grouping_hash` ensures that the specified hash value is sent.