### PR TITLE
Add exception notes as metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* The exception's `__notes__` field will now be sent as metadata if it exists
+  [#340](https://github.com/bugsnag/bugsnag-python/pull/340)
+
 ## v4.4.0 (2023-02-21)
 
 ### Enhancements

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -127,7 +127,7 @@ class Event:
         if hasattr(exception, "__notes__"):
             self.add_tab(
                 "exception notes",
-                dict(enumerate(exception.__notes__))
+                dict(enumerate(exception.__notes__)) # type: ignore # noqa
             )
 
     @property

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -124,6 +124,9 @@ class Event:
         for name, tab in options.items():
             self.add_tab(name, tab)
 
+        if hasattr(exception, "__notes__"):
+            self.add_tab("notes", dict(enumerate(exception.__notes__)))
+
     @property
     def meta_data(self) -> Dict[str, Dict[str, Any]]:
         warnings.warn('The Event "metadata" property has been replaced ' +

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -125,7 +125,10 @@ class Event:
             self.add_tab(name, tab)
 
         if hasattr(exception, "__notes__"):
-            self.add_tab("exception notes", dict(enumerate(exception.__notes__)))
+            self.add_tab(
+                "exception notes",
+                dict(enumerate(exception.__notes__))
+            )
 
     @property
     def meta_data(self) -> Dict[str, Dict[str, Any]]:

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -125,7 +125,7 @@ class Event:
             self.add_tab(name, tab)
 
         if hasattr(exception, "__notes__"):
-            self.add_tab("notes", dict(enumerate(exception.__notes__)))
+            self.add_tab("exception notes", dict(enumerate(exception.__notes__)))
 
     @property
     def meta_data(self) -> Dict[str, Dict[str, Any]]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1071,7 +1071,6 @@ class ClientTest(IntegrationTest):
         assert notes['0'] == "exception note 1"
         assert notes['1'] == "exception note 2"
 
-
     def test_chained_exceptions_with_explicit_cause_using_capture_cm(self):
         try:
             with self.client.capture():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1069,7 +1069,7 @@ class ClientTest(IntegrationTest):
 
         payload = self.server.received[0]['json_body']
         metadata = payload['events'][0]['metaData']
-        notes = metadata['notes']
+        notes = metadata['exception notes']
 
         assert len(notes) == 2
         assert notes['0'] == "exception note 1"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1056,6 +1056,22 @@ class ClientTest(IntegrationTest):
             }
         ]
 
+    def test_notes(self):
+        e = Exception("exception")
+        e.add_note("exception note 1")
+        e.add_note("exception note 2")
+        self.client.notify(e)
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        metadata = payload['events'][0]['metaData']
+        notes = metadata['notes']
+
+        assert len(notes) == 2
+        assert notes['0'] == "exception note 1"
+        assert notes['1'] == "exception note 2"
+
+
     def test_chained_exceptions_with_explicit_cause_using_capture_cm(self):
         try:
             with self.client.capture():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1056,6 +1056,10 @@ class ClientTest(IntegrationTest):
             }
         ]
 
+    @pytest.mark.skipif(
+         sys.version_info < (3, 11),
+         reason="requires BaseException.add_note (Python 3.11 or higher)"
+    )
     def test_notes(self):
         e = Exception("exception")
         e.add_note("exception note 1")


### PR DESCRIPTION
## Goal

Send new `__notes__` field added in https://peps.python.org/pep-0678/

## Changeset

Add a notes tab if the exception has a `__notes__` attribute.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
New `test_notes` test added to ensure that the notes are added to the payload's metadata.