### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         pyversion=${{ matrix.python-version }}
         TOXFACTOR=${pyversion//.0-*/}
-        tox -f py${TOXFACTOR//./} --parallel --quiet
+        tox -f py${TOXFACTOR//./}
 
     - name: Upload code coverage data
       env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,14 +4,18 @@ on: [ push, pull_request ]
 
 jobs:
   test:
-    # TODO: a GH action update broke the 'ubuntu-latest' image
-    #       when it's fixed, we should switch back
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        os: ['ubuntu-latest']
+        include:
+          - python-version: '3.5'
+            os: 'ubuntu-20.04'
+          - python-version: '3.6'
+            os: 'ubuntu-20.04'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Goal

CI has been very flaky recently, often failing multiple times on each PR while setting up the test environment (i.e. the tests themselves run fine)

This seems to be caused by running tox in parallel as it's much more stable after turning that off. Unfortunately that makes CI take significantly longer but it's better than randomly failing builds

Updating to tox v4 may fix this (we're still using tox v3 which isn't supported anymore) but the update isn't trivial so needs some dedicated time to get fully working