### PR TITLE
Release v4.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,12 @@
 Changelog
 =========
 
-## TBD
-
-### Enhancements
-
-* Avoid using deprecated `flask.__version__` attribute
-  [#365](https://github.com/bugsnag/bugsnag-python/pull/365)
+## v4.6.1 (2023-12-11)
 
 ### Bug fixes
 
+* Avoid using deprecated `flask.__version__` attribute
+  [#365](https://github.com/bugsnag/bugsnag-python/pull/365)
 * Ensure the session delivery queue is started regardless of `auto_capture_sessions` configuration
   [#367](https://github.com/bugsnag/bugsnag-python/pull/367)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changelog
 * Avoid using deprecated `flask.__version__` attribute
   [#365](https://github.com/bugsnag/bugsnag-python/pull/365)
 
+### Bug fixes
+
+* Ensure the session delivery queue is started regardless of `auto_capture_sessions` configuration
+  [#367](https://github.com/bugsnag/bugsnag-python/pull/367)
+
 ## v4.6.0 (2023-09-05)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Avoid using deprecated `flask.__version__` attribute
+  [#365](https://github.com/bugsnag/bugsnag-python/pull/365)
+
 ## v4.6.0 (2023-09-05)
 
 ### Enhancements

--- a/bugsnag/flask/__init__.py
+++ b/bugsnag/flask/__init__.py
@@ -5,7 +5,7 @@ import bugsnag
 from bugsnag.wsgi import request_path
 from bugsnag.legacy import _auto_leave_breadcrumb
 from bugsnag.breadcrumbs import BreadcrumbType
-from bugsnag.utils import remove_query_from_url
+from bugsnag.utils import remove_query_from_url, get_package_version
 
 
 __all__ = ('handle_exceptions',)
@@ -36,9 +36,16 @@ def add_flask_request_to_notification(event: bugsnag.Event):
 
 
 def handle_exceptions(app):
-    middleware = bugsnag.configure().internal_middleware
-    bugsnag.configure().runtime_versions['flask'] = flask.__version__
+    configuration = bugsnag.configure()
+
+    version = get_package_version("flask")
+
+    if version is not None:
+        configuration.runtime_versions["flask"] = version
+
+    middleware = configuration.internal_middleware
     middleware.before_notify(add_flask_request_to_notification)
+
     flask.got_request_exception.connect(__log_exception, app)
     flask.request_started.connect(_on_request_started, app)
 

--- a/bugsnag/notifier.py
+++ b/bugsnag/notifier.py
@@ -1,5 +1,5 @@
 _NOTIFIER_INFORMATION = {
     'name': 'Python Bugsnag Notifier',
     'url': 'https://github.com/bugsnag/bugsnag-python',
-    'version': '4.6.0'
+    'version': '4.6.1'
 }

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -38,9 +38,10 @@ class SessionTracker:
         self.delivery_thread = None
 
     def start_session(self):
-        if not self.auto_sessions and self.config.auto_capture_sessions:
+        if not self.auto_sessions:
             self.auto_sessions = True
             self.__start_delivery()
+
         start_time = strftime('%Y-%m-%dT%H:%M:00', gmtime())
         new_session = {
             'id': uuid4().hex,

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -461,3 +461,20 @@ except Exception:
             int(dt.microsecond / 1000),
             _get_timezone_offset(dt)
         )
+
+
+def get_package_version(package_name: str) -> Optional[str]:
+    try:
+        from importlib import metadata
+
+        return metadata.version(package_name)  # type: ignore
+    except ImportError:
+        try:
+            import pkg_resources
+        except ImportError:
+            return None
+
+        try:
+            return pkg_resources.get_distribution(package_name).version
+        except pkg_resources.DistributionNotFound:
+            return None

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='bugsnag',
-    version='4.6.0',
+    version='4.6.1',
     description='Automatic error monitoring for django, flask, etc.',
     long_description=__doc__,
     author='Simon Maynard',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,8 @@ def reset_breadcrumbs():
 def bugsnag_server():
     server = FakeBugsnagServer(wait_for_duplicate_requests=False)
     bugsnag.configure(
-        endpoint=server.url,
-        session_endpoint=server.url,
+        endpoint=server.events_url,
+        session_endpoint=server.sessions_url,
         api_key='3874876376238728937'
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,11 @@ def reset_breadcrumbs():
 @pytest.fixture
 def bugsnag_server():
     server = FakeBugsnagServer(wait_for_duplicate_requests=False)
-    bugsnag.configure(endpoint=server.url, api_key='3874876376238728937')
+    bugsnag.configure(
+        endpoint=server.url,
+        session_endpoint=server.url,
+        api_key='3874876376238728937'
+    )
 
     yield server
 

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -7,7 +7,11 @@ from tests.utils import FakeBugsnagServer
 @pytest.fixture
 def bugsnag_server():
     server = FakeBugsnagServer(wait_for_duplicate_requests=True)
-    bugsnag.configure(endpoint=server.url, api_key='3874876376238728937')
+    bugsnag.configure(
+        endpoint=server.url,
+        session_endpoint=server.url,
+        api_key='3874876376238728937'
+    )
 
     yield server
 

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -8,8 +8,8 @@ from tests.utils import FakeBugsnagServer
 def bugsnag_server():
     server = FakeBugsnagServer(wait_for_duplicate_requests=True)
     bugsnag.configure(
-        endpoint=server.url,
-        session_endpoint=server.url,
+        endpoint=server.events_url,
+        session_endpoint=server.sessions_url,
         api_key='3874876376238728937'
     )
 

--- a/tests/integrations/test_asgi.py
+++ b/tests/integrations/test_asgi.py
@@ -14,10 +14,14 @@ import pytest
 class TestASGIMiddleware(IntegrationTest):
     def setUp(self):
         super(TestASGIMiddleware, self).setUp()
-        bugsnag.configure(endpoint=self.server.url,
-                          asynchronous=False,
-                          api_key='3874876376238728937',
-                          max_breadcrumbs=25)
+        bugsnag.configure(
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            asynchronous=False,
+            api_key='3874876376238728937',
+            max_breadcrumbs=25,
+            auto_capture_sessions=False,
+        )
 
     def test_normal_http_operation(self):
         async def app(scope, recv, send):

--- a/tests/integrations/test_asgi.py
+++ b/tests/integrations/test_asgi.py
@@ -15,12 +15,11 @@ class TestASGIMiddleware(IntegrationTest):
     def setUp(self):
         super(TestASGIMiddleware, self).setUp()
         bugsnag.configure(
-            endpoint=self.server.url,
-            session_endpoint=self.server.url,
+            endpoint=self.server.events_url,
+            session_endpoint=self.server.sessions_url,
             asynchronous=False,
             api_key='3874876376238728937',
             max_breadcrumbs=25,
-            auto_capture_sessions=False,
         )
 
     def test_normal_http_operation(self):
@@ -50,7 +49,7 @@ class TestASGIMiddleware(IntegrationTest):
         self.assertRaises(ScaryException, lambda: app.get('/'))
         self.assertSentReportCount(1)
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         request = payload['events'][0]['metaData']['request']
         self.assertEqual('/', request['path'])
         self.assertEqual('GET', request['httpMethod'])
@@ -88,7 +87,7 @@ class TestASGIMiddleware(IntegrationTest):
         self.assertRaises(ScaryException, lambda: app.get('/'))
         self.assertSentReportCount(1)
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         environment = payload['events'][0]['metaData']['environment']
 
         self.assertEqual('/', environment['path'])
@@ -120,7 +119,7 @@ class TestASGIMiddleware(IntegrationTest):
         )
         self.assertSentReportCount(1)
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         headers = payload['events'][0]['metaData']['request']['headers']
 
         self.assertEqual('[FILTERED]', headers['authorization'])
@@ -134,7 +133,7 @@ class TestASGIMiddleware(IntegrationTest):
         self.assertRaises(ScaryException, lambda: app.get('/'))
         self.assertSentReportCount(1)
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         request = payload['events'][0]['metaData']['request']
         self.assertEqual('/', request['path'])
         self.assertEqual('GET', request['httpMethod'])
@@ -171,7 +170,7 @@ class TestASGIMiddleware(IntegrationTest):
         self.assertRaises(ScaryException, lambda: app.get('/'))
         self.assertSentReportCount(1)
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         metadata = payload['events'][0]['metaData']
         request = metadata['request']
         self.assertEqual('/', request['path'])
@@ -206,7 +205,7 @@ class TestASGIMiddleware(IntegrationTest):
 
         self.assertSentReportCount(1)
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         metadata = payload['events'][0]['metaData']
         request = metadata['request']
         self.assertEqual('/', request['path'])
@@ -242,7 +241,7 @@ class TestASGIMiddleware(IntegrationTest):
         )
         self.assertSentReportCount(1)
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         request = payload['events'][0]['metaData']['request']
         self.assertEqual(
             'http://testserver/path?password=[FILTERED]',
@@ -276,7 +275,7 @@ class TestASGIMiddleware(IntegrationTest):
         )
         self.assertSentReportCount(1)
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         request = payload['events'][0]['metaData']['request']
         self.assertEqual('/', request['path'])
         self.assertEqual('GET', request['httpMethod'])
@@ -320,7 +319,7 @@ class TestASGIMiddleware(IntegrationTest):
 
         assert self.sent_report_count == 1
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
 
         print(payload)
         assert len(payload['events'][0]['exceptions']) == 2
@@ -368,7 +367,7 @@ class TestASGIMiddleware(IntegrationTest):
 
         assert self.sent_report_count == 1
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         exception = payload['events'][0]['exceptions'][0]
         feature_flags = payload['events'][0]['featureFlags']
 
@@ -387,7 +386,7 @@ class TestASGIMiddleware(IntegrationTest):
 
         assert self.sent_report_count == 2
 
-        payload = self.server.received[1]['json_body']
+        payload = self.server.events_received[1]['json_body']
         feature_flags = payload['events'][0]['featureFlags']
 
         assert feature_flags == [
@@ -400,7 +399,7 @@ class TestASGIMiddleware(IntegrationTest):
 
         assert self.sent_report_count == 3
 
-        payload = self.server.received[2]['json_body']
+        payload = self.server.events_received[2]['json_body']
         feature_flags = payload['events'][0]['featureFlags']
 
         assert feature_flags == []

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.django_db]
 
 @pytest.fixture
 def django_client():
-    bugsnag.configure(max_breadcrumbs=25, auto_capture_sessions=False)
+    bugsnag.configure(max_breadcrumbs=25)
 
     client = Client()
     User.objects.create_user(
@@ -42,11 +42,11 @@ def test_notify(bugsnag_server, django_client):
 
     assert response.status_code == 200
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
 
@@ -95,22 +95,22 @@ def test_enable_environment(bugsnag_server, django_client):
     response = django_client.get('/notes/handled-exception/?foo=strawberry')
     assert response.status_code == 200
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
     assert event['metaData']['environment']['REQUEST_METHOD'] == 'GET'
 
 
 def test_notify_custom_info(bugsnag_server, django_client):
     django_client.get('/notes/handled-exception-custom/')
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
 
     assert payload['apiKey'] == 'a05afff2bd2ffaf0ab0f52715bbdcffd'
@@ -125,11 +125,11 @@ def test_notify_post_body(bugsnag_server, django_client):
                                   content_type='application/json')
     assert response.status_code == 200
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
 
@@ -170,11 +170,11 @@ def test_unhandled_exception(bugsnag_server, django_client):
     with pytest.raises(RuntimeError):
         django_client.get('/notes/unhandled-crash/')
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
 
@@ -218,11 +218,11 @@ def test_unhandled_exception_chain(bugsnag_server, django_client):
     with pytest.raises(Exception):
         django_client.get('/notes/unhandled-crash-chain/')
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
 
@@ -266,11 +266,11 @@ def test_unhandled_exception_in_template(bugsnag_server, django_client):
     with pytest.raises(TemplateSyntaxError):
         django_client.get('/notes/unhandled-template-crash/')
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
 
@@ -299,7 +299,7 @@ def test_ignores_http404(bugsnag_server, django_client):
     assert response.status_code == 404
 
     with pytest.raises(MissingRequestError):
-        bugsnag_server.wait_for_request()
+        bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 0
 
@@ -308,11 +308,11 @@ def test_report_error_from_http404handler(bugsnag_server, django_client):
     with pytest.raises(Exception):
         django_client.get('/notes/poorly-handled-404')
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
 
@@ -356,11 +356,11 @@ def test_notify_appends_user_data(bugsnag_server, django_client):
     response = django_client.get('/notes/handled-exception/?foo=strawberry')
     assert response.status_code == 200
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
 
@@ -403,11 +403,11 @@ def test_crash_appends_user_data(bugsnag_server, django_client):
     with pytest.raises(RuntimeError):
         django_client.get('/notes/unhandled-crash/')
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
 
@@ -451,11 +451,11 @@ def test_read_request_in_callback(bugsnag_server, django_client):
     with pytest.raises(RuntimeError):
         django_client.get('/notes/crash-with-callback/?user_id=foo')
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
     assert event['context'] == 'foo'
 
@@ -471,11 +471,11 @@ def test_bugsnag_middleware_leaves_breadcrumb_with_referer(
 
     assert response.status_code == 200
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     event = payload['events'][0]
     exception = event['exceptions'][0]
 

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -4,6 +4,7 @@ import pytest
 import django
 from django.contrib.auth.models import User
 from django.test import Client
+from tests.utils import MissingRequestError
 try:
     from django.template.exceptions import TemplateSyntaxError
     template_error_class = 'django.template.exceptions.TemplateSyntaxError'
@@ -11,19 +12,9 @@ except ImportError:
     from django.template.base import TemplateSyntaxError
     template_error_class = 'django.template.base.TemplateSyntaxError'
 
-from django.conf import settings
-
-from tests.utils import MissingRequestError
 
 # All tests will be treated as marked.
 pytestmark = [pytest.mark.django_db]
-
-
-def pytest_configure(bugsnag_server):
-    settings.configure(BUGSNAG={
-        'endpoint': bugsnag_server.url,
-        'session_endpoint': bugsnag_server.url,
-    })
 
 
 @pytest.fixture

--- a/tests/integrations/test_django.py
+++ b/tests/integrations/test_django.py
@@ -28,7 +28,7 @@ def pytest_configure(bugsnag_server):
 
 @pytest.fixture
 def django_client():
-    bugsnag.configure(max_breadcrumbs=25)
+    bugsnag.configure(max_breadcrumbs=25, auto_capture_sessions=False)
 
     client = Client()
     User.objects.create_user(

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -16,14 +16,13 @@ class TestFlask(IntegrationTest):
     def setUp(self):
         super(TestFlask, self).setUp()
         bugsnag.configure(
-            endpoint=self.server.url,
-            session_endpoint=self.server.url,
+            endpoint=self.server.events_url,
+            session_endpoint=self.server.sessions_url,
             api_key='3874876376238728937',
             notify_release_stages=['dev'],
             release_stage='dev',
             asynchronous=False,
             max_breadcrumbs=25,
-            auto_capture_sessions=False,
         )
 
     def test_bugsnag_middleware_working(self):
@@ -38,7 +37,7 @@ class TestFlask(IntegrationTest):
         resp = app.test_client().get('/hello')
         self.assertEqual(resp.data, b'OK')
 
-        self.assertEqual(0, len(self.server.received))
+        self.assertEqual(0, len(self.server.events_received))
 
     def test_bugsnag_crash(self):
         app = Flask("bugsnag")
@@ -50,8 +49,8 @@ class TestFlask(IntegrationTest):
         handle_exceptions(app)
         app.test_client().get('/hello?password=secret')
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['exceptions'][0]['errorClass'],
                          'test_flask.SentinelError')
@@ -78,8 +77,8 @@ class TestFlask(IntegrationTest):
         handle_exceptions(app)
         app.test_client().get('/hello')
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['metaData']['environment']['REMOTE_ADDR'],
                          '127.0.0.1')
@@ -95,8 +94,8 @@ class TestFlask(IntegrationTest):
         handle_exceptions(app)
         app.test_client().get('/hello')
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         self.assertEqual(payload['events'][0]['metaData']['request']['url'],
                          'http://localhost/hello')
 
@@ -116,16 +115,16 @@ class TestFlask(IntegrationTest):
             client.get('/hello')
             client.get('/hello')
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['metaData'].get('hello'), None)
         self.assertEqual(event['metaData']['again']['hello'], 'world')
 
-        payload = self.server.received[1]['json_body']
+        payload = self.server.events_received[1]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['metaData']['hello']['world'], 'once')
         self.assertEqual(event['metaData'].get('again'), None)
-        self.assertEqual(2, len(self.server.received))
+        self.assertEqual(2, len(self.server.events_received))
 
     def test_bugsnag_includes_posted_json_data(self):
         app = Flask("bugsnag")
@@ -148,8 +147,8 @@ class TestFlask(IntegrationTest):
             '/ajax', data=json.dumps(body),
             content_type='application/hal+json')
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['exceptions'][0]['errorClass'],
                          'test_flask.SentinelError')
@@ -167,8 +166,8 @@ class TestFlask(IntegrationTest):
         handle_exceptions(app)
         app.test_client().post(
             '/ajax', data='{"key": "value"', content_type='application/json')
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['exceptions'][0]['errorClass'],
                          'test_flask.SentinelError')
