### PR TITLE
Restrict pytest-celery to <1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps=
     bottle: bottle
     celery4: celery>=4,<5
     celery5: celery>=5,<6
-    celery5: pytest-celery
+    celery5: pytest-celery<1
     py37-celery{4,5}: importlib_metadata<5
     flask: flask
     flask: blinker


### PR DESCRIPTION
## Goal

Our tests don't work on pytest-celery v1 currently, so restrict the version until we have time to fix them on the new version