### PR TITLE
Remove use of deprecated pkg_resources module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## v4.6.0 (TBD)
+
+### Enhancements
+
+* Remove use of deprecated `pkg_resources` module
+  [#362](https://github.com/bugsnag/bugsnag-python/pull/362)
+
 ## v4.5.0 (2023-07-17)
 
 ### Enhancements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,30 +90,24 @@ If you're on the core team, you can release Bugsnag as follows:
 
 ## Making a release
 
-* Update the version number in setup.py
-* Update the CHANGELOG.md, and README.md if necessary
-* Commit
+* Create branch for the release
 
     ```
-    git commit -am v4.x.x
+    git checkout -b release/v4.x.x
     ```
 
-* Tag the release in git
-
-    ```
-    git tag v4.x.x
-    ```
-
-* Push to git
-
-    ```
-    git push origin master && git push --tags
-    ```
-
+* Update the version number in [`setup.py`](./setup.py) and `bugsnag/notifier.py`(./bugsnag/notifier.py)
+* Update the CHANGELOG.md and README.md if necessary
+* Commit and open a pull request into `master`
+* Merge the PR when it's been reviewed
+* Create a release on GitHub, tagging the new version `v4.x.x`
 * Push the release to PyPI
 
-      python setup.py sdist bdist_wheel
-      twine upload dist/*
+    ```
+    git fetch --tags && git checkout tags/v4.x.x
+    python setup.py sdist bdist_wheel
+    twine upload dist/*
+    ```
 
 ## Update docs.bugsnag.com
 

--- a/bugsnag/event.py
+++ b/bugsnag/event.py
@@ -11,8 +11,12 @@ from copy import deepcopy
 import bugsnag
 
 from bugsnag.breadcrumbs import Breadcrumb
-from bugsnag.utils import fully_qualified_class_name as class_name
-from bugsnag.utils import FilterDict, package_version, SanitizingJSONEncoder
+from bugsnag.notifier import _NOTIFIER_INFORMATION
+from bugsnag.utils import (
+    fully_qualified_class_name as class_name,
+    FilterDict,
+    SanitizingJSONEncoder
+)
 from bugsnag.error import Error
 from bugsnag.feature_flags import FeatureFlag, FeatureFlagDelegate
 
@@ -32,8 +36,8 @@ class Event:
     """
     An occurrence of an exception for delivery to Bugsnag
     """
-    NOTIFIER_NAME = "Python Bugsnag Notifier"
-    NOTIFIER_URL = "https://github.com/bugsnag/bugsnag-python"
+    NOTIFIER_NAME = _NOTIFIER_INFORMATION['name']
+    NOTIFIER_URL = _NOTIFIER_INFORMATION['url']
     PAYLOAD_VERSION = "4.0"
     SUPPORTED_SEVERITIES = ["info", "warning", "error"]
 
@@ -422,7 +426,6 @@ class Event:
 
     def _payload(self):
         # Fetch the notifier version from the package
-        notifier_version = package_version("bugsnag") or "unknown"
         encoder = SanitizingJSONEncoder(
             self.config.logger,
             separators=(',', ':'),
@@ -432,11 +435,7 @@ class Event:
         # Construct the payload dictionary
         return encoder.encode({
             "apiKey": self.api_key,
-            "notifier": {
-                "name": self.NOTIFIER_NAME,
-                "url": self.NOTIFIER_URL,
-                "version": notifier_version,
-            },
+            "notifier": _NOTIFIER_INFORMATION,
             "events": [{
                 "severity": self.severity,
                 "severityReason": self.severity_reason,

--- a/bugsnag/notifier.py
+++ b/bugsnag/notifier.py
@@ -1,0 +1,5 @@
+_NOTIFIER_INFORMATION = {
+    'name': 'Python Bugsnag Notifier',
+    'url': 'https://github.com/bugsnag/bugsnag-python',
+    'version': '4.5.0'
+}

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -13,7 +13,8 @@ except ImportError:
     # flake8: noqa
     _session_info = ThreadContextVar('bugsnag-session', default={})  # type: ignore
 
-from bugsnag.utils import package_version, FilterDict, SanitizingJSONEncoder
+from bugsnag.notifier import _NOTIFIER_INFORMATION
+from bugsnag.utils import FilterDict, SanitizingJSONEncoder
 from bugsnag.event import Event
 
 
@@ -109,14 +110,8 @@ class SessionTracker:
             self.config.logger.debug("Not delivering due to release_stages")
             return
 
-        notifier_version = package_version('bugsnag') or 'unknown'
-
         payload = {
-            'notifier': {
-                'name': Event.NOTIFIER_NAME,
-                'url': Event.NOTIFIER_URL,
-                'version': notifier_version
-            },
+            'notifier': _NOTIFIER_INFORMATION,
             'device': FilterDict({
                 'hostname': self.config.hostname,
                 'runtimeVersions': self.config.runtime_versions

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -286,18 +286,6 @@ def fully_qualified_class_name(obj):
     return module.__name__ + '.' + qualified_name
 
 
-def package_version(package_name):
-    try:
-        import pkg_resources
-    except ImportError:
-        return None
-    else:
-        try:
-            return pkg_resources.get_distribution(package_name).version
-        except pkg_resources.DistributionNotFound:
-            return None
-
-
 def _validate_setter(types, func, should_error=False):
     """
     Check that the first argument of a function is of a provided set of types

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -2,10 +2,9 @@ import platform
 import time
 
 from bugsnag import Client
-from bugsnag.event import Event
 from bugsnag.configuration import Configuration
+from bugsnag.notifier import _NOTIFIER_INFORMATION
 from bugsnag.sessiontracker import SessionTracker
-from bugsnag.utils import package_version
 from tests.utils import IntegrationTest
 
 
@@ -49,15 +48,10 @@ class TestConfiguration(IntegrationTest):
         client.session_tracker.start_session()
         client.session_tracker.send_sessions()
         json_body = self.server.received[0]['json_body']
+
         # Notifier properties
-        notifier = json_body['notifier']
-        self.assertTrue('name' in notifier)
-        self.assertEqual(notifier['name'], Event.NOTIFIER_NAME)
-        self.assertTrue('url' in notifier)
-        self.assertEqual(notifier['url'], Event.NOTIFIER_URL)
-        self.assertTrue('version' in notifier)
-        notifier_version = package_version('bugsnag') or 'unknown'
-        self.assertEqual(notifier['version'], notifier_version)
+        assert json_body['notifier'] == _NOTIFIER_INFORMATION
+
         # App properties
         app = json_body['app']
         self.assertTrue('releaseStage' in app)

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,6 @@ deps=
     exceptiongroup: exceptiongroup
     lint: flake8
     lint: mypy
-    lint: types-pkg_resources
     lint: types-requests
     lint: types-Flask
     lint: types-contextvars


### PR DESCRIPTION
## Goal

`pkg_resources` has been deprecated but we only use it to fetch bugsnag-python's version number for the `notifier` part of the payload. We can encode this in the source to avoid depending on this module. This also removes a couple of possible (though unlikely in practice) failure cases that would result in no version being sent

See the warning in the docs: https://setuptools.pypa.io/en/latest/pkg_resources.html