### PR TITLE
Fix encoding identical siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fixes one of the fields being mistakenly replaced with `[RECURSIVE]` when encoding a list or dictionary with identical siblings but no recursion.
+  [#341](https://github.com/bugsnag/bugsnag-python/pull/341)
+
 ## v4.4.0 (2023-02-21)
 
 ### Enhancements

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -42,7 +42,7 @@ class BugsnagRequestHandler(RequestHandler):
         event.add_tab("request", request_tab)
 
         if bugsnag.configure().send_environment:
-            env = WSGIContainer.environ(self.request)
+            env = WSGIContainer(self.application).environ(self.request)
             event.add_tab("environment", env)
 
     def _handle_request_exception(self, exc: BaseException):

--- a/bugsnag/tornado/__init__.py
+++ b/bugsnag/tornado/__init__.py
@@ -42,7 +42,7 @@ class BugsnagRequestHandler(RequestHandler):
         event.add_tab("request", request_tab)
 
         if bugsnag.configure().send_environment:
-            env = WSGIContainer(self.application).environ(self.request)
+            env = WSGIContainer.environ(self.request)
             event.add_tab("environment", env)
 
     def _handle_request_exception(self, exc: BaseException):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -204,6 +204,18 @@ class TestUtils(unittest.TestCase):
         sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data,
                          {"Test": ["a", "b", "c"], "Self": "[RECURSIVE]"})
+        
+    def test_encoding_identical_siblings(self):
+        """
+        Test encoding identical siblings
+        """
+        inner_list = [1,2,3]
+        nested_list = [inner_list, inner_list]
+        data = {"nested0": nested_list, "nested1": nested_list, "inner": inner_list}
+        encoder = SanitizingJSONEncoder(logger, keyword_filters=[])
+        sane_data = json.loads(encoder.encode(data))
+        self.assertEqual(sane_data,
+                         {"0": nested_list, "1": nested_list, "inner": inner_list})
 
     def test_encoding_nested_repeated(self):
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -204,18 +204,22 @@ class TestUtils(unittest.TestCase):
         sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data,
                          {"Test": ["a", "b", "c"], "Self": "[RECURSIVE]"})
-        
+
     def test_encoding_identical_siblings(self):
         """
         Test encoding identical siblings
         """
-        inner_list = [1,2,3]
+        inner_list = [1, 2, 3]
         nested_list = [inner_list, inner_list]
-        data = {"nested0": nested_list, "nested1": nested_list, "inner": inner_list}
+        data = {"nested0": nested_list,
+                "nested1": nested_list,
+                "inner": inner_list}
         encoder = SanitizingJSONEncoder(logger, keyword_filters=[])
         sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data,
-                         {"nested0": nested_list, "nested1": nested_list, "inner": inner_list})
+                         {"nested0": nested_list,
+                          "nested1": nested_list,
+                          "inner": inner_list})
 
     def test_encoding_nested_repeated(self):
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -215,7 +215,7 @@ class TestUtils(unittest.TestCase):
         encoder = SanitizingJSONEncoder(logger, keyword_filters=[])
         sane_data = json.loads(encoder.encode(data))
         self.assertEqual(sane_data,
-                         {"0": nested_list, "1": nested_list, "inner": inner_list})
+                         {"nested0": nested_list, "nested1": nested_list, "inner": inner_list})
 
     def test_encoding_nested_repeated(self):
         """


### PR DESCRIPTION
## Goal

Currently when encoding a list or dictionary with identical siblings but no recursion, one of the fields is mistakenly replaced with `[RECURSIVE]`.

## Design

After finishing encoding an object, it is removed from the ignored list.

## Changeset

Identical sibling objects are now properly encoded.

## Testing

New `test_encoding_identical_siblings` test added.
<!-- How was it tested? What manual and automated tests were
     run/added? -->