### PR TITLE
Fix asyncio event loop deprecation warning in test

### DIFF
--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -341,7 +341,7 @@ def test_the_breadcrumb_list_is_separate_on_different_async_contexts():
 
         await asyncio.gather(*tasks)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
 
     try:
         loop.run_until_complete(test())


### PR DESCRIPTION
## Goal

There's no event loop when we call 'get_event_loop' in this test, which works fine as it creates a new one anyway but now emits a deprecation warning

Creating a new event loop fixes the deprecation without changing the test's behaviour
