### PR TITLE
Avoid using deprecated flask.__version__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Avoid using deprecated `flask.__version__` attribute
+  [#365](https://github.com/bugsnag/bugsnag-python/pull/365)
+
 ## v4.6.0 (2023-09-05)
 
 ### Enhancements

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -5,7 +5,7 @@ import bugsnag
 from bugsnag.wsgi import request_path
 from bugsnag.legacy import _auto_leave_breadcrumb
 from bugsnag.breadcrumbs import BreadcrumbType
-from bugsnag.utils import remove_query_from_url
+from bugsnag.utils import remove_query_from_url, get_package_version
 
 
 __all__ = ('handle_exceptions',)
@@ -36,9 +36,16 @@ def add_flask_request_to_notification(event: bugsnag.Event):
 
 
 def handle_exceptions(app):
-    middleware = bugsnag.configure().internal_middleware
-    bugsnag.configure().runtime_versions['flask'] = flask.__version__
+    configuration = bugsnag.configure()
+
+    version = get_package_version("flask")
+
+    if version is not None:
+        configuration.runtime_versions["flask"] = version
+
+    middleware = configuration.internal_middleware
     middleware.before_notify(add_flask_request_to_notification)
+
     flask.got_request_exception.connect(__log_exception, app)
     flask.request_started.connect(_on_request_started, app)
 

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -461,3 +461,20 @@ except Exception:
             int(dt.microsecond / 1000),
             _get_timezone_offset(dt)
         )
+
+
+def get_package_version(package_name: str) -> Optional[str]:
+    try:
+        from importlib import metadata
+
+        return metadata.version(package_name)  # type: ignore
+    except ImportError:
+        try:
+            import pkg_resources
+        except ImportError:
+            return None
+
+        try:
+            return pkg_resources.get_distribution(package_name).version
+        except pkg_resources.DistributionNotFound:
+            return None

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -261,16 +261,14 @@ class TestFlask(IntegrationTest):
         handle_exceptions(app)
         app.test_client().get('/hello')
 
-        self.assertEqual(len(self.server.received), 1)
+        assert self.server.sent_report_count == 1
 
         payload = self.server.received[0]['json_body']
-        device_data = payload['events'][0]['device']
+        versions = payload['events'][0]['device']['runtimeVersions']
 
-        self.assertEquals(len(device_data['runtimeVersions']), 2)
-        self.assertTrue(re.match(r'\d+\.\d+\.\d+',
-                                 device_data['runtimeVersions']['python']))
-        self.assertTrue(re.match(r'\d+\.\d+\.\d+',
-                                 device_data['runtimeVersions']['flask']))
+        assert re.match(r'^\d+\.\d+\.\d+$', versions['python'])
+        assert re.match(r'^\d+\.\d+\.\d+$', versions['flask'])
+        assert len(versions) == 2
 
     def test_read_request_in_callback(self):
         def callback(event):

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ deps=
     exceptiongroup: exceptiongroup
     lint: flake8
     lint: mypy
+    lint: types-pkg_resources
     lint: types-requests
     lint: types-Flask
     lint: types-contextvars


### PR DESCRIPTION
## Goal

Flask is removing their `__version__` attribute (see https://github.com/bugsnag/bugsnag-python/issues/364) so we can no longer rely on this to report the current Flask version

Instead we need to use `importlib.metadata` on Python 3.8+ or `pkg_resources` on older versions (partially reverting #362)