@@ -190,8 +189,8 @@ class TestFlask(IntegrationTest):
         app.test_client().put(
             '/form', data='_data', content_type='application/octet-stream')
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['metaData']['account']['premium'], False)
         self.assertEqual(event['metaData']['account']['id'], 1)
@@ -207,8 +206,8 @@ class TestFlask(IntegrationTest):
         app.test_client().put(
             '/form', data='_data', content_type='application/octet-stream')
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['exceptions'][0]['errorClass'],
                          'test_flask.SentinelError')
@@ -229,8 +228,8 @@ class TestFlask(IntegrationTest):
         handle_exceptions(app)
         app.test_client().get('/hello')
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         self.assertEqual(payload['events'][0]['context'],
                          'custom_context_event_testing')
 
@@ -244,8 +243,8 @@ class TestFlask(IntegrationTest):
         handle_exceptions(app)
         app.test_client().get("/test")
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertTrue(event['unhandled'])
         self.assertEqual(event['severityReason'], {
@@ -267,7 +266,7 @@ class TestFlask(IntegrationTest):
 
         assert self.server.sent_report_count == 1
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         versions = payload['events'][0]['device']['runtimeVersions']
 
         assert re.match(r'^\d+\.\d+\.\d+$', versions['python'])
@@ -289,8 +288,8 @@ class TestFlask(IntegrationTest):
         handle_exceptions(app)
         app.test_client().get('/hello?id=foo')
 
-        assert len(self.server.received) == 1
-        payload = self.server.received[0]['json_body']
+        assert len(self.server.events_received) == 1
+        payload = self.server.events_received[0]['json_body']
         assert payload['events'][0]['user']['id'] == 'foo'
 
     def test_bugsnag_middleware_leaves_breadcrumb_with_referer(self):
@@ -304,8 +303,8 @@ class TestFlask(IntegrationTest):
         headers = {'referer': 'http://localhost/hi?password=hunter2'}
         app.test_client().get('/hello', headers=headers)
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['exceptions'][0]['errorClass'],
                          'test_flask.SentinelError')
@@ -338,7 +337,7 @@ class TestFlask(IntegrationTest):
 
         assert self.sent_report_count == 1
 
-        payload = self.server.received[0]['json_body']
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
 
         assert len(event['exceptions']) == 2

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -261,16 +261,14 @@ class TestFlask(IntegrationTest):
         handle_exceptions(app)
         app.test_client().get('/hello')
 
-        self.assertEqual(len(self.server.received), 1)
+        assert self.server.sent_report_count == 1
 
         payload = self.server.received[0]['json_body']
-        device_data = payload['events'][0]['device']
+        versions = payload['events'][0]['device']['runtimeVersions']
 
-        self.assertEquals(len(device_data['runtimeVersions']), 2)
-        self.assertTrue(re.match(r'\d+\.\d+\.\d+',
-                                 device_data['runtimeVersions']['python']))
-        self.assertTrue(re.match(r'\d+\.\d+\.\d+',
-                                 device_data['runtimeVersions']['flask']))
+        assert re.match(r'^\d+\.\d+\.\d+$', versions['python'])
+        assert re.match(r'^\d+\.\d+\.\d+$', versions['flask'])
+        assert len(versions) == 2
 
     def test_read_request_in_callback(self):
         def callback(event):

--- a/tests/integrations/test_flask.py
+++ b/tests/integrations/test_flask.py
@@ -15,12 +15,16 @@ class TestFlask(IntegrationTest):
 
     def setUp(self):
         super(TestFlask, self).setUp()
-        bugsnag.configure(endpoint=self.server.url,
-                          api_key='3874876376238728937',
-                          notify_release_stages=['dev'],
-                          release_stage='dev',
-                          asynchronous=False,
-                          max_breadcrumbs=25)
+        bugsnag.configure(
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            api_key='3874876376238728937',
+            notify_release_stages=['dev'],
+            release_stage='dev',
+            asynchronous=False,
+            max_breadcrumbs=25,
+            auto_capture_sessions=False,
+        )
 
     def test_bugsnag_middleware_working(self):
         app = Flask("bugsnag")

--- a/tests/integrations/test_requests_delivery.py
+++ b/tests/integrations/test_requests_delivery.py
@@ -11,11 +11,12 @@ class RequestsDeliveryTest(IntegrationTest):
         self.config = Configuration()
         self.config.configure(
             api_key='abc',
-            asynchronous=False
+            asynchronous=False,
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
         )
 
     def test_requests_delivery(self):
-        self.config.configure(endpoint=self.server.url)
         RequestsDelivery().deliver(self.config, '{"legit": 4}')
 
         self.assertSentReportCount(1)
@@ -29,8 +30,6 @@ class RequestsDeliveryTest(IntegrationTest):
         )
 
     def test_requests_delivery_full_url(self):
