### PR TITLE
Accept PathLike as project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
 * Allows changing the grouping hash when using `BugsnagHandler` via the logger methods' `extra` keyword argument
   [#334](https://github.com/bugsnag/bugsnag-python/pull/334)
 
+* PathLike objects are now accepted as the project path
+  [#344](https://github.com/bugsnag/bugsnag-python/pull/344)
+
 ### Bug fixes
 
 * Fixes one of the fields being mistakenly replaced with `[RECURSIVE]` when encoding a list or dictionary with identical siblings but no recursion.

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -8,7 +8,6 @@ import warnings
 import logging
 from threading import Lock
 
-from pathlib import PurePath
 from bugsnag.breadcrumbs import (
     BreadcrumbType,
     Breadcrumb,
@@ -42,6 +41,14 @@ try:
 except ImportError:
     from bugsnag.utils import ThreadContextVar
     _request_info = ThreadContextVar('bugsnag-request', default=None)  # type: ignore  # noqa: E501
+
+
+try:
+    from os import PathLike
+except ImportError:
+    # PathLike was added in Python 3.6 so fallback to PurePath on Python 3.5 as
+    # all builtin Path objects inherit from PurePath
+    from pathlib import PurePath as PathLike  # type: ignore
 
 
 __all__ = ('Configuration', 'RequestConfiguration')
@@ -371,7 +378,7 @@ class Configuration:
 
     @project_root.setter  # type: ignore
     @validate_path_setter
-    def project_root(self, value: Union[str, PurePath]):
+    def project_root(self, value: Union[str, PathLike]):
         self._project_root = str(value)
 
     @property

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -8,6 +8,7 @@ import warnings
 import logging
 from threading import Lock
 
+from os import PathLike
 from bugsnag.breadcrumbs import (
     BreadcrumbType,
     Breadcrumb,
@@ -20,12 +21,16 @@ from bugsnag.middleware import (
     MiddlewareStack,
     skip_bugsnag_middleware
 )
-from bugsnag.utils import (fully_qualified_class_name,
-                           partly_qualified_class_name,
-                           validate_str_setter, validate_bool_setter,
-                           validate_iterable_setter,
-                           validate_required_str_setter,
-                           validate_int_setter)
+from bugsnag.utils import (
+    fully_qualified_class_name,
+    partly_qualified_class_name,
+    validate_str_setter,
+    validate_bool_setter,
+    validate_iterable_setter,
+    validate_required_str_setter,
+    validate_int_setter,
+    validate_path_setter
+)
 from bugsnag.delivery import (create_default_delivery, DEFAULT_ENDPOINT,
                               DEFAULT_SESSIONS_ENDPOINT)
 from bugsnag.uwsgi import warn_if_running_uwsgi_without_threads
@@ -365,9 +370,9 @@ class Configuration:
         return self._project_root
 
     @project_root.setter  # type: ignore
-    @validate_str_setter
-    def project_root(self, value: str):
-        self._project_root = value
+    @validate_path_setter
+    def project_root(self, value: Union[str, PathLike]):
+        self._project_root = str(value)
 
     @property
     def proxy_host(self):

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -8,7 +8,7 @@ import warnings
 import logging
 from threading import Lock
 
-from os import PathLike
+from pathlib import PurePath
 from bugsnag.breadcrumbs import (
     BreadcrumbType,
     Breadcrumb,
@@ -371,7 +371,7 @@ class Configuration:
 
     @project_root.setter  # type: ignore
     @validate_path_setter
-    def project_root(self, value: Union[str, PathLike]):
+    def project_root(self, value: Union[str, PurePath]):
         self._project_root = str(value)
 
     @property

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -8,6 +8,7 @@ import copy
 import logging
 from datetime import datetime, timedelta
 from urllib.parse import urlparse, urlunsplit, parse_qs
+from os import PathLike
 
 MAX_PAYLOAD_LENGTH = 128 * 1024
 MAX_STRING_LENGTH = 1024
@@ -318,6 +319,7 @@ validate_required_str_setter = partial(_validate_setter, (str,),
 validate_bool_setter = partial(_validate_setter, (bool,))
 validate_iterable_setter = partial(_validate_setter, (list, tuple))
 validate_int_setter = partial(_validate_setter, (int,))
+validate_path_setter = partial(_validate_setter, (str, PathLike))
 
 
 class ThreadContextVar:

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -8,7 +8,15 @@ import copy
 import logging
 from datetime import datetime, timedelta
 from urllib.parse import urlparse, urlunsplit, parse_qs
-from pathlib import PurePath
+
+
+try:
+    from os import PathLike
+except ImportError:
+    # PathLike was added in Python 3.6 so fallback to PurePath on Python 3.5 as
+    # all builtin Path objects inherit from PurePath
+    from pathlib import PurePath as PathLike  # type: ignore
+
 
 MAX_PAYLOAD_LENGTH = 128 * 1024
 MAX_STRING_LENGTH = 1024
@@ -319,7 +327,7 @@ validate_required_str_setter = partial(_validate_setter, (str,),
 validate_bool_setter = partial(_validate_setter, (bool,))
 validate_iterable_setter = partial(_validate_setter, (list, tuple))
 validate_int_setter = partial(_validate_setter, (int,))
-validate_path_setter = partial(_validate_setter, (str, PurePath))
+validate_path_setter = partial(_validate_setter, (str, PathLike))
 
 
 class ThreadContextVar:

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -8,7 +8,7 @@ import copy
 import logging
 from datetime import datetime, timedelta
 from urllib.parse import urlparse, urlunsplit, parse_qs
-from os import PathLike
+from pathlib import PurePath
 
 MAX_PAYLOAD_LENGTH = 128 * 1024
 MAX_STRING_LENGTH = 1024
@@ -319,7 +319,7 @@ validate_required_str_setter = partial(_validate_setter, (str,),
 validate_bool_setter = partial(_validate_setter, (bool,))
 validate_iterable_setter = partial(_validate_setter, (list, tuple))
 validate_int_setter = partial(_validate_setter, (int,))
-validate_path_setter = partial(_validate_setter, (str, PathLike))
+validate_path_setter = partial(_validate_setter, (str, PurePath))
 
 
 class ThreadContextVar:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,6 +4,7 @@ import logging
 import random
 import time
 import unittest
+from pathlib import PurePath, Path
 from unittest.mock import patch
 from io import StringIO
 from threading import Thread
@@ -292,13 +293,24 @@ class TestConfiguration(unittest.TestCase):
 
             assert len(record) == 1
             assert (str(record[0].message) ==
-                    'project_root should be str, got bool')
+                    'project_root should be str or PathLike, got bool')
             assert c.project_root == os.getcwd()
 
             c.configure(project_root='/path/to/python/project')
 
             assert len(record) == 1
             assert c.project_root == '/path/to/python/project'
+
+            c.configure(project_root=Path('/path/to/python/project'))
+
+            assert len(record) == 1
+            assert c.project_root == '/path/to/python/project'
+
+            c.configure(project_root=PurePath('/path/to/python/project'))
+
+            assert len(record) == 1
+            assert c.project_root == '/path/to/python/project'
+
 
     def test_validate_proxy_host(self):
         c = Configuration()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,6 +2,7 @@ import os
 import socket
 import logging
 import random
+import sys
 import time
 import unittest
 from pathlib import PurePath, Path
@@ -288,12 +289,18 @@ class TestConfiguration(unittest.TestCase):
 
     def test_validate_project_root(self):
         c = Configuration()
+
+        if sys.version_info < (3, 6):
+            expected_type = 'PurePath'
+        else:
+            expected_type = 'PathLike'
+
         with pytest.warns(RuntimeWarning) as record:
             c.configure(project_root=True)
 
             assert len(record) == 1
-            assert (str(record[0].message) ==
-                    'project_root should be str or PurePath, got bool')
+            assert str(record[0].message) == \
+                'project_root should be str or %s, got bool' % expected_type
             assert c.project_root == os.getcwd()
 
             c.configure(project_root='/path/to/python/project')

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -311,7 +311,6 @@ class TestConfiguration(unittest.TestCase):
             assert len(record) == 1
             assert c.project_root == '/path/to/python/project'
 
-
     def test_validate_proxy_host(self):
         c = Configuration()
         with pytest.warns(RuntimeWarning) as record:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -293,7 +293,7 @@ class TestConfiguration(unittest.TestCase):
 
             assert len(record) == 1
             assert (str(record[0].message) ==
-                    'project_root should be str or PathLike, got bool')
+                    'project_root should be str or PurePath, got bool')
             assert c.project_root == os.getcwd()
 
             c.configure(project_root='/path/to/python/project')

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -5,6 +5,7 @@ import time
 
 import pytest
 import bugsnag
+from pathlib import Path
 from tests import fixtures
 from tests.utils import ScaryException, IntegrationTest
 from tests.fixtures import samples
@@ -175,7 +176,7 @@ class TestBugsnag(IntegrationTest):
 
         self.assertEqual(4, event['metaData']['custom']['foo'])
         self.assertEqual('[FILTERED]', event['metaData']['custom']['bar'])
-        self.assertEqual(170, exception['stacktrace'][0]['lineNumber'])
+        self.assertEqual(171, exception['stacktrace'][0]['lineNumber'])
 
     def test_notify_ignore_class(self):
         bugsnag.configure(ignore_classes=['tests.utils.ScaryException'])
@@ -314,6 +315,15 @@ class TestBugsnag(IntegrationTest):
         json_body = self.server.received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('/the/basement', event['projectRoot'])
+
+    def test_notify_configured_project_root_using_path_object(self):
+        bugsnag.configure(project_root=Path('/the/basement'))
+        bugsnag.notify(ScaryException('unexpected failover'))
+
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+
+        assert event['projectRoot'] == '/the/basement'
 
     def test_notify_invalid_severity(self):
         bugsnag.notify(ScaryException('unexpected failover'),


### PR DESCRIPTION
## Goal

Currently if a PathLike object is passed in such as PurePath or Path from pathlib, the path will not be set and a warning is produced. The PathLike object should be converted to a string and accepted.

## Changeset

* PathLike objects are now accepted
* Warning message for invalid paths has changed

## Testing

Modification to `test_validate_project_root` to ensure that PathLike objects are accepted and converted to strings.