### PR TITLE
Guard access to `__code__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Avoid reading `__code__` when setting a custom delivery unless it exists
+  [#387](https://github.com/bugsnag/bugsnag-python/pull/387)
+
 ## v4.7.0 (2024-04-24)
 
 ### Enhancements

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -279,7 +279,11 @@ class Configuration:
             # this should be made mandatory in the next major release
             if (
                 hasattr(value, 'deliver_sessions') and
-                callable(value.deliver_sessions)
+                callable(value.deliver_sessions) and
+                # Mock objects don't allow accessing or mocking '__code__' so
+                # ensure it exists before attempting to read it
+                # __code__ should always be present in a real delivery object
+                hasattr(value.deliver_sessions, '__code__')
             ):
                 parameter_names = value.deliver_sessions.__code__.co_varnames
 

--- a/bugsnag/sessiontracker.py
+++ b/bugsnag/sessiontracker.py
@@ -139,7 +139,10 @@ class SessionTracker:
 
             deliver = self.config.delivery.deliver_sessions
 
-            if 'options' in deliver.__code__.co_varnames:
+            if (
+                hasattr(deliver, '__code__') and
+                'options' in deliver.__code__.co_varnames
+            ):
                 try:
                     post_delivery_callback = self._request_tracker.new_request()
 


### PR DESCRIPTION
## Goal

We read `__code__` when setting a custom delivery object and when sending sessions in order to warn when a custom Delivery implementation doesn't have an `options` parameter

However, this breaks when using a `Mock` object as `__code__` does not exist, nor can it be mocked

This PR adds a guard before reading `__code__` so that we avoid a crash if it does not exist. We don't warn in this case as real delivery implementations should always have `__code__` available, so a warning is likely to be just noise when running tests

## Testing

Added a unit test using a `Mock` object for delivery