### PR TITLE
Implement __eq__ for FeatureFlag

### DIFF
--- a/bugsnag/feature_flags.py
+++ b/bugsnag/feature_flags.py
@@ -36,6 +36,18 @@ class FeatureFlag:
             (self._variant is None or isinstance(self._variant, (str, bytes)))
         )
 
+    def __eq__(self, other) -> bool:
+        if isinstance(other, FeatureFlag):
+            return (
+                self._name == other._name and
+                self._variant == other._variant
+            )
+
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self._name, self._variant))
+
     def _coerce_variant(
         self,
         variant: Union[None, str, bytes]

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -92,6 +92,26 @@ def test_a_feature_flag_with_none_name_is_not_valid():
     assert flag.is_valid() is False
 
 
+def test_feature_flags_are_comparable():
+    flag1 = FeatureFlag('a')
+    flag2 = FeatureFlag('b', 'x')
+    flag3 = FeatureFlag('c')
+
+    assert flag1 == FeatureFlag('a')
+    assert flag2 == FeatureFlag('b', 'x')
+    assert flag3 == FeatureFlag('c')
+
+    assert flag1 != FeatureFlag('a', '1')
+    assert flag2 != FeatureFlag('b')
+
+    assert flag1 != flag2
+    assert flag1 != flag3
+    assert flag2 != flag3
+
+    assert flag1 != 'a'
+    assert flag1 is not None
+
+
 def test_delegate_contains_no_flags_by_default():
     delegate = FeatureFlagDelegate()
 

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -387,28 +387,23 @@ def test_delegate_clear_does_nothing_when_there_are_no_flags():
 
 def test_delegate_to_list_returns_a_list_of_feature_flags():
     delegate = FeatureFlagDelegate()
+    delegate.merge([FeatureFlag('a'), FeatureFlag('b'), FeatureFlag('c')])
 
-    flag1 = FeatureFlag('a')
-    flag2 = FeatureFlag('b')
-    flag3 = FeatureFlag('c')
-
-    delegate.merge([flag1, flag2, flag3])
-
-    assert delegate.to_list() == [flag1, flag2, flag3]
+    assert delegate.to_list() == [
+        FeatureFlag('a'),
+        FeatureFlag('b'),
+        FeatureFlag('c')
+    ]
 
 
 def test_delegate_can_be_mutated_without_affecting_the_internal_storage():
     delegate = FeatureFlagDelegate()
-
-    flag1 = FeatureFlag('a')
-    flag2 = FeatureFlag('b')
-
-    delegate.merge([flag1, flag2])
+    delegate.merge([FeatureFlag('a'), FeatureFlag('b')])
 
     flags = delegate.to_list()
     flags.pop()
     flags.append(1234)
     flags.append(5678)
 
-    assert flags == [flag1, 1234, 5678]
-    assert delegate.to_list() == [flag1, flag2]
+    assert flags == [FeatureFlag('a'), 1234, 5678]
+    assert delegate.to_list() == [FeatureFlag('a'), FeatureFlag('b')]


### PR DESCRIPTION
## Goal

Implement `__eq__` for `FeatureFlag` so that they are compared by name & variant, rather than by object identity

This is primarily to make the unit tests easier to write but could also be helpful in callbacks for the same reasons — it makes comparing feature flags easier:

```python
flag1 = FeatureFlag('a', '1')
flag2 = FeatureFlag('b', '2')

# without this change:
flags_are_equal = flag1.name == flag2.name and flag1.variant == flag2.variant

# with this change:
flags_are_equal = flag1 == flag2
```