-        self.config.configure(endpoint=self.server.url)
-
         RequestsDelivery().deliver(self.config, '{"good": 5}')
 
         self.assertSentReportCount(1)

--- a/tests/integrations/test_requests_delivery.py
+++ b/tests/integrations/test_requests_delivery.py
@@ -12,8 +12,8 @@ class RequestsDeliveryTest(IntegrationTest):
         self.config.configure(
             api_key='abc',
             asynchronous=False,
-            endpoint=self.server.url,
-            session_endpoint=self.server.url,
+            endpoint=self.server.events_url,
+            session_endpoint=self.server.sessions_url,
         )
 
     def test_requests_delivery(self):
@@ -21,7 +21,7 @@ class RequestsDeliveryTest(IntegrationTest):
 
         self.assertSentReportCount(1)
 
-        request = self.server.received[0]
+        request = self.server.events_received[0]
 
         self.assertEqual(request['json_body'], {"legit": 4})
         self.assertEqual(
@@ -34,7 +34,7 @@ class RequestsDeliveryTest(IntegrationTest):
 
         self.assertSentReportCount(1)
 
-        request = self.server.received[0]
+        request = self.server.events_received[0]
 
         self.assertEqual(request['json_body'], {'good': 5})
 

--- a/tests/integrations/test_thread_excepthook.py
+++ b/tests/integrations/test_thread_excepthook.py
@@ -27,9 +27,9 @@ def test_uncaught_exception_on_thread_sends_event(bugsnag_server):
     thread.start()
     thread.join()
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
 
-    event = bugsnag_server.received[0]['json_body']['events'][0]
+    event = bugsnag_server.events_received[0]['json_body']['events'][0]
     exception = event['exceptions'][0]
 
     assert 'dispatch' == event['app']['type']

--- a/tests/integrations/test_tornado.py
+++ b/tests/integrations/test_tornado.py
@@ -12,12 +12,16 @@ class TornadoTests(AsyncHTTPTestCase, IntegrationTest):
 
     def setUp(self):
         super(TornadoTests, self).setUp()
-        bugsnag.configure(endpoint=self.server.url,
-                          api_key='3874876376238728937',
-                          notify_release_stages=['dev'],
-                          release_stage='dev',
-                          asynchronous=False,
-                          max_breadcrumbs=25)
+        bugsnag.configure(
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            api_key='3874876376238728937',
+            notify_release_stages=['dev'],
+            release_stage='dev',
+            asynchronous=False,
+            max_breadcrumbs=25,
+            auto_capture_sessions=False,
+        )
 
     def test_notify(self):
         response = self.fetch('/notify', method="GET")

--- a/tests/integrations/test_wsgi.py
+++ b/tests/integrations/test_wsgi.py
@@ -17,14 +17,13 @@ class TestWSGI(IntegrationTest):
     def setUp(self):
         super(TestWSGI, self).setUp()
         bugsnag.configure(
-            endpoint=self.server.url,
-            session_endpoint=self.server.url,
+            endpoint=self.server.events_url,
+            session_endpoint=self.server.sessions_url,
             api_key='3874876376238728937',
             notify_release_stages=['dev'],
             release_stage='dev',
             asynchronous=False,
             max_breadcrumbs=25,
-            auto_capture_sessions=False,
         )
 
     def test_bugsnag_middleware_working(self):
@@ -38,7 +37,7 @@ class TestWSGI(IntegrationTest):
         resp = app.get('/', status=200)
 
         self.assertEqual(resp.body, b'OK')
-        self.assertEqual(0, len(self.server.received))
+        self.assertEqual(0, len(self.server.events_received))
 
     def test_bugsnag_middleware_crash_on_start(self):
 
@@ -53,8 +52,8 @@ class TestWSGI(IntegrationTest):
             lambda: app.get('/beans?password=drowssap')
         )
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['context'], 'GET /beans')
         assert 'environment' not in event['metaData']
@@ -82,8 +81,8 @@ class TestWSGI(IntegrationTest):
 
         self.assertRaises(SentinelError, lambda: app.get('/beans'))
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['metaData']['environment']['PATH_INFO'],
                          '/beans')
@@ -109,8 +108,8 @@ class TestWSGI(IntegrationTest):
 
         self.assertRaises(SentinelError, lambda: app.get('/beans'))
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         assert 'environment' not in event['metaData']
 
@@ -139,8 +138,8 @@ class TestWSGI(IntegrationTest):
 
         self.assertRaises(SentinelError, lambda: app.get('/beans'))
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         assert 'environment' not in event['metaData']
 
@@ -166,8 +165,8 @@ class TestWSGI(IntegrationTest):
 
         self.assertRaises(SentinelError, lambda: app.get('/beans'))
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         self.assertEqual(payload['events'][0]['user']['id'], '5')
 
         breadcrumbs = payload['events'][0]['breadcrumbs']
@@ -191,8 +190,8 @@ class TestWSGI(IntegrationTest):
 
         self.assertRaises(SentinelError, lambda: app.get('/beans'))
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['metaData']['account'], {"paying": True})
 
@@ -221,8 +220,8 @@ class TestWSGI(IntegrationTest):
 
         self.assertRaises(SentinelError, lambda: app.get('/beans'))
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         assert 'environment' not in event['metaData']
 
@@ -244,8 +243,8 @@ class TestWSGI(IntegrationTest):
 
         self.assertRaises(SentinelError, lambda: app.get('/beans'))
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
 
         self.assertTrue(event['unhandled'])
