### PR TITLE
Fix `ExceptionGroup` support when there is also a `__cause__` or `__context__`

### DIFF
--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -266,8 +266,8 @@ class Event:
         # we don't recurse into nested BaseExceptionGroups or cause/context
         # here because there's a big risk of that leading to a huge number of
         # exceptions, which is difficult to reason about
-        if isinstance(exception, BaseExceptionGroup):
-            for sub_exception in exception.exceptions:  # type: ignore
+        if isinstance(self._original_error, BaseExceptionGroup):
+            for sub_exception in self._original_error.exceptions: # type: ignore # noqa
                 error_list.append(
                     Error(
                         class_name(sub_exception),

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -20,4 +20,5 @@ if sys.version_info >= (3, 11):
         exception_group_with_no_cause,
         base_exception_group_subclass,
         exception_group_with_nested_group,
+        exception_group_with_implicit_cause,
     )

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -21,4 +21,5 @@ if sys.version_info >= (3, 11):
         base_exception_group_subclass,
         exception_group_with_nested_group,
         exception_group_with_implicit_cause,
+        exception_group_with_explicit_cause,
     )

--- a/tests/fixtures/exception_groups.py
+++ b/tests/fixtures/exception_groups.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-
+from .caused_by import exception_with_explicit_cause
 # this creates an exception with a very small __traceback__, so it's easier to
 # assert against in tests
 def generate_exception(exception_class, message):
@@ -65,3 +65,20 @@ except BaseExceptionGroup as exception_group:
     exception_group_with_nested_group = exception_group
 
 
+def raise_exception_group_with_implicit_cause():
+    try:
+        raise_exception_group_with_nested_group()
+    except BaseExceptionGroup as exception_group:
+        raise ExceptionGroup(
+            'group with implicit cause',
+            [
+                exception_with_explicit_cause,
+                generate_exception(NameError, 'exception #2'),
+            ]
+        )
+
+
+try:
+    raise_exception_group_with_implicit_cause()
+except BaseExceptionGroup as exception_group:
+    exception_group_with_implicit_cause = exception_group

--- a/tests/fixtures/exception_groups.py
+++ b/tests/fixtures/exception_groups.py
@@ -82,3 +82,22 @@ try:
     raise_exception_group_with_implicit_cause()
 except BaseExceptionGroup as exception_group:
     exception_group_with_implicit_cause = exception_group
+
+
+def raise_exception_group_with_explicit_cause():
+    try:
+        raise_exception_group_with_implicit_cause()
+    except BaseExceptionGroup as exception_group:
+        raise ExceptionGroup(
+            'group with explicit cause',
+            [
+                generate_exception(NameError, 'exception #1'),
+                exception_with_explicit_cause,
+            ]
+        ) from exception_group
+
+
+try:
+    raise_exception_group_with_explicit_cause()
+except BaseExceptionGroup as exception_group:
+    exception_group_with_explicit_cause = exception_group

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1710,6 +1710,111 @@ class ClientTest(IntegrationTest):
             ]
         }
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 11),
+        reason="requires python 3.11 or higher"
+    )
+    def test_exception_group_implicit_cause_is_traversed(self):
+        # disable send_code so we can assert against stacktraces more easily
+        self.client.configuration.configure(send_code=False)
+
+        self.client.notify(fixtures.exception_group_with_implicit_cause)
+
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        exceptions = payload['events'][0]['exceptions']
+
+        print(exceptions)
+
+        # there should be 1 ExceptionGroup with 1 cause and 2 sub-exceptions
+        assert len(exceptions) == 4
+
+        # the ExceptionGroup
+        assert exceptions[0] == {
+            'message': 'group with implicit cause (2 sub-exceptions)',
+            'errorClass': 'ExceptionGroup',
+            'type': 'python',
+            'stacktrace': [
+                {
+                    'file': 'fixtures/exception_groups.py',
+                    'method': 'raise_exception_group_with_implicit_cause',
+                    'lineNumber': 72,
+                    'inProject': True,
+                    'code': None,
+                },
+                {
+                    'file': 'fixtures/exception_groups.py',
+                    'method': '<module>',
+                    'lineNumber': 82,
+                    'inProject': True,
+                    'code': None,
+                },
+            ],
+        }
+
+        # the cause - another ExceptionGroup
+        # note: we don't recurse into this!
+        assert exceptions[1] == {
+            'message': 'the message of the group (3 sub-exceptions)',
+            'errorClass': 'ExceptionGroup',
+            'type': 'python',
+            'stacktrace': [
+                {
+                    'file': 'fixtures/exception_groups.py',
+                    'method': 'raise_exception_group_with_nested_group',
+                    'lineNumber': 52,
+                    'inProject': True,
+                    'code': None,
+                },
+                {
+                    'file': 'fixtures/exception_groups.py',
+                    'method': 'raise_exception_group_with_implicit_cause',
+                    'lineNumber': 70,
+                    'inProject': True,
+                    'code': None,
+                },
+            ],
+        }
+
+        # the exceptions in the original ExceptionGroup
+        assert exceptions[2] == {
+            'message': 'a',
+            'errorClass': 'NameError',
+            'type': 'python',
+            'stacktrace': [
+                {
+                    'file': 'fixtures/caused_by.py',
+                    'method': 'raise_exception_with_explicit_cause',
+                    'lineNumber': 5,
+                    'inProject': True,
+                    'code': None,
+                },
+                {
+                    'file': 'fixtures/caused_by.py',
+                    'method': '<module>',
+                    'lineNumber': 20,
+                    'inProject': True,
+                    'code': None,
+                },
+            ],
+        }
+
+        assert exceptions[3] == {
+            'message': 'exception #2',
+            'errorClass': 'NameError',
+            'type': 'python',
+            'stacktrace': [
+                {
+                    'file': 'fixtures/exception_groups.py',
+                    'method': 'generate_exception',
+                    'lineNumber': 7,
+                    'inProject': True,
+                    'code': None,
+                },
+            ],
+        }
+
 
 @pytest.mark.parametrize("metadata,type", [
     (1234, 'int'),


### PR DESCRIPTION
## Goal

In #332 we now extract sub-exceptions from an `ExceptionGroup`, but this didn't work correctly when the group had a `__cause__` or `__context__`. This is because we re-use the `exception` variable when traversing the cause/context chain, so it would point to the wrong exception object when we checked for an `ExceptionGroup`

We now use the Event's `original_error` instead, which will always point to the reported exception object