### PR TITLE
Ignore nested classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+* Fix the ignore class list not accounting for nested classes
+  [#342](https://github.com/bugsnag/bugsnag-python/pull/342)
+
 ## v4.4.0 (2023-02-21)
 
 ### Enhancements

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -20,9 +20,12 @@ from bugsnag.middleware import (
     MiddlewareStack,
     skip_bugsnag_middleware
 )
-from bugsnag.utils import (fully_qualified_class_name, validate_str_setter,
-                           validate_bool_setter, validate_iterable_setter,
-                           validate_required_str_setter, validate_int_setter)
+from bugsnag.utils import (fully_qualified_class_name,
+                           partly_qualified_class_name,
+                           validate_str_setter, validate_bool_setter,
+                           validate_iterable_setter,
+                           validate_required_str_setter,
+                           validate_int_setter)
 from bugsnag.delivery import (create_default_delivery, DEFAULT_ENDPOINT,
                               DEFAULT_SESSIONS_ENDPOINT)
 from bugsnag.uwsgi import warn_if_running_uwsgi_without_threads
@@ -521,7 +524,8 @@ class Configuration:
         if isinstance(exception, list):
             return any(e.error_class in self.ignore_classes for e in exception)
 
-        return fully_qualified_class_name(exception) in self.ignore_classes
+        return (fully_qualified_class_name(exception) in self.ignore_classes or
+                partly_qualified_class_name(exception) in self.ignore_classes)
 
     def _create_default_logger(self) -> logging.Logger:
         logger = logging.getLogger('bugsnag')

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -243,13 +243,26 @@ def is_json_content_type(value: str) -> bool:
 _ignore_modules = ('__main__', 'builtins')
 
 
-def fully_qualified_class_name(obj):
+def partly_qualified_class_name(obj):
     module = inspect.getmodule(obj)
 
     if module is None or module.__name__ in _ignore_modules:
         return obj.__class__.__name__
 
     return module.__name__ + '.' + obj.__class__.__name__
+
+
+def fully_qualified_class_name(obj):
+    module = inspect.getmodule(obj)
+    if hasattr(obj.__class__, "__qualname__"):
+        qualified_name = obj.__class__.__qualname__
+    else:
+        qualified_name = obj.__class__.__name__
+
+    if module is None or module.__name__ in _ignore_modules:
+        return qualified_name
+
+    return module.__name__ + '.' + qualified_name
 
 
 def package_version(package_name):

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -182,6 +182,12 @@ class TestBugsnag(IntegrationTest):
         bugsnag.notify(ScaryException('unexpected failover'))
         self.assertEqual(0, len(self.server.received))
 
+    def test_notify_ignore_class_nested(self):
+        bugsnag.configure(
+            ignore_classes=['tests.utils.ScaryException.NestedScaryException'])
+        bugsnag.notify(ScaryException.NestedScaryException('nested'))
+        self.assertEqual(0, len(self.server.received))
+
     def test_ignore_classes_checks_exception_chain_with_explicit_cause(self):
         bugsnag.configure(ignore_classes=['ArithmeticError'])
         bugsnag.notify(fixtures.exception_with_explicit_cause)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -130,4 +130,5 @@ class FakeBugsnagServer(object):
 
 
 class ScaryException(Exception):
-    pass
+    class NestedScaryException(Exception):
+        pass


### PR DESCRIPTION
## Goal

The ignore classes does not account for nested classes

## Design

Check both the legacy `partly_qualified_class_name` and the new `fully_qualified_class_name` based on `__qualname__` for backwards compatibility.

## Changeset

<!-- What changed? -->

## Testing

New test to check matching the fully qualified class name.