### PR TITLE
Create a new context for each WSGI request

### DIFF
--- a/bugsnag/wsgi/middleware.py
+++ b/bugsnag/wsgi/middleware.py
@@ -3,6 +3,7 @@ import sys
 from typing import Dict
 
 import bugsnag
+from bugsnag.context import create_new_context
 from bugsnag.wsgi import request_path
 from bugsnag.breadcrumbs import BreadcrumbType
 from bugsnag.legacy import _auto_leave_breadcrumb
@@ -59,6 +60,8 @@ class WrappedWSGIApp:
         self.environ = environ
 
         bugsnag.configure_request(wsgi_environ=self.environ)
+        create_new_context()
+
         try:
             if bugsnag.configuration.auto_capture_sessions:
                 bugsnag.start_session()


### PR DESCRIPTION
## Goal

This allows feature flags to be stored separately in each request, rather than be shared by all requests