### PR TITLE
Ignore 'builtins' in fully qualified class names

### DIFF
--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -240,12 +240,16 @@ def is_json_content_type(value: str) -> bool:
     return type == 'application' and (subtype == 'json' or suffix == 'json')
 
 
+_ignore_modules = ('__main__', 'builtins')
+
+
 def fully_qualified_class_name(obj):
     module = inspect.getmodule(obj)
-    if module is not None and module.__name__ != "__main__":
-        return module.__name__ + "." + obj.__class__.__name__
-    else:
+
+    if module is None or module.__name__ in _ignore_modules:
         return obj.__class__.__name__
+
+    return module.__name__ + '.' + obj.__class__.__name__
 
 
 def package_version(package_name):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1513,7 +1513,7 @@ class ClientTest(IntegrationTest):
 
         assert exceptions[0] == {
             'message': 'the message of the group (4 sub-exceptions)',
-            'errorClass': 'builtins.ExceptionGroup',
+            'errorClass': 'ExceptionGroup',
             'type': 'python',
             'stacktrace': [
                 {
@@ -1638,7 +1638,7 @@ class ClientTest(IntegrationTest):
 
         assert exceptions[0] == {
             'message': 'the message of the group (3 sub-exceptions)',
-            'errorClass': 'builtins.ExceptionGroup',
+            'errorClass': 'ExceptionGroup',
             'type': 'python',
             'stacktrace': [
                 {
@@ -1675,7 +1675,7 @@ class ClientTest(IntegrationTest):
 
         assert exceptions[2] == {
             'message': 'the message of the group (4 sub-exceptions)',
-            'errorClass': 'builtins.ExceptionGroup',
+            'errorClass': 'ExceptionGroup',
             'type': 'python',
             'stacktrace': [
                 {


### PR DESCRIPTION
## Goal

Currently we report events from an `ExceptionGroup` with an error class of `builtins.ExceptionGroup`. This isn't _wrong_ but it is the only built-in exception that's displayed this way

This happens because the `ExceptionGroup` class is declared differently to other exception types as it uses the `PyErr_NewException` function. This requires a module name, which means `ExceptionGroup` can't just be called `ExceptionGroup` but must be `builtins.ExceptionGroup`

https://github.com/python/cpython/blob/878ead1ac1651965126322c1b3d124faf5484dc6/Objects/exceptions.c#L1475-L1476 https://github.com/python/cpython/blob/878ead1ac1651965126322c1b3d124faf5484dc6/Python/errors.c#L1137-L1138

`fully_qualified_class_name` is used for ignore_classes, but no other built-in exception has `builtins` as a module name, so we can safely ignore the `builtins` module without causing previously ignored errors to be reported