### PR TITLE
Track in flight requests

### DIFF
--- a/bugsnag/request_tracker.py
+++ b/bugsnag/request_tracker.py
@@ -1,0 +1,49 @@
+from uuid import uuid4
+from threading import Lock
+from typing import Callable
+
+
+class RequestTracker:
+    def __init__(self):
+        self._mutex = Lock()
+        self._requests = set()  # type: set[str]
+
+    def new_request(self) -> Callable[[], None]:
+        """
+        Track a new request, returning a callback that marks the request as
+        complete.
+
+        >>> request_tracker = RequestTracker()
+        >>> mark_request_complete = request_tracker.new_request()
+        >>> # ...make the request...
+        >>> mark_request_complete()
+        """
+        request_id = uuid4().hex
+
+        with self._mutex:
+            self._requests.add(request_id)
+
+        def mark_request_complete():
+            with self._mutex:
+                # we use 'discard' instead of 'remove' to allow this callback
+                # to be called multiple times without raising an error
+                self._requests.discard(request_id)
+
+        return mark_request_complete
+
+    def has_in_flight_requests(self) -> bool:
+        """
+        See if there are any requests that have not been marked as completed.
+
+        >>> request_tracker = RequestTracker()
+        >>> request_tracker.has_in_flight_requests()
+        False
+        >>> mark_request_complete = request_tracker.new_request()
+        >>> request_tracker.has_in_flight_requests()
+        True
+        >>> mark_request_complete()
+        >>> request_tracker.has_in_flight_requests()
+        False
+        """
+        with self._mutex:
+            return bool(self._requests)

--- a/tests/test_request_tracker.py
+++ b/tests/test_request_tracker.py
@@ -1,0 +1,60 @@
+from bugsnag.request_tracker import RequestTracker
+
+
+def test_a_request_can_be_tracked():
+    tracker = RequestTracker()
+    assert not tracker.has_in_flight_requests()
+
+    tracker.new_request()
+    assert tracker.has_in_flight_requests()
+
+
+def test_a_request_can_be_marked_as_complete():
+    tracker = RequestTracker()
+    assert not tracker.has_in_flight_requests()
+
+    complete_request = tracker.new_request()
+    assert tracker.has_in_flight_requests()
+
+    complete_request()
+    assert not tracker.has_in_flight_requests()
+
+
+def test_requests_can_be_marked_as_complete():
+    tracker = RequestTracker()
+
+    complete_request_1 = tracker.new_request()
+    complete_request_2 = tracker.new_request()
+    complete_request_3 = tracker.new_request()
+
+    assert tracker.has_in_flight_requests()
+
+    complete_request_1()
+    complete_request_2()
+
+    assert tracker.has_in_flight_requests()
+
+    complete_request_3()
+    assert not tracker.has_in_flight_requests()
+
+
+def test_callbacks_can_be_called_multiple_times():
+    tracker = RequestTracker()
+    assert not tracker.has_in_flight_requests()
+
+    complete_request_1 = tracker.new_request()
+    complete_request_2 = tracker.new_request()
+
+    assert tracker.has_in_flight_requests()
+
+    complete_request_1()
+    complete_request_1()
+    complete_request_1()
+
+    assert tracker.has_in_flight_requests()
+
+    complete_request_2()
+    assert not tracker.has_in_flight_requests()
+
+    complete_request_2()
+    assert not tracker.has_in_flight_requests()


### PR DESCRIPTION
## Goal

This PR adds a `RequestTracker` class that can be used to (surprise surprise) track requests:

```python
request_tracker = RequestTracker()
mark_request_complete = request_tracker.new_request()
request_tracker.has_in_flight_requests() # => True

# ...make the request...

mark_request_complete()
request_tracker.has_in_flight_requests() # => False
```

The `Client` and `SessionTracker` use this, along with post-delivery callbacks (#375), to keep track of when there are in-flight event or session requests