@@ -279,8 +278,8 @@ class TestWSGI(IntegrationTest):
         with pytest.raises(SentinelError):
             app.get('/beans?user_id=my_id')
 
-        assert len(self.server.received) == 1
-        payload = self.server.received[0]['json_body']
+        assert len(self.server.events_received) == 1
+        payload = self.server.events_received[0]['json_body']
         assert payload['events'][0]['user']['id'] == 'my_id'
 
         breadcrumbs = payload['events'][0]['breadcrumbs']
@@ -303,8 +302,8 @@ class TestWSGI(IntegrationTest):
             lambda: app.get('/beans', headers=headers)
         )
 
-        self.assertEqual(1, len(self.server.received))
-        payload = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        payload = self.server.events_received[0]['json_body']
         event = payload['events'][0]
         self.assertEqual(event['context'], 'GET /beans')
         assert 'environment' not in event['metaData']

--- a/tests/integrations/test_wsgi.py
+++ b/tests/integrations/test_wsgi.py
@@ -16,12 +16,16 @@ class TestWSGI(IntegrationTest):
 
     def setUp(self):
         super(TestWSGI, self).setUp()
-        bugsnag.configure(endpoint=self.server.url,
-                          api_key='3874876376238728937',
-                          notify_release_stages=['dev'],
-                          release_stage='dev',
-                          asynchronous=False,
-                          max_breadcrumbs=25)
+        bugsnag.configure(
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            api_key='3874876376238728937',
+            notify_release_stages=['dev'],
+            release_stage='dev',
+            asynchronous=False,
+            max_breadcrumbs=25,
+            auto_capture_sessions=False,
+        )
 
     def test_bugsnag_middleware_working(self):
         def BasicWorkingApp(environ, start_response):

--- a/tests/integrations/test_wsgi.py
+++ b/tests/integrations/test_wsgi.py
@@ -13,7 +13,6 @@ class SentinelError(RuntimeError):
 
 
 class TestWSGI(IntegrationTest):
