### PR TITLE
Ensure sessions are sent at exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Ensure sessions are sent at exit
+  [#371](https://github.com/bugsnag/bugsnag-python/pull/371)
+
 ## v4.6.1 (2023-12-11)
 
 ### Bug fixes

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -273,6 +273,25 @@ class Configuration:
     def delivery(self, value):
         if hasattr(value, 'deliver') and callable(value.deliver):
             self._delivery = value
+
+            # deliver_sessions is _technically_ optional in that if you disable
+            # session tracking it will never be called
+            # this should be made mandatory in the next major release
+            if (
+                hasattr(value, 'deliver_sessions') and
+                callable(value.deliver_sessions)
+            ):
+                parameter_names = value.deliver_sessions.__code__.co_varnames
+
+                if 'options' not in parameter_names:
+                    warnings.warn(
+                        'delivery.deliver_sessions should accept an ' +
+                        '"options" parameter to allow for synchronous ' +
+                        'delivery, sessions may be lost when the process ' +
+                        'exits',
+                        DeprecationWarning
+                    )
+
         else:
             message = ('delivery should implement Delivery interface, got ' +
                        '{0}. This will be an error in a future release.')

--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -61,7 +61,7 @@ class Delivery:
         """
         pass
 
-    def deliver_sessions(self, config, payload: Any):
+    def deliver_sessions(self, config, payload: Any, options=None):
         """
         Sends sessions to Bugsnag
         """
@@ -72,10 +72,12 @@ class Delivery:
                               'No sessions will be sent to Bugsnag.')
                 self.sent_session_warning = True
         else:
-            options = {
-                'endpoint': config.session_endpoint,
-                'success': 202,
-            }
+            if options is None:
+                options = {}
+
+            options['endpoint'] = config.session_endpoint
+            options['success'] = 202
+
             self.deliver(config, payload, options)
 
     def queue_request(self, request: Callable, config, options: Dict):

--- a/bugsnag/delivery.py
+++ b/bugsnag/delivery.py
@@ -55,7 +55,7 @@ class Delivery:
     def __init__(self):
         self.sent_session_warning = False
 
-    def deliver(self, config, payload: Any, options={}):
+    def deliver(self, config, payload: Any, options=None):
         """
         Sends error reports to Bugsnag
         """
@@ -98,8 +98,9 @@ class Delivery:
 
 
 class UrllibDelivery(Delivery):
-
-    def deliver(self, config, payload: Any, options={}):
+    def deliver(self, config, payload: Any, options=None):
+        if options is None:
+            options = {}
 
         def request():
             uri = options.pop('endpoint', config.endpoint)
@@ -136,8 +137,9 @@ class UrllibDelivery(Delivery):
 
 
 class RequestsDelivery(Delivery):
-
-    def deliver(self, config, payload: Any, options={}):
+    def deliver(self, config, payload: Any, options=None):
+        if options is None:
+            options = {}
 
         def request():
             uri = options.pop('endpoint', config.endpoint)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -195,6 +195,13 @@ class TestConfiguration(unittest.TestCase):
             def deliv(self, *args, **kwargs):
                 pass
 
+        class OkDelivery:
+            def deliver(self, *args, **kwargs):
+                pass
+
+            def deliver_sessions(self, config, payload):
+                pass
+
         class GoodDelivery(object):
             def deliver(self, *args, **kwargs):
                 pass
@@ -212,6 +219,20 @@ class TestConfiguration(unittest.TestCase):
             c.configure(delivery=good)
             assert len(record) == 1
             assert c.delivery == good
+
+        with pytest.warns(DeprecationWarning) as record:
+            ok = OkDelivery()
+
+            c.configure(delivery=ok)
+
+            assert len(record) == 1
+            assert str(record[0].message) == (
+                'delivery.deliver_sessions should accept an "options" ' +
+                'parameter to allow for synchronous delivery, sessions ' +
+                'may be lost when the process exits'
+            )
+
+            assert c.delivery == ok
 
     def test_validate_hostname(self):
         c = Configuration()


### PR DESCRIPTION
## Goal

We use an `atexit` hook to deliver any outstanding sessions when the process exits, but this delivery happens asynchronously and therefore isn't guaranteed to finish

This PR adds an `options` parameter to `deliver_sessions` (matching `deliver`) that allows forcing synchronous delivery and then uses this to send sessions synchronously at exit