### PR TITLE
Implement __repr__ for FeatureFlag

### DIFF
--- a/bugsnag/feature_flags.py
+++ b/bugsnag/feature_flags.py
@@ -48,6 +48,9 @@ class FeatureFlag:
     def __hash__(self):
         return hash((self._name, self._variant))
 
+    def __repr__(self):
+        return 'FeatureFlag(%s, %s)' % (repr(self._name), repr(self._variant))
+
     def _coerce_variant(
         self,
         variant: Union[None, str, bytes]

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -49,6 +49,12 @@ def test_feature_flag_variant_is_unset_if_not_coercable():
     assert FeatureFlag('a', Unstringable()).variant is None
 
 
+def test_feature_flag_implements_repr():
+    assert repr(FeatureFlag('abc', 'xyz')) == "FeatureFlag('abc', 'xyz')"
+    assert repr(FeatureFlag('ayc', None)) == "FeatureFlag('ayc', None)"
+    assert repr(FeatureFlag('xyz')) == "FeatureFlag('xyz', None)"
+
+
 def test_feature_flag_can_be_converted_to_dict():
     flag = FeatureFlag('abc', 'xyz')
 


### PR DESCRIPTION
## Goal

Implement `__repr__` for the `FeatureFlag` class to help with debugging. e.g.:

```python
repr(FeatureFlag('abc', 'xyz'))
# => "FeatureFlag('abc', 'xyz')"
repr(FeatureFlag('xyz'))
# => "FeatureFlag('xyz', None)"
```