### PR TITLE
fix: utcnow() warning with python 3.12

### DIFF
--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -6,7 +6,7 @@ from typing import AnyStr, Tuple, Optional
 import warnings
 import copy
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse, urlunsplit, parse_qs
 
 
@@ -424,7 +424,7 @@ def remove_query_from_url(url: AnyStr) -> Optional[AnyStr]:
 # fallback implementation for Python 3.5
 try:
     # this will raise if 'timespec' isn't supported
-    datetime.utcnow().isoformat(timespec='milliseconds')  # type: ignore
+    dt.datetime.now(timezone.utc).replace(tzinfo=None).isoformat(timespec='milliseconds')  # type: ignore
 
     def to_rfc3339(dt: datetime) -> str:
         return dt.isoformat(timespec='milliseconds')  # type: ignore


### PR DESCRIPTION
Fix warning for python 3.12 on utcnow()

## Goal

Remove the following deprecation warning:

DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC)


## Design

Since datetule.UTC does not exists in previous versions, 

## Changeset

Replaced utcnow()  with `dt.datetime.now(timezone.utc).replace(tzinfo=None)`

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->