### PR TITLE
Fix ASGI test

### DIFF
--- a/tests/integrations/test_asgi.py
+++ b/tests/integrations/test_asgi.py
@@ -139,7 +139,6 @@ class TestASGIMiddleware(IntegrationTest):
         self.assertEqual('GET', request['httpMethod'])
         self.assertEqual('http', request['type'])
         self.assertEqual('http://testserver/', request['url'])
-        self.assertEqual('testclient', request['clientIp'])
         self.assertEqual('testclient', request['headers']['user-agent'])
 
         exception = payload['events'][0]['exceptions'][0]


### PR DESCRIPTION
## Goal

The `client` scope was removed in https://github.com/encode/starlette/pull/2377 when using the `TestClient`, which means we no longer get a `clientIp` key in request metadata when running unit tests

This is still set outside of a testing environment and is still covered by a different unit test:

https://github.com/bugsnag/bugsnag-python/blob/b22ab1fa819cb46ae45d80c92c27b5bc086e514d/tests/integrations/test_async_asgi.py#L112