### PR TITLE
Release v4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,31 @@
 Changelog
 =========
 
-## TBD
+## v4.5.0 (2023-07-17)
 
 ### Enhancements
 
 * The exception's `__notes__` field will now be sent as metadata if it exists
   [#340](https://github.com/bugsnag/bugsnag-python/pull/340)
+  [0HyperCube](https://github.com/0HyperCube)
 
 * Allows changing the grouping hash when using `BugsnagHandler` via the logger methods' `extra` keyword argument
   [#334](https://github.com/bugsnag/bugsnag-python/pull/334)
+  [0HyperCube](https://github.com/0HyperCube)
 
 * PathLike objects are now accepted as the project path
   [#344](https://github.com/bugsnag/bugsnag-python/pull/344)
+  [0HyperCube](https://github.com/0HyperCube)
 
 ### Bug fixes
 
 * Fixes one of the fields being mistakenly replaced with `[RECURSIVE]` when encoding a list or dictionary with identical siblings but no recursion.
   [#341](https://github.com/bugsnag/bugsnag-python/pull/341)
+  [0HyperCube](https://github.com/0HyperCube)
 
 * Fix the ignore class list not accounting for nested classes
   [#342](https://github.com/bugsnag/bugsnag-python/pull/342)
-
+  [0HyperCube](https://github.com/0HyperCube)
 
 ## v4.4.0 (2023-02-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Enhancements
 
+* The exception's `__notes__` field will now be sent as metadata if it exists
+  [#340](https://github.com/bugsnag/bugsnag-python/pull/340)
+
 * Allows changing the grouping hash when using `BugsnagHandler` via the logger methods' `extra` keyword argument
   [#334](https://github.com/bugsnag/bugsnag-python/pull/334)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## TBD
 
+### Enhancements
+
+* Allows changing the grouping hash when using `BugsnagHandler` via the logger methods' `extra` keyword argument
+  [#334](https://github.com/bugsnag/bugsnag-python/pull/334)
+
 ### Bug fixes
 
 * Fixes one of the fields being mistakenly replaced with `[RECURSIVE]` when encoding a list or dictionary with identical siblings but no recursion.
@@ -10,6 +15,7 @@ Changelog
 
 * Fix the ignore class list not accounting for nested classes
   [#342](https://github.com/bugsnag/bugsnag-python/pull/342)
+
 
 ## v4.4.0 (2023-02-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
 * Allows changing the grouping hash when using `BugsnagHandler` via the logger methods' `extra` keyword argument
   [#334](https://github.com/bugsnag/bugsnag-python/pull/334)
 
+* PathLike objects are now accepted as the project path
+  [#344](https://github.com/bugsnag/bugsnag-python/pull/344)
+
 ### Bug fixes
 
 * Fixes one of the fields being mistakenly replaced with `[RECURSIVE]` when encoding a list or dictionary with identical siblings but no recursion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 ## TBD
 
 ### Bug fixes
+
+* Fixes one of the fields being mistakenly replaced with `[RECURSIVE]` when encoding a list or dictionary with identical siblings but no recursion.
+  [#341](https://github.com/bugsnag/bugsnag-python/pull/341)
+
 * Fix the ignore class list not accounting for nested classes
   [#342](https://github.com/bugsnag/bugsnag-python/pull/342)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+* Fix the ignore class list not accounting for nested classes
+  [#342](https://github.com/bugsnag/bugsnag-python/pull/342)
+
 ## v4.4.0 (2023-02-21)
 
 ### Enhancements

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -20,9 +20,12 @@ from bugsnag.middleware import (
     MiddlewareStack,
     skip_bugsnag_middleware
 )
-from bugsnag.utils import (fully_qualified_class_name, validate_str_setter,
-                           validate_bool_setter, validate_iterable_setter,
-                           validate_required_str_setter, validate_int_setter)
+from bugsnag.utils import (fully_qualified_class_name,
+                           partly_qualified_class_name,
+                           validate_str_setter, validate_bool_setter,
+                           validate_iterable_setter,
+                           validate_required_str_setter,
+                           validate_int_setter)
 from bugsnag.delivery import (create_default_delivery, DEFAULT_ENDPOINT,
                               DEFAULT_SESSIONS_ENDPOINT)
 from bugsnag.uwsgi import warn_if_running_uwsgi_without_threads
@@ -521,7 +524,8 @@ class Configuration:
         if isinstance(exception, list):
             return any(e.error_class in self.ignore_classes for e in exception)
 
-        return fully_qualified_class_name(exception) in self.ignore_classes
+        return (fully_qualified_class_name(exception) in self.ignore_classes or
+                partly_qualified_class_name(exception) in self.ignore_classes)
 
     def _create_default_logger(self) -> logging.Logger:
         logger = logging.getLogger('bugsnag')

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -20,12 +20,16 @@ from bugsnag.middleware import (
     MiddlewareStack,
     skip_bugsnag_middleware
 )
-from bugsnag.utils import (fully_qualified_class_name,
-                           partly_qualified_class_name,
-                           validate_str_setter, validate_bool_setter,
-                           validate_iterable_setter,
-                           validate_required_str_setter,
-                           validate_int_setter)
+from bugsnag.utils import (
+    fully_qualified_class_name,
+    partly_qualified_class_name,
+    validate_str_setter,
+    validate_bool_setter,
+    validate_iterable_setter,
+    validate_required_str_setter,
+    validate_int_setter,
+    validate_path_setter
+)
 from bugsnag.delivery import (create_default_delivery, DEFAULT_ENDPOINT,
                               DEFAULT_SESSIONS_ENDPOINT)
 from bugsnag.uwsgi import warn_if_running_uwsgi_without_threads
@@ -37,6 +41,14 @@ try:
 except ImportError:
     from bugsnag.utils import ThreadContextVar
     _request_info = ThreadContextVar('bugsnag-request', default=None)  # type: ignore  # noqa: E501
+
+
+try:
+    from os import PathLike
+except ImportError:
+    # PathLike was added in Python 3.6 so fallback to PurePath on Python 3.5 as
+    # all builtin Path objects inherit from PurePath
+    from pathlib import PurePath as PathLike  # type: ignore
 
 
 __all__ = ('Configuration', 'RequestConfiguration')
@@ -365,9 +377,9 @@ class Configuration:
         return self._project_root
 
     @project_root.setter  # type: ignore
-    @validate_str_setter
-    def project_root(self, value: str):
-        self._project_root = value
+    @validate_path_setter
+    def project_root(self, value: Union[str, PathLike]):
+        self._project_root = str(value)
 
     @property
     def proxy_host(self):

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -124,6 +124,12 @@ class Event:
         for name, tab in options.items():
             self.add_tab(name, tab)
 
+        if hasattr(exception, "__notes__"):
+            self.add_tab(
+                "exception notes",
+                dict(enumerate(exception.__notes__)) # type: ignore # noqa
+            )
+
     @property
     def meta_data(self) -> Dict[str, Dict[str, Any]]:
         warnings.warn('The Event "meta_data" property has been replaced ' +

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -113,7 +113,7 @@ class Event:
 
         self.metadata = {}  # type: Dict[str, Dict[str, Any]]
         if 'meta_data' in options:
-            warnings.warn('The Event "metadata" argument has been replaced ' +
+            warnings.warn('The Event "meta_data" argument has been replaced ' +
                           'with "metadata"', DeprecationWarning)
             for name, tab in options.pop("meta_data").items():
                 self.add_tab(name, tab)
@@ -126,8 +126,8 @@ class Event:
 
     @property
     def meta_data(self) -> Dict[str, Dict[str, Any]]:
-        warnings.warn('The Event "metadata" property has been replaced ' +
-                      'with "meta_data".', DeprecationWarning)
+        warnings.warn('The Event "meta_data" property has been replaced ' +
+                      'with "metadata".', DeprecationWarning)
         return self.metadata
 
     @property

--- a/bugsnag/handlers.py
+++ b/bugsnag/handlers.py
@@ -18,7 +18,8 @@ class BugsnagHandler(logging.Handler, object):
         self.custom_metadata_fields = extra_fields
         self.callbacks = [self.extract_default_metadata,
                           self.extract_custom_metadata,
-                          self.extract_severity]
+                          self.extract_severity,
+                          self.extract_grouping_hash]
 
     def emit(self, record: LogRecord):
         """
@@ -112,6 +113,13 @@ class BugsnagHandler(logging.Handler, object):
             options['severity'] = 'warning'
         else:
             options['severity'] = 'info'
+
+    def extract_grouping_hash(self, record: LogRecord, options: Dict):
+        """
+        Add the grouping_hash from a log record to the options
+        """
+        if 'groupingHash' in record.__dict__:
+            options['grouping_hash'] = record.__dict__['groupingHash']
 
     def extract_custom_metadata(self, record: LogRecord, options: Dict):
         """

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -243,13 +243,26 @@ def is_json_content_type(value: str) -> bool:
 _ignore_modules = ('__main__', 'builtins')
 
 
-def fully_qualified_class_name(obj):
+def partly_qualified_class_name(obj):
     module = inspect.getmodule(obj)
 
     if module is None or module.__name__ in _ignore_modules:
         return obj.__class__.__name__
 
     return module.__name__ + '.' + obj.__class__.__name__
+
+
+def fully_qualified_class_name(obj):
+    module = inspect.getmodule(obj)
+    if hasattr(obj.__class__, "__qualname__"):
+        qualified_name = obj.__class__.__qualname__
+    else:
+        qualified_name = obj.__class__.__name__
+
+    if module is None or module.__name__ in _ignore_modules:
+        return qualified_name
+
+    return module.__name__ + '.' + qualified_name
 
 
 def package_version(package_name):

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -9,6 +9,15 @@ import logging
 from datetime import datetime, timedelta
 from urllib.parse import urlparse, urlunsplit, parse_qs
 
+
+try:
+    from os import PathLike
+except ImportError:
+    # PathLike was added in Python 3.6 so fallback to PurePath on Python 3.5 as
+    # all builtin Path objects inherit from PurePath
+    from pathlib import PurePath as PathLike  # type: ignore
+
+
 MAX_PAYLOAD_LENGTH = 128 * 1024
 MAX_STRING_LENGTH = 1024
 
@@ -318,6 +327,7 @@ validate_required_str_setter = partial(_validate_setter, (str,),
 validate_bool_setter = partial(_validate_setter, (bool,))
 validate_iterable_setter = partial(_validate_setter, (list, tuple))
 validate_int_setter = partial(_validate_setter, (int,))
+validate_path_setter = partial(_validate_setter, (str, PathLike))
 
 
 class ThreadContextVar:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='bugsnag',
-    version='4.4.0',
+    version='4.5.0',
     description='Automatic error monitoring for django, flask, etc.',
     long_description=__doc__,
     author='Simon Maynard',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1056,6 +1056,25 @@ class ClientTest(IntegrationTest):
             }
         ]
 
+    @pytest.mark.skipif(
+         sys.version_info < (3, 11),
+         reason="requires BaseException.add_note (Python 3.11 or higher)"
+    )
+    def test_notes(self):
+        e = Exception("exception")
+        e.add_note("exception note 1")
+        e.add_note("exception note 2")
+        self.client.notify(e)
+        assert self.sent_report_count == 1
+
+        payload = self.server.received[0]['json_body']
+        metadata = payload['events'][0]['metaData']
+        notes = metadata['exception notes']
+
+        assert len(notes) == 2
+        assert notes['0'] == "exception note 1"
+        assert notes['1'] == "exception note 2"
+
     def test_chained_exceptions_with_explicit_cause_using_capture_cm(self):
         try:
             with self.client.capture():

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -358,7 +358,7 @@ class TestEvent(unittest.TestCase):
 
             assert len(records) > 0
             i = len(records) - 1
-            assert str(records[i].message) == ('The Event "metadata" ' +
+            assert str(records[i].message) == ('The Event "meta_data" ' +
                                                'argument has been replaced ' +
                                                'with "metadata"')
             assert event.metadata['nuts']['almonds']

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -458,6 +458,18 @@ class HandlersTest(IntegrationTest):
                          {'exception': 'metadata'})
 
     @use_client_logger
+    def test_logging_grouping_hash(self, handler, logger):
+        logger.info("This happened", extra={'groupingHash': '<hash value>'})
+
+        self.assertSentReportCount(1)
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+        exception = event['exceptions'][0]
+
+        self.assertEqual(exception['message'], 'This happened')
+        self.assertEqual(event['groupingHash'], '<hash value>')
+
+    @use_client_logger
     def test_log_filter_leaves_breadcrumbs_for_logs_below_report_level(
         self,
         handler,

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -5,6 +5,7 @@ import time
 
 import pytest
 import bugsnag
+from pathlib import Path
 from tests import fixtures
 from tests.utils import ScaryException, IntegrationTest
 from tests.fixtures import samples
@@ -175,7 +176,7 @@ class TestBugsnag(IntegrationTest):
 
         self.assertEqual(4, event['metaData']['custom']['foo'])
         self.assertEqual('[FILTERED]', event['metaData']['custom']['bar'])
-        self.assertEqual(170, exception['stacktrace'][0]['lineNumber'])
+        self.assertEqual(171, exception['stacktrace'][0]['lineNumber'])
 
     def test_notify_ignore_class(self):
         bugsnag.configure(ignore_classes=['tests.utils.ScaryException'])
@@ -314,6 +315,15 @@ class TestBugsnag(IntegrationTest):
         json_body = self.server.received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('/the/basement', event['projectRoot'])
+
+    def test_notify_configured_project_root_using_path_object(self):
+        bugsnag.configure(project_root=Path('/the/basement'))
+        bugsnag.notify(ScaryException('unexpected failover'))
+
+        json_body = self.server.received[0]['json_body']
+        event = json_body['events'][0]
+
+        assert event['projectRoot'] == '/the/basement'
 
     def test_notify_invalid_severity(self):
         bugsnag.notify(ScaryException('unexpected failover'),

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -182,6 +182,12 @@ class TestBugsnag(IntegrationTest):
         bugsnag.notify(ScaryException('unexpected failover'))
         self.assertEqual(0, len(self.server.received))
 
+    def test_notify_ignore_class_nested(self):
+        bugsnag.configure(
+            ignore_classes=['tests.utils.ScaryException.NestedScaryException'])
+        bugsnag.notify(ScaryException.NestedScaryException('nested'))
+        self.assertEqual(0, len(self.server.received))
+
     def test_ignore_classes_checks_exception_chain_with_explicit_cause(self):
         bugsnag.configure(ignore_classes=['ArithmeticError'])
         bugsnag.notify(fixtures.exception_with_explicit_cause)

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -843,7 +843,7 @@ class TestBugsnag(IntegrationTest):
                            meta_data={'fruit': {'apples': 2}})
 
             assert len(records) == 1
-            assert str(records[0].message) == ('The Event "metadata" ' +
+            assert str(records[0].message) == ('The Event "meta_data" ' +
                                                'argument has been replaced ' +
                                                'with "metadata"')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -205,6 +205,22 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(sane_data,
                          {"Test": ["a", "b", "c"], "Self": "[RECURSIVE]"})
 
+    def test_encoding_identical_siblings(self):
+        """
+        Test encoding identical siblings
+        """
+        inner_list = [1, 2, 3]
+        nested_list = [inner_list, inner_list]
+        data = {"nested0": nested_list,
+                "nested1": nested_list,
+                "inner": inner_list}
+        encoder = SanitizingJSONEncoder(logger, keyword_filters=[])
+        sane_data = json.loads(encoder.encode(data))
+        self.assertEqual(sane_data,
+                         {"nested0": nested_list,
+                          "nested1": nested_list,
+                          "inner": inner_list})
+
     def test_encoding_nested_repeated(self):
         """
         Test that encoding the same object within a new object is not

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -130,4 +130,5 @@ class FakeBugsnagServer(object):
 
 
 class ScaryException(Exception):
-    pass
+    class NestedScaryException(Exception):
+        pass


### PR DESCRIPTION
### Enhancements

* The exception's `__notes__` field will now be sent as metadata if it exists
  [#340](https://github.com/bugsnag/bugsnag-python/pull/340)
  [0HyperCube](https://github.com/0HyperCube)

* Allows changing the grouping hash when using `BugsnagHandler` via the logger methods' `extra` keyword argument
  [#334](https://github.com/bugsnag/bugsnag-python/pull/334)
  [0HyperCube](https://github.com/0HyperCube)

* PathLike objects are now accepted as the project path
  [#344](https://github.com/bugsnag/bugsnag-python/pull/344)
  [0HyperCube](https://github.com/0HyperCube)

### Bug fixes

* Fixes one of the fields being mistakenly replaced with `[RECURSIVE]` when encoding a list or dictionary with identical siblings but no recursion.
  [#341](https://github.com/bugsnag/bugsnag-python/pull/341)
  [0HyperCube](https://github.com/0HyperCube)

* Fix the ignore class list not accounting for nested classes
  [#342](https://github.com/bugsnag/bugsnag-python/pull/342)
  [0HyperCube](https://github.com/0HyperCube)