-
     def setUp(self):
         super(TestWSGI, self).setUp()
         bugsnag.configure(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,11 +30,14 @@ class ClientTest(IntegrationTest):
     def setUp(self):
         super(ClientTest, self).setUp()
 
-        self.client = Client(api_key='testing client key',
-                             endpoint=self.server.url,
-                             project_root=os.path.join(os.getcwd(), 'tests'),
-                             asynchronous=False,
-                             install_sys_hook=False)
+        self.client = Client(
+            api_key='testing client key',
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            project_root=os.path.join(os.getcwd(), 'tests'),
+            asynchronous=False,
+            install_sys_hook=False
+        )
 
     # Initialisation
 
@@ -433,10 +436,18 @@ class ClientTest(IntegrationTest):
     # Multiple Clients
 
     def test_multiple_clients_different_keys(self):
-        client1 = Client(api_key='abc', asynchronous=False,
-                         endpoint=self.server.url)
-        client2 = Client(api_key='456', asynchronous=False,
-                         endpoint=self.server.url)
+        client1 = Client(
+            api_key='abc',
+            asynchronous=False,
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+        )
+        client2 = Client(
+            api_key='456',
+            asynchronous=False,
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+        )
 
         client1.notify(ScaryException('foo'))
         self.assertSentReportCount(1)
@@ -454,10 +465,19 @@ class ClientTest(IntegrationTest):
             pass
         sys.excepthook = excepthook
 
-        client1 = Client(api_key='abc', asynchronous=False,
-                         endpoint=self.server.url)
-        Client(api_key='456', asynchronous=False, endpoint=self.server.url,
-               install_sys_hook=False)
+        client1 = Client(
+            api_key='456',
+            asynchronous=False,
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+        )
+        Client(
+            api_key='456',
+            asynchronous=False,
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            install_sys_hook=False,
+        )
 
         self.assertEqual(client1, sys.excepthook.bugsnag_client)
         self.assertEqual(client1.sys_excepthook, excepthook)

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -5,7 +5,8 @@ from bugsnag import Configuration
 from bugsnag.delivery import (
     UrllibDelivery,
     RequestsDelivery,
-    create_default_delivery
+    create_default_delivery,
+    DEFAULT_SESSIONS_ENDPOINT
 )
 
 from tests.utils import IntegrationTest
@@ -16,9 +17,12 @@ class DeliveryTest(IntegrationTest):
     def setUp(self):
         super(DeliveryTest, self).setUp()
         self.config = Configuration()
-        self.config.configure(api_key='abc',
-                              endpoint=self.server.url,
-                              asynchronous=False)
+        self.config.configure(
+            api_key='abc',
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            asynchronous=False
+        )
 
     def test_urllib_delivery(self):
         UrllibDelivery().deliver(self.config, '{"legit": 4}')
@@ -40,6 +44,17 @@ class DeliveryTest(IntegrationTest):
     def test_misconfigured_sessions_endpoint_sends_warning(self):
         delivery = create_default_delivery()
 
+        self.config.configure(session_endpoint=self.server.url)
+
+        with warnings.catch_warnings(record=True) as warn:
+            warnings.simplefilter("always")
+            delivery.deliver_sessions(self.config, '{"apiKey":"aaab"}')
+            self.assertEqual(0, len(warn))
+            self.assertEqual(1, len(self.server.received))
+
+        self.server.received.clear()
+        self.config.configure(session_endpoint=DEFAULT_SESSIONS_ENDPOINT)
+
         with warnings.catch_warnings(record=True) as warn:
             warnings.simplefilter("always")
             delivery.deliver_sessions(self.config, '{"apiKey":"aaab"}')
@@ -49,11 +64,3 @@ class DeliveryTest(IntegrationTest):
             delivery.deliver_sessions(self.config, '{"apiKey":"aaab"}')
             self.assertEqual(1, len(warn))
             self.assertEqual(0, len(self.server.received))
-
-        self.config.configure(session_endpoint=self.server.url)
-
-        with warnings.catch_warnings(record=True) as warn:
-            warnings.simplefilter("always")
-            delivery.deliver_sessions(self.config, '{"apiKey":"aaab"}')
-            self.assertEqual(0, len(warn))
-            self.assertEqual(1, len(self.server.received))

--- a/tests/test_exception_groups.py
+++ b/tests/test_exception_groups.py
@@ -25,10 +25,10 @@ def test_exception_groups_are_unwrapped(bugsnag_server):
 
     bugsnag.notify(fixtures.exception_group_with_no_cause)
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     exceptions = payload['events'][0]['exceptions']
 
     # there should be 1 ExceptionGroup with 4 sub-exceptions
@@ -90,10 +90,10 @@ def test_base_exception_group_subclasses_are_unwrapped(bugsnag_server):
 
     bugsnag.notify(fixtures.base_exception_group_subclass)
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     exceptions = payload['events'][0]['exceptions']
 
     # there should be 1 MyExceptionGroup with 3 sub-exceptions
@@ -154,10 +154,10 @@ def test_do_not_recurse_into_sub_exception_groups(bugsnag_server):
 
     bugsnag.notify(fixtures.exception_group_with_nested_group)
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     exceptions = payload['events'][0]['exceptions']
 
     # there should be 1 ExceptionGroup with 3 sub-exceptions
@@ -248,10 +248,10 @@ def test_exception_group_implicit_cause_is_traversed(bugsnag_server):
 
     bugsnag.notify(fixtures.exception_group_with_implicit_cause)
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     exceptions = payload['events'][0]['exceptions']
 
     print(exceptions)
@@ -355,10 +355,10 @@ def test_exception_group_explicit_cause_is_traversed(bugsnag_server):
 
     bugsnag.notify(fixtures.exception_group_with_explicit_cause)
 
-    bugsnag_server.wait_for_request()
+    bugsnag_server.wait_for_event()
     assert bugsnag_server.sent_report_count == 1
 
-    payload = bugsnag_server.received[0]['json_body']
+    payload = bugsnag_server.events_received[0]['json_body']
     exceptions = payload['events'][0]['exceptions']
 
     print(exceptions)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -15,8 +15,8 @@ def use_client_logger(func):
     def wrapped(obj):
         client = Client(
             api_key='abcdef',
-            endpoint=obj.server.url,
-            session_endpoint=obj.server.url,
+            endpoint=obj.server.events_url,
+            session_endpoint=obj.server.sessions_url,
             asynchronous=False
         )
 
@@ -46,8 +46,8 @@ class HandlersTest(IntegrationTest):
     def setUp(self):
         super(HandlersTest, self).setUp()
         bugsnag.configure(
-            endpoint=self.server.url,
-            session_endpoint=self.server.url,
+            endpoint=self.server.events_url,
+            session_endpoint=self.server.sessions_url,
             notify_release_stages=['dev'],
             release_stage='dev',
             asynchronous=False,
@@ -69,7 +69,7 @@ class HandlersTest(IntegrationTest):
 
         self.assertSentReportCount(1)
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual('The system is down', exception['message'])
@@ -84,7 +84,7 @@ class HandlersTest(IntegrationTest):
 
         self.assertSentReportCount(1)
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual('LogCRITICAL', exception['errorClass'])
@@ -104,7 +104,7 @@ class HandlersTest(IntegrationTest):
 
         self.assertSentReportCount(1)
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual('LogERROR', exception['errorClass'])
@@ -123,7 +123,7 @@ class HandlersTest(IntegrationTest):
         logger.removeHandler(handler)
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual('LogWARNING', exception['errorClass'])
@@ -143,7 +143,7 @@ class HandlersTest(IntegrationTest):
         logger.removeHandler(handler)
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual('LogINFO', exception['errorClass'])
@@ -170,7 +170,7 @@ class HandlersTest(IntegrationTest):
         logger.removeHandler(handler)
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual('LogMessage', exception['errorClass'])
@@ -184,7 +184,7 @@ class HandlersTest(IntegrationTest):
         logger.removeHandler(handler)
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual('LogLevel 341', exception['errorClass'])
@@ -199,7 +199,7 @@ class HandlersTest(IntegrationTest):
         logger.removeHandler(handler)
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual('LogOMG', exception['errorClass'])
@@ -218,7 +218,7 @@ class HandlersTest(IntegrationTest):
         logger.removeHandler(handler)
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual(exception['errorClass'], 'tests.utils.ScaryException')
@@ -233,7 +233,7 @@ class HandlersTest(IntegrationTest):
         })
         logger.removeHandler(handler)
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual(event['metaData']['fruit'], {
             'grapes': 8, 'pears': 2
@@ -242,8 +242,8 @@ class HandlersTest(IntegrationTest):
     def test_client_metadata_fields(self):
         client = Client(
             api_key='abcdef',
-            endpoint=self.server.url,
-            session_endpoint=self.server.url,
+            endpoint=self.server.events_url,
+            session_endpoint=self.server.sessions_url,
             asynchronous=False
         )
 
@@ -258,7 +258,7 @@ class HandlersTest(IntegrationTest):
         })
         logger.removeHandler(handler)
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual(event['metaData']['fruit'], {
             'grapes': 8, 'pears': 2
@@ -269,7 +269,7 @@ class HandlersTest(IntegrationTest):
         logger.critical('The system is down')
         self.assertSentReportCount(1)
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
 
@@ -281,7 +281,7 @@ class HandlersTest(IntegrationTest):
 
         self.assertSentReportCount(1)
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
 
@@ -298,7 +298,7 @@ class HandlersTest(IntegrationTest):
 
         self.assertSentReportCount(1)
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
 
@@ -314,7 +314,7 @@ class HandlersTest(IntegrationTest):
         logger.warning('The system is down')
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
 
@@ -330,7 +330,7 @@ class HandlersTest(IntegrationTest):
         logger.info('The system is down')
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
 
@@ -355,7 +355,7 @@ class HandlersTest(IntegrationTest):
         }})
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual(event['metaData']['food'], {
             'fruit': ['pear', 'grape']
@@ -379,7 +379,7 @@ class HandlersTest(IntegrationTest):
         logger.info('Everything is fine')
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertTrue('tab' not in event['metaData'])
         self.assertEqual(event['metaData']['tab2'], {
@@ -401,7 +401,7 @@ class HandlersTest(IntegrationTest):
         logger.info('Everything is fine')
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertTrue('tab' not in event['metaData'])
         self.assertTrue('tab2' not in event['metaData'])
@@ -421,7 +421,7 @@ class HandlersTest(IntegrationTest):
         logger.info('Everything is fine')
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual(event['metaData']['tab'], {
             'key': 'value', 'key2': 'other value'
@@ -437,7 +437,7 @@ class HandlersTest(IntegrationTest):
         logger.info('Everything is fine')
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
 
@@ -454,7 +454,7 @@ class HandlersTest(IntegrationTest):
         logger.info('Everything is fine')
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
 
@@ -468,7 +468,7 @@ class HandlersTest(IntegrationTest):
         logger.info("This happened", extra={'groupingHash': '<hash value>'})
 
         self.assertSentReportCount(1)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
 
@@ -502,7 +502,7 @@ class HandlersTest(IntegrationTest):
         # the notify caused by the 'error' log
         assert len(handler.client.configuration.breadcrumbs) == 2
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
 
@@ -645,7 +645,7 @@ class HandlersTest(IntegrationTest):
             # from the notify caused by the 'error' log
             assert len(default_client.configuration.breadcrumbs) == 2
 
-            json_body = self.server.received[0]['json_body']
+            json_body = self.server.events_received[0]['json_body']
             event = json_body['events'][0]
             exception = event['exceptions'][0]
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -16,6 +16,7 @@ def use_client_logger(func):
         client = Client(
             api_key='abcdef',
             endpoint=obj.server.url,
+            session_endpoint=obj.server.url,
             asynchronous=False
         )
 
@@ -44,10 +45,14 @@ def scoped_logger():
 class HandlersTest(IntegrationTest):
     def setUp(self):
         super(HandlersTest, self).setUp()
-        bugsnag.configure(endpoint=self.server.url,
-                          notify_release_stages=['dev'],
-                          release_stage='dev',
-                          asynchronous=False)
+        bugsnag.configure(
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            notify_release_stages=['dev'],
+            release_stage='dev',
+            asynchronous=False,
+        )
+
         bugsnag.logger.setLevel(logging.INFO)
 
     def tearDown(self):
@@ -238,6 +243,7 @@ class HandlersTest(IntegrationTest):
         client = Client(
             api_key='abcdef',
             endpoint=self.server.url,
+            session_endpoint=self.server.url,
             asynchronous=False
         )
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -15,11 +15,14 @@ class TestBugsnag(IntegrationTest):
 
     def setUp(self):
         super(TestBugsnag, self).setUp()
-        bugsnag.configure(endpoint=self.server.url,
-                          api_key='tomatoes',
-                          notify_release_stages=['dev'],
-                          release_stage='dev',
-                          asynchronous=False)
+        bugsnag.configure(
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            api_key='tomatoes',
+            notify_release_stages=['dev'],
+            release_stage='dev',
+            asynchronous=False,
+        )
 
     def test_asynchronous_notify(self):
         bugsnag.configure(asynchronous=True)
@@ -176,7 +179,7 @@ class TestBugsnag(IntegrationTest):
 
         self.assertEqual(4, event['metaData']['custom']['foo'])
         self.assertEqual('[FILTERED]', event['metaData']['custom']['bar'])
-        self.assertEqual(171, exception['stacktrace'][0]['lineNumber'])
+        self.assertEqual(174, exception['stacktrace'][0]['lineNumber'])
 
     def test_notify_ignore_class(self):
         bugsnag.configure(ignore_classes=['tests.utils.ScaryException'])
@@ -665,11 +668,14 @@ class TestBugsnag(IntegrationTest):
         self.assertEqual(event['metaData']['test']['array'], [1, 2])
 
     def test_middleware_stack_order(self):
-        client = bugsnag.Client(endpoint=self.server.url,
-                                api_key='tomatoes',
-                                notify_release_stages=['dev'],
-                                release_stage='dev',
-                                asynchronous=False)
+        client = bugsnag.Client(
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            api_key='tomatoes',
+            notify_release_stages=['dev'],
+            release_stage='dev',
+            asynchronous=False,
+        )
 
         def first_callback(event):
             event.metadata['test']['array'].append(1)
@@ -688,11 +694,14 @@ class TestBugsnag(IntegrationTest):
         self.assertEqual(event['metaData']['test']['array'], [1, 2])
 
     def test_internal_middleware_changes_severity(self):
-        client = bugsnag.Client(endpoint=self.server.url,
-                                api_key='tomatoes',
-                                notify_release_stages=['dev'],
-                                release_stage='dev',
-                                asynchronous=False)
+        client = bugsnag.Client(
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            api_key='tomatoes',
+            notify_release_stages=['dev'],
+            release_stage='dev',
+            asynchronous=False,
+        )
 
         def severity_callback(event):
             event.severity = 'info'
@@ -708,11 +717,14 @@ class TestBugsnag(IntegrationTest):
         self.assertEqual(event['severityReason']['type'], 'handledException')
 
     def test_internal_middleware_can_change_severity_reason(self):
-        client = bugsnag.Client(endpoint=self.server.url,
-                                api_key='tomatoes',
-                                notify_release_stages=['dev'],
-                                release_stage='dev',
-                                asynchronous=False)
+        client = bugsnag.Client(
+            endpoint=self.server.url,
+            session_endpoint=self.server.url,
+            api_key='tomatoes',
+            notify_release_stages=['dev'],
+            release_stage='dev',
+            asynchronous=False,
+        )
 
         def severity_reason_callback(event):
             event.severity_reason['type'] = 'testReason'

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -16,8 +16,8 @@ class TestBugsnag(IntegrationTest):
     def setUp(self):
         super(TestBugsnag, self).setUp()
         bugsnag.configure(
-            endpoint=self.server.url,
-            session_endpoint=self.server.url,
+            endpoint=self.server.events_url,
+            session_endpoint=self.server.sessions_url,
             api_key='tomatoes',
             notify_release_stages=['dev'],
             release_stage='dev',
@@ -31,71 +31,71 @@ class TestBugsnag(IntegrationTest):
         self.server.paused = False
 
         start = time.time()
-        while len(self.server.received) == 0:
+        while len(self.server.events_received) == 0:
             if time.time() > (start + 0.5):
                 raise Exception(
                     'Timed out while waiting for asynchronous request.')
 
             time.sleep(0.001)
 
-        self.assertEqual(len(self.server.received), 1)
+        self.assertEqual(len(self.server.events_received), 1)
 
     def test_notify_method(self):
         bugsnag.notify(ScaryException('unexpected failover'))
-        request = self.server.received[0]
+        request = self.server.events_received[0]
         self.assertEqual('POST', request['method'])
 
     def test_notify_request_count(self):
         bugsnag.notify(ScaryException('unexpected failover'))
-        self.assertEqual(1, len(self.server.received))
+        self.assertEqual(1, len(self.server.events_received))
 
     def test_notify_configured_api_key(self):
         bugsnag.notify(ScaryException('unexpected failover'))
-        headers = self.server.received[0]['headers']
+        headers = self.server.events_received[0]['headers']
         self.assertEqual('tomatoes', headers['Bugsnag-Api-Key'])
 
     def test_notify_configured_release_stage(self):
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('dev', event['releaseStage'])
 
     def test_notify_unconfigured_release_stage(self):
         bugsnag.configure(release_stage='pickles')
         bugsnag.notify(ScaryException('unexpected failover'))
-        self.assertEqual(0, len(self.server.received))
+        self.assertEqual(0, len(self.server.events_received))
 
     def test_notify_default_severity(self):
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('warning', event['severity'])
 
     def test_notify_override_severity(self):
         bugsnag.notify(ScaryException('unexpected failover'),
                        severity='info')
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('info', event['severity'])
 
     def test_notify_configured_app_version(self):
         bugsnag.configure(app_version='343.2.10')
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('343.2.10', event['app']['version'])
 
     def test_notify_override_context(self):
         bugsnag.notify(ScaryException('unexpected failover'),
                        context='/some/path')
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('/some/path', event['context'])
 
     def test_notify_override_grouping_hash(self):
         bugsnag.notify(ScaryException('unexpected failover'),
                        grouping_hash='Callout errors')
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('Callout errors', event['groupingHash'])
 
@@ -104,7 +104,7 @@ class TestBugsnag(IntegrationTest):
                        user={'name': 'bob',
                              'email': 'mcbob@example.com',
                              'id': '542347329'})
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('bob', event['user']['name'])
         self.assertEqual('542347329', event['user']['id'])
@@ -113,7 +113,7 @@ class TestBugsnag(IntegrationTest):
     def test_notify_configured_hostname(self):
         bugsnag.configure(hostname='I_AM_ROOT')
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('I_AM_ROOT', event['device']['hostname'])
 
@@ -121,7 +121,7 @@ class TestBugsnag(IntegrationTest):
         bugsnag.add_metadata_tab('food', {'beans': 3, 'corn': 'purple'})
         bugsnag.notify(ScaryException('unexpected failover'),
                        metadata={'food': {'beans': 5}, 'skills': {'spear': 6}})
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual(6, event['metaData']['skills']['spear'])
         self.assertEqual('purple', event['metaData']['food']['corn'])
@@ -130,7 +130,7 @@ class TestBugsnag(IntegrationTest):
     def test_notify_configured_metadata_sections(self):
         bugsnag.add_metadata_tab('food', {'beans': 3, 'corn': 'purple'})
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('purple', event['metaData']['food']['corn'])
         self.assertEqual(3, event['metaData']['food']['beans'])
@@ -139,7 +139,7 @@ class TestBugsnag(IntegrationTest):
         bugsnag.configure(params_filters=['apple', 'grape'])
         bugsnag.notify(ScaryException('unexpected failover'),
                        apple='four', cantaloupe='green')
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('[FILTERED]', event['metaData']['custom']['apple'])
         self.assertEqual('green', event['metaData']['custom']['cantaloupe'])
@@ -147,7 +147,7 @@ class TestBugsnag(IntegrationTest):
     def test_notify_device_filter(self):
         bugsnag.configure(params_filters=['hostname'])
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('[FILTERED]', event['device']['hostname'])
 
@@ -161,7 +161,7 @@ class TestBugsnag(IntegrationTest):
                            "firstname": "Test",
                            "lastname": "Man"
                            })
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('[FILTERED]', event['user']['address'])
         self.assertEqual('[FILTERED]', event['user']['phonenumber'])
@@ -173,7 +173,7 @@ class TestBugsnag(IntegrationTest):
         bugsnag.configure(params_filters=['bar'])
         bugsnag.notify(ScaryException('unexpected failover'), foo=4, bar=76)
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
 
@@ -184,13 +184,13 @@ class TestBugsnag(IntegrationTest):
     def test_notify_ignore_class(self):
         bugsnag.configure(ignore_classes=['tests.utils.ScaryException'])
         bugsnag.notify(ScaryException('unexpected failover'))
-        self.assertEqual(0, len(self.server.received))
+        self.assertEqual(0, len(self.server.events_received))
 
     def test_notify_ignore_class_nested(self):
         bugsnag.configure(
             ignore_classes=['tests.utils.ScaryException.NestedScaryException'])
         bugsnag.notify(ScaryException.NestedScaryException('nested'))
-        self.assertEqual(0, len(self.server.received))
+        self.assertEqual(0, len(self.server.events_received))
 
     def test_ignore_classes_checks_exception_chain_with_explicit_cause(self):
         bugsnag.configure(ignore_classes=['ArithmeticError'])
@@ -224,11 +224,11 @@ class TestBugsnag(IntegrationTest):
         config = bugsnag.configure()
         config.api_key = None
         bugsnag.notify(ScaryException('unexpected failover'))
-        self.assertEqual(0, len(self.server.received))
+        self.assertEqual(0, len(self.server.events_received))
 
     def test_notify_custom_app_type(self):
         bugsnag.notify(ScaryException('unexpected failover'), app_type='work')
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('work', event['app']['type'])
 
@@ -240,14 +240,14 @@ class TestBugsnag(IntegrationTest):
         bugsnag.configure(app_type='rq')
         bugsnag.before_notify(callback)
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('whopper', event['app']['type'])
 
     def test_notify_configured_app_type(self):
         bugsnag.configure(app_type='rq')
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('rq', event['app']['type'])
 
@@ -259,8 +259,8 @@ class TestBugsnag(IntegrationTest):
 
         bugsnag.before_notify(callback)
         bugsnag.notify(ScaryException('unexpected failover'))
-        self.assertEqual(1, len(self.server.received))
-        json_body = self.server.received[0]['json_body']
+        self.assertEqual(1, len(self.server.events_received))
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('bar', event['metaData']['custom']['foo'])
 
@@ -271,7 +271,7 @@ class TestBugsnag(IntegrationTest):
 
         bugsnag.before_notify(callback)
         bugsnag.notify(ScaryException('unexpected failover'))
-        self.assertEqual(0, len(self.server.received))
+        self.assertEqual(0, len(self.server.events_received))
 
     def test_notify_before_notify_modifying_api_key(self):
 
@@ -280,7 +280,7 @@ class TestBugsnag(IntegrationTest):
 
         bugsnag.before_notify(callback)
         bugsnag.notify(ScaryException('unexpected failover'))
-        headers = self.server.received[0]['headers']
+        headers = self.server.events_received[0]['headers']
         self.assertEqual('sandwich', headers['Bugsnag-Api-Key'])
 
     def test_notify_before_notify_modifying_metadata(self):
@@ -290,7 +290,7 @@ class TestBugsnag(IntegrationTest):
 
         bugsnag.before_notify(callback)
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('bar', event['metaData']['foo']['sandwich'])
 
@@ -301,21 +301,21 @@ class TestBugsnag(IntegrationTest):
 
         bugsnag.before_notify(callback)
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('green', event['metaData']['custom']['color'])
 
     def test_notify_configured_lib_root(self):
         bugsnag.configure(lib_root='/the/basement')
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('/the/basement', event['libRoot'])
 
     def test_notify_configured_project_root(self):
         bugsnag.configure(project_root='/the/basement')
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('/the/basement', event['projectRoot'])
 
@@ -323,7 +323,7 @@ class TestBugsnag(IntegrationTest):
         bugsnag.configure(project_root=Path('/the/basement'))
         bugsnag.notify(ScaryException('unexpected failover'))
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
 
         assert event['projectRoot'] == '/the/basement'
@@ -331,31 +331,31 @@ class TestBugsnag(IntegrationTest):
     def test_notify_invalid_severity(self):
         bugsnag.notify(ScaryException('unexpected failover'),
                        severity='debug')
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('warning', event['severity'])
 
     def test_notify_override_deprecated_user_id(self):
         bugsnag.notify(ScaryException('unexpected failover'),
                        user_id='542347329')
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('542347329', event['user']['id'])
 
     def test_notify_override_api_key(self):
         bugsnag.notify(ScaryException('unexpected failover'),
                        api_key='gravy!')
-        headers = self.server.received[0]['headers']
+        headers = self.server.events_received[0]['headers']
         self.assertEqual('gravy!', headers['Bugsnag-Api-Key'])
 
     def test_notify_payload_version(self):
         bugsnag.notify(ScaryException('unexpected failover'))
-        headers = self.server.received[0]['headers']
+        headers = self.server.events_received[0]['headers']
         self.assertEqual('4.0', headers['Bugsnag-Payload-Version'])
 
     def test_notify_error_class(self):
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual('tests.utils.ScaryException', exception['errorClass'])
@@ -368,7 +368,7 @@ class TestBugsnag(IntegrationTest):
                 raise Exception('nah')
 
         bugsnag.notify(ScaryException('unexpected failover'), bad=BadThings())
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('[BADENCODING]', event['metaData']['custom']['bad'])
 
@@ -377,7 +377,7 @@ class TestBugsnag(IntegrationTest):
         a['baz'] = a
         bugsnag.add_metadata_tab('a', a)
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('bar', event['metaData']['a']['foo'])
         self.assertEqual('[RECURSIVE]', event['metaData']['a']['baz']['baz'])
@@ -387,7 +387,7 @@ class TestBugsnag(IntegrationTest):
         a.append(a)
         bugsnag.add_metadata_tab('a', {'b': a})
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual(['foo', 'bar', '[RECURSIVE]'],
                          event['metaData']['a']['b'])
@@ -395,7 +395,7 @@ class TestBugsnag(IntegrationTest):
     def test_notify_metadata_bool_value(self):
         bugsnag.notify(ScaryException('unexpected failover'),
                        value=True, value2=False)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual(True, event['metaData']['custom']['value'])
         self.assertEqual(False, event['metaData']['custom']['value2'])
@@ -403,17 +403,17 @@ class TestBugsnag(IntegrationTest):
     def test_notify_metadata_complex_value(self):
         bugsnag.notify(ScaryException('unexpected failover'),
                        value=(5 + 0j), value2=(13 + 3.4j))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('(5+0j)', event['metaData']['custom']['value'])
         self.assertEqual('(13+3.4j)', event['metaData']['custom']['value2'])
 
     def test_notify_non_exception(self):
         bugsnag.notify(2)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
-        self.assertEqual(1, len(self.server.received))
+        self.assertEqual(1, len(self.server.events_received))
         self.assertEqual('RuntimeError', exception['errorClass'])
         self.assertTrue(repr(2) in exception['message'])
 
@@ -425,26 +425,26 @@ class TestBugsnag(IntegrationTest):
                 raise Exception('nah')
 
         bugsnag.notify(BadThings())
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual('[BADENCODING]', exception['message'])
 
     def test_notify_single_value_tuple(self):
         bugsnag.notify((None,))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
-        self.assertEqual(1, len(self.server.received))
+        self.assertEqual(1, len(self.server.events_received))
         self.assertEqual('RuntimeError', exception['errorClass'])
         self.assertTrue(repr(None) in exception['message'])
 
     def test_notify_invalid_values_tuple(self):
         bugsnag.notify((None, 2, "foo"))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
-        self.assertEqual(1, len(self.server.received))
+        self.assertEqual(1, len(self.server.events_received))
         self.assertEqual('RuntimeError', exception['errorClass'])
         self.assertTrue(repr(2) in exception['message'])
 
@@ -456,11 +456,11 @@ class TestBugsnag(IntegrationTest):
             backtrace = sys.exc_info()[2]
 
         bugsnag.notify(Exception("foo"), traceback=backtrace)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         stacktrace = exception['stacktrace']
-        self.assertEqual(1, len(self.server.received))
+        self.assertEqual(1, len(self.server.events_received))
         self.assertEqual('foo', exception['message'])
         self.assertEqual('test_notify_exception_with_traceback_option',
                          stacktrace[0]['method'])
@@ -476,27 +476,27 @@ class TestBugsnag(IntegrationTest):
             bugsnag.notify((Exception, Exception("foo"), backtrace))
 
         send_notify()
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         stacktrace = exception['stacktrace']
-        self.assertEqual(1, len(self.server.received))
+        self.assertEqual(1, len(self.server.events_received))
         self.assertEqual('foo', exception['message'])
         self.assertEqual('send_notify',
                          stacktrace[0]['method'])
 
     def test_notify_exception_tuple(self):
         bugsnag.notify((Exception, Exception("foo"), None))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
-        self.assertEqual(1, len(self.server.received))
+        self.assertEqual(1, len(self.server.events_received))
         self.assertEqual("RuntimeError", exception['errorClass'])
 
     def test_notify_metadata_set_value(self):
         bugsnag.notify(ScaryException('unexpected failover'),
                        value=set([6, "cow", "gravy"]))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         value = event['metaData']['custom']['value']
         self.assertEqual(3, len(value))
@@ -507,7 +507,7 @@ class TestBugsnag(IntegrationTest):
     def test_notify_metadata_tuple_value(self):
         bugsnag.notify(ScaryException('unexpected failover'),
                        value=(3, "cow", "gravy"))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual([3, "cow", "gravy"],
                          event['metaData']['custom']['value'])
@@ -515,14 +515,14 @@ class TestBugsnag(IntegrationTest):
     def test_notify_metadata_integer_value(self):
         bugsnag.notify(ScaryException('unexpected failover'),
                        value=5, value2=-13)
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual(5, event['metaData']['custom']['value'])
         self.assertEqual(-13, event['metaData']['custom']['value2'])
 
     def test_notify_error_message(self):
         bugsnag.notify(ScaryException('unexpécted failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         exception = event['exceptions'][0]
         self.assertEqual('unexpécted failover', exception['message'])
@@ -545,7 +545,7 @@ class TestBugsnag(IntegrationTest):
             'self': self,
             'var': bins
         }})
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertEqual('∆πåß∂ƒ', event['metaData']['payload']['project'])
         self.assertEqual('♥♥♥♥♥♥',
@@ -571,7 +571,7 @@ class TestBugsnag(IntegrationTest):
 
     def test_notify_stacktrace(self):
         samples.call_bugsnag_nested()
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         frames = event['exceptions'][0]['stacktrace']
 
@@ -603,18 +603,17 @@ class TestBugsnag(IntegrationTest):
         self.assertEqual('', frames[2]['code']['4'])
 
     def test_notify_proxy(self):
-        bugsnag.configure(proxy_host=self.server.url)
+        bugsnag.configure(proxy_host='http://' + self.server.address)
         bugsnag.notify(ScaryException('unexpected failover'))
 
-        self.assertEqual(len(self.server.received), 1)
-        self.assertEqual(self.server.received[0]['method'], 'POST')
-        self.assertEqual(self.server.received[0]['path'].strip('/'),
-                         self.server.url)
+        assert self.sent_report_count == 1
+        assert self.server.events_received[0]['method'] == 'POST'
+        assert self.server.events_received[0]['path'] == self.server.events_url
 
     def test_notify_unhandled_defaults(self):
         bugsnag.notify(ScaryException("unexpected failover"))
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertFalse(event['unhandled'])
         self.assertEqual(event['severityReason'], {
@@ -624,7 +623,7 @@ class TestBugsnag(IntegrationTest):
     def test_notify_severity_overridden(self):
         bugsnag.notify(ScaryException("unexpected failover"), severity="info")
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertFalse(event['unhandled'])
         self.assertEqual(event['severityReason'], {
@@ -639,7 +638,7 @@ class TestBugsnag(IntegrationTest):
 
         bugsnag.notify(ScaryException("unexpected failover"), severity="error")
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertFalse(event['unhandled'])
         self.assertEqual(event['severityReason'], {
@@ -662,15 +661,15 @@ class TestBugsnag(IntegrationTest):
 
         bugsnag.notify(ScaryException('unexpected failover'),
                        test={'array': []})
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
 
         self.assertEqual(event['metaData']['test']['array'], [1, 2])
 
     def test_middleware_stack_order(self):
         client = bugsnag.Client(
-            endpoint=self.server.url,
-            session_endpoint=self.server.url,
+            endpoint=self.server.events_url,
+            session_endpoint=self.server.sessions_url,
             api_key='tomatoes',
             notify_release_stages=['dev'],
             release_stage='dev',
@@ -688,15 +687,15 @@ class TestBugsnag(IntegrationTest):
 
         client.notify(ScaryException('unexpected failover'),
                       test={'array': []})
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
 
         self.assertEqual(event['metaData']['test']['array'], [1, 2])
 
     def test_internal_middleware_changes_severity(self):
         client = bugsnag.Client(
-            endpoint=self.server.url,
-            session_endpoint=self.server.url,
+            endpoint=self.server.events_url,
+            session_endpoint=self.server.sessions_url,
             api_key='tomatoes',
             notify_release_stages=['dev'],
             release_stage='dev',
@@ -710,7 +709,7 @@ class TestBugsnag(IntegrationTest):
         internal_middleware.before_notify(severity_callback)
 
         client.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
 
         self.assertEqual(event['severity'], 'info')
@@ -718,8 +717,8 @@ class TestBugsnag(IntegrationTest):
 
     def test_internal_middleware_can_change_severity_reason(self):
         client = bugsnag.Client(
-            endpoint=self.server.url,
-            session_endpoint=self.server.url,
+            endpoint=self.server.events_url,
+            session_endpoint=self.server.sessions_url,
             api_key='tomatoes',
             notify_release_stages=['dev'],
             release_stage='dev',
@@ -733,7 +732,7 @@ class TestBugsnag(IntegrationTest):
         internal_middleware.before_notify(severity_reason_callback)
 
         client.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
 
         self.assertEqual(event['severityReason']['type'], 'testReason')
@@ -746,7 +745,7 @@ class TestBugsnag(IntegrationTest):
         bugsnag.before_notify(severity_callback)
 
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
 
         self.assertEqual(event['severity'], 'info')
@@ -761,7 +760,7 @@ class TestBugsnag(IntegrationTest):
         bugsnag.before_notify(severity_reason_callback)
 
         bugsnag.notify(ScaryException('unexpected failover'))
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
 
         self.assertEqual(event['severityReason']['type'], 'handledException')
@@ -769,7 +768,7 @@ class TestBugsnag(IntegrationTest):
     def test_auto_notify_defaults(self):
         bugsnag.auto_notify(ScaryException("unexpected failover"))
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertTrue(event['unhandled'])
         self.assertEqual(event['severity'], 'error')
@@ -790,7 +789,7 @@ class TestBugsnag(IntegrationTest):
             }
         )
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertFalse(event['unhandled'])
         self.assertEqual(event['severity'], 'info')
@@ -808,7 +807,7 @@ class TestBugsnag(IntegrationTest):
         except Exception:
             bugsnag.auto_notify_exc_info()
 
-        self.assertEqual(len(self.server.received), 0)
+        self.assertEqual(len(self.server.events_received), 0)
 
     def test_auto_notify_exc_info(self):
         try:
@@ -816,8 +815,8 @@ class TestBugsnag(IntegrationTest):
         except Exception:
             bugsnag.auto_notify_exc_info()
 
-        self.assertEqual(len(self.server.received), 1)
-        json_body = self.server.received[0]['json_body']
+        self.assertEqual(len(self.server.events_received), 1)
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertTrue(event['unhandled'])
         self.assertEqual(event['severity'], 'error')
@@ -845,7 +844,7 @@ class TestBugsnag(IntegrationTest):
                 }
             )
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         event = json_body['events'][0]
         self.assertFalse(event['unhandled'])
         self.assertEqual(event['severity'], 'info')
@@ -863,7 +862,7 @@ class TestBugsnag(IntegrationTest):
         bugsnag.configure(asynchronous=True)
         bugsnag.notify(ScaryException('unexpected failover'),
                        asynchronous=False)
-        assert len(self.server.received) == 1
+        assert len(self.server.events_received) == 1
 
     def test_meta_data_warning(self):
         with pytest.warns(DeprecationWarning) as records:
@@ -875,6 +874,6 @@ class TestBugsnag(IntegrationTest):
                                                'argument has been replaced ' +
                                                'with "metadata"')
 
-        json_body = self.server.received[0]['json_body']
+        json_body = self.server.events_received[0]['json_body']
         metadata = json_body['events'][0]['metaData']
         assert metadata['fruit']['apples'] == 2

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -100,8 +100,6 @@ class TestConfiguration(IntegrationTest):
             api_key='a05afff2bd2ffaf0ab0f52715bbdcffd',
             session_endpoint=self.server.url,
             asynchronous=False,
-            release_stage="dev",
-            notify_release_stages=["prod"],
         )
         client.session_tracker.send_sessions()
         self.assertEqual(0, len(self.server.received))
@@ -123,8 +121,6 @@ class TestConfiguration(IntegrationTest):
             api_key=None,
             session_endpoint=self.server.url,
             asynchronous=False,
-            release_stage="dev",
-            notify_release_stages=["prod"],
         )
         client.session_tracker.start_session()
         client.session_tracker.send_sessions()

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -1,4 +1,3 @@
-import pytest
 import logging
 import platform
 
@@ -6,7 +5,7 @@ from bugsnag import Client
 from bugsnag.configuration import Configuration
 from bugsnag.notifier import _NOTIFIER_INFORMATION
 from bugsnag.sessiontracker import SessionTracker
-from tests.utils import IntegrationTest, MissingRequestError
+from tests.utils import IntegrationTest
 from unittest.mock import Mock
 
 
@@ -178,7 +177,7 @@ class TestConfiguration(IntegrationTest):
 
         assert self.server.sent_session_count == 1
 
-    def test_session_tracker_doesnt_start_delivery_when_auto_capture_is_off(self):  # noqa
+    def test_session_tracker_starts_delivery_when_auto_capture_is_off(self):
         client = Client(
             api_key='a05afff2bd2ffaf0ab0f52715bbdcffd',
             auto_capture_sessions=False,
@@ -188,11 +187,8 @@ class TestConfiguration(IntegrationTest):
 
         client.session_tracker.start_session()
 
-        assert client.session_tracker.delivery_thread is None
+        force_timer_to_fire(client.session_tracker.delivery_thread)
 
-        # we expect not to receive a session request, so this wait should
-        # timeout
-        with pytest.raises(MissingRequestError):
-            self.server.wait_for_session()
+        self.server.wait_for_session()
 
-        assert self.server.sent_session_count == 0
+        assert self.server.sent_session_count == 1

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -10,13 +10,11 @@ from unittest.mock import Mock
 
 
 class TestConfiguration(IntegrationTest):
-    def setUp(self):
-        super(TestConfiguration, self).setUp()
-        self.config = Configuration()
-        self.config.auto_capture_sessions = True
-
     def test_session_tracker_adds_session_object_to_queue(self):
-        tracker = SessionTracker(self.config)
+        config = Configuration()
+        config.auto_capture_sessions = True
+
+        tracker = SessionTracker(config)
         tracker.auto_sessions = True
         tracker.start_session()
 

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -118,7 +118,7 @@ class TestConfiguration(IntegrationTest):
 
     def test_session_tracker_does_not_send_when_misconfigured(self):
         client = Client(
-            api_key=None,
+            api_key='',
             session_endpoint=self.server.url,
             asynchronous=False,
         )

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -24,6 +24,7 @@ class TestConfiguration(IntegrationTest):
 
     def test_session_tracker_send_sessions_sends_sessions(self):
         client = Client(
+            api_key='a05afff2bd2ffaf0ab0f52715bbdcffd',
             auto_capture_sessions=True,
             session_endpoint=self.server.url,
             asynchronous=False
@@ -41,6 +42,7 @@ class TestConfiguration(IntegrationTest):
 
     def test_session_tracker_sets_details_from_config(self):
         client = Client(
+            api_key='a05afff2bd2ffaf0ab0f52715bbdcffd',
             auto_capture_sessions=True,
             session_endpoint=self.server.url,
             asynchronous=False
@@ -71,7 +73,7 @@ class TestConfiguration(IntegrationTest):
 
     def test_session_middleware_attaches_session_to_event(self):
         client = Client(
-            auto_capture_sessions=True,
+            api_key='a05afff2bd2ffaf0ab0f52715bbdcffd',
             session_endpoint=self.server.url + '/ignore',
             endpoint=self.server.url,
             asynchronous=False
@@ -95,7 +97,7 @@ class TestConfiguration(IntegrationTest):
 
     def test_session_tracker_does_not_send_when_nothing_to_send(self):
         client = Client(
-            api_key='fff',
+            api_key='a05afff2bd2ffaf0ab0f52715bbdcffd',
             session_endpoint=self.server.url,
             asynchronous=False,
             release_stage="dev",
@@ -106,7 +108,7 @@ class TestConfiguration(IntegrationTest):
 
     def test_session_tracker_does_not_send_when_disabled(self):
         client = Client(
-            api_key='fff',
+            api_key='a05afff2bd2ffaf0ab0f52715bbdcffd',
             session_endpoint=self.server.url,
             asynchronous=False,
             release_stage="dev",

--- a/tests/test_sessiontracker.py
+++ b/tests/test_sessiontracker.py
@@ -1,4 +1,3 @@
-import time
 import logging
 import platform
 
@@ -83,8 +82,8 @@ class TestConfiguration(IntegrationTest):
 
         client.session_tracker.start_session()
         client.notify(Exception("Test"))
-        while len(self.server.received) == 0:
-            time.sleep(0.5)
+
+        assert len(self.server.received) == 1
 
         json_body = self.server.received[0]['json_body']
         session = json_body['events'][0]['session']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,9 +31,17 @@ class IntegrationTest(unittest.TestCase):
         self.server.sessions_received = []
 
     def tearDown(self):
-        bugsnag.legacy.default_client.uninstall_sys_hook()
-        client = bugsnag.Client()
-        client.configuration.api_key = 'some key'
+        previous_client = bugsnag.legacy.default_client
+        previous_client.uninstall_sys_hook()
+
+        if previous_client.session_tracker.delivery_thread is not None:
+            previous_client.session_tracker.delivery_thread.cancel()
+            previous_client.session_tracker.delivery_thread = None
+
+        previous_client.session_tracker.session_counts = {}
+
+        client = bugsnag.Client(api_key='some key')
+
         bugsnag.legacy.default_client = client
         bugsnag.legacy.configuration = client.configuration
 

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ deps=
     exceptiongroup: exceptiongroup
     lint: flake8
     lint: mypy
+    lint: types-pkg_resources
     lint: types-requests
     lint: types-Flask
     lint: types-contextvars


### PR DESCRIPTION
## v4.6.1 (2023-12-11)

### Enhancements

* Avoid using deprecated `flask.__version__` attribute
  [#365](https://github.com/bugsnag/bugsnag-python/pull/365)

### Bug fixes

* Ensure the session delivery queue is started regardless of `auto_capture_sessions` configuration
  [#367](https://github.com/bugsnag/bugsnag-python/pull/367)
