### PR TITLE
Add `aws_lambda_handler` decorator to Client

### DIFF
--- a/bugsnag/__init__.py
+++ b/bugsnag/__init__.py
@@ -15,7 +15,8 @@ from bugsnag.legacy import (configuration, configure, configure_request,
                             auto_notify_exc_info, logger, leave_breadcrumb,
                             add_on_breadcrumb, remove_on_breadcrumb,
                             add_feature_flag, add_feature_flags,
-                            clear_feature_flag, clear_feature_flags)
+                            clear_feature_flag, clear_feature_flags,
+                            aws_lambda_handler)
 
 __all__ = ('Client', 'Event', 'Configuration', 'RequestConfiguration',
            'configuration', 'configure', 'configure_request',
@@ -25,4 +26,5 @@ __all__ = ('Client', 'Event', 'Configuration', 'RequestConfiguration',
            'BreadcrumbType', 'Breadcrumb', 'Breadcrumbs',
            'OnBreadcrumbCallback', 'leave_breadcrumb', 'add_on_breadcrumb',
            'remove_on_breadcrumb', 'FeatureFlag', 'add_feature_flag',
-           'add_feature_flags', 'clear_feature_flag', 'clear_feature_flags')
+           'add_feature_flags', 'clear_feature_flag', 'clear_feature_flags',
+           'aws_lambda_handler')

--- a/bugsnag/client.py
+++ b/bugsnag/client.py
@@ -366,6 +366,14 @@ class Client:
 
             raise Exception("flush timed out after %dms" % timeout_ms)
 
+    def add_metadata_tab(self, tab_name: str, data: Dict[str, Any]) -> None:
+        metadata = RequestConfiguration.get_instance().metadata
+
+        if tab_name not in metadata:
+            metadata[tab_name] = {}
+
+        metadata[tab_name].update(data)
+
 
 class ClientContext:
     def __init__(self, client,

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -38,11 +38,7 @@ def add_metadata_tab(tab_name: str, data: Dict[str, Any]):
 
     bugsnag.add_metadata_tab("user", {"id": "1", "name": "Conrad"})
     """
-    metadata = RequestConfiguration.get_instance().metadata
-    if tab_name not in metadata:
-        metadata[tab_name] = {}
-
-    metadata[tab_name].update(data)
+    default_client.add_metadata_tab(tab_name, data)
 
 
 def clear_request_config():

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Tuple, Type, Optional, Union, List
+from typing import Dict, Any, Tuple, Type, Optional, Union, List, Callable
 import types
 import sys
 
@@ -176,3 +176,10 @@ def clear_feature_flag(name: Union[str, bytes]) -> None:
 
 def clear_feature_flags() -> None:
     default_client.clear_feature_flags()
+
+
+def aws_lambda_handler(
+    real_handler: Optional[Callable] = None,
+    flush_timeout_ms: int = 2000,
+) -> Callable:
+    return default_client.aws_lambda_handler(real_handler, flush_timeout_ms)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,7 @@ from http.server import SimpleHTTPRequestHandler, HTTPServer
 
 import bugsnag
 from bugsnag.delivery import Delivery
+from bugsnag.configuration import RequestConfiguration
 
 
 try:
@@ -32,6 +33,7 @@ class IntegrationTest(unittest.TestCase):
         self.server.sessions_received = []
 
     def tearDown(self):
+        RequestConfiguration.get_instance().clear()
         previous_client = bugsnag.legacy.default_client
         previous_client.uninstall_sys_hook()
 


### PR DESCRIPTION
## Goal

This PR adds a decorator that wraps an AWS Lambda handler that:

1. reports any errors raised by the handler
2. creates a session for the function invocation
3. adds the `event` and `context` parameters as metadata, under the names "AWS Lambda Event" and `AWS Lambda Context"
4. waits for outstanding event and session requests to finish before allowing the lambda to exit (with a timeout of 2 seconds by default)

Usage:

```python
@bugsnag.aws_lambda_handler
def my_handler(event, context):
    pass
```

The maximum time to wait for events and sessions to be delivered is configurable with the `flush_timeout_ms` parameter:

```python
@bugsnag.aws_lambda_handler(flush_timeout_ms=1000)
def my_handler(event, context):
    pass
```