### PR TITLE
Add warning when lambda function may timeout

### DIFF
--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -604,6 +604,10 @@ class RequestConfiguration:
         return instance
 
     @classmethod
+    def set_instance(cls, instance: 'RequestConfiguration') -> None:
+        _request_info.set(instance)  # type: ignore
+
+    @classmethod
     def clear(cls):
         """
         Clear this thread's instance of the RequestConfiguration.

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -261,7 +261,7 @@ def is_json_content_type(value: str) -> bool:
     return type == 'application' and (subtype == 'json' or suffix == 'json')
 
 
-_ignore_modules = ('__main__', 'builtins')
+_ignore_modules = ('__main__', 'builtins', 'bugsnag.client')
 
 
 def partly_qualified_class_name(obj):


### PR DESCRIPTION
## Goal

Adds a notify for lambda functions when they are likely to timeout — by default this happens 1 second before the timeout occurs but can be configured with the new `lambda_timeout_notify_ms` option:

```python
@bugsnag.aws_lambda_handler(lambda_timeout_notify_ms=2000)
def my_handler(event, context):
    pass
```

There's some complexity here because the notify happens off of the main thread so any thread-local data wouldn't be present in the event. In order to include all of the relevant information (e.g. metadata, breadcrumbs, feature flags) we need to manually copy it over into the timer thread