### PR TITLE
Start delivery regardless of auto_capture_sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changelog
 * Avoid using deprecated `flask.__version__` attribute
   [#365](https://github.com/bugsnag/bugsnag-python/pull/365)
 
+### Bug fixes
+
+* Ensure the session delivery queue is started regardless of `auto_capture_sessions` configuration
+  [#367](https://github.com/bugsnag/bugsnag-python/pull/367)
+
 ## v4.6.0 (2023-09-05)
 
 ### Enhancements

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -38,9 +38,10 @@ class SessionTracker:
         self.delivery_thread = None
 
     def start_session(self):
-        if not self.auto_sessions and self.config.auto_capture_sessions:
+        if not self.auto_sessions:
             self.auto_sessions = True
             self.__start_delivery()
+
         start_time = strftime('%Y-%m-%dT%H:%M:00', gmtime())
         new_session = {
             'id': uuid4().hex,

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -1,4 +1,3 @@
-import pytest
 import logging
 import platform
 
@@ -6,7 +5,7 @@ from bugsnag import Client
 from bugsnag.configuration import Configuration
 from bugsnag.notifier import _NOTIFIER_INFORMATION
 from bugsnag.sessiontracker import SessionTracker
-from tests.utils import IntegrationTest, MissingRequestError
+from tests.utils import IntegrationTest
 from unittest.mock import Mock
 
 
@@ -178,7 +177,7 @@ class TestConfiguration(IntegrationTest):
 
         assert self.server.sent_session_count == 1
 
-    def test_session_tracker_doesnt_start_delivery_when_auto_capture_is_off(self):  # noqa
+    def test_session_tracker_starts_delivery_when_auto_capture_is_off(self):
         client = Client(
             api_key='a05afff2bd2ffaf0ab0f52715bbdcffd',
             auto_capture_sessions=False,
@@ -188,11 +187,8 @@ class TestConfiguration(IntegrationTest):
 
         client.session_tracker.start_session()
 
-        assert client.session_tracker.delivery_thread is None
+        force_timer_to_fire(client.session_tracker.delivery_thread)
 
-        # we expect not to receive a session request, so this wait should
-        # timeout
-        with pytest.raises(MissingRequestError):
-            self.server.wait_for_session()
+        self.server.wait_for_session()
 
-        assert self.server.sent_session_count == 0
+        assert self.server.sent_session_count == 1


### PR DESCRIPTION
## Goal

If `auto_capture_sessions` is `False` we still want to deliver any manual sessions that may be left, so we should still start session delivery in this case

Currently session delivery only happens if `auto_capture_sessions` is `True` or `notify` is called:

https://github.com/bugsnag/bugsnag-python/blob/563063f3dd34abfd7d9399720f3371b5b1087c99/bugsnag/client.py#L205-L206