### PR TITLE
Add support for post-delivery callbacks

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,7 @@ from threading import Thread
 from http.server import SimpleHTTPRequestHandler, HTTPServer
 
 import bugsnag
+from bugsnag.delivery import Delivery
 
 
 try:
@@ -176,3 +177,27 @@ class FakeBugsnagServer(object):
 class ScaryException(Exception):
     class NestedScaryException(Exception):
         pass
+
+
+class QueueingDelivery(Delivery):
+    def __init__(self):
+        self._queue = []
+
+    def deliver(self, config, payload, options):
+        self._queue.append(options['post_delivery_callback'])
+
+    def flush_request_queue(self):
+        for callback in self._queue:
+            callback()
+
+        self._queue.clear()
+
+
+class BrokenDelivery(Delivery):
+    def deliver(self, config, payload, options):
+        def request():
+            raise Exception('broken!')
+
+        options['asynchronous'] = False
+
+        self.queue_request(request, config, options)


### PR DESCRIPTION
## Goal

Adds a new `post_delivery_callback` setting to the `options` in the base `Delivery` class. If a callback is provided it is then called after delivery has finished

This will allow other parts of bugsnag to determine when delivery has finished, which is currently not possible for asynchronous requests

Users that have implemented their own delivery system will have to ensure the callback is called in order to fulfil the delivery contract (this will be called out in the docs)