### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -30,6 +30,10 @@ jobs:
       run: >
         docker run -v $PWD:/scan licensefinder/license_finder /bin/bash -lc "
           cd /scan &&
-          pip3 install -r requirements.txt --quiet &&
+          apt-get update &&
+          apt-get install -y python3-venv &&
+          python3 -m venv .venv &&
+          source .venv/bin/activate &&
+          pip3 install -r requirements.txt &&
           license_finder --decisions-file decisions.yml --python-version 3 --enabled-package-managers=pip
         "

--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         # License Finder's Docker image uses Python 3.5
         python-version: 3.5

--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -4,18 +4,16 @@ on: [push, pull_request]
 
 jobs:
   license-audit:
-    # TODO: a GH action update broke the 'ubuntu-latest' image
-    #       when it's fixed, we should switch back
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-latest'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v2
       with:
-        # License Finder's Docker image uses Python 3.5
-        python-version: 3.5
+        # License Finder's Docker image uses Python 3.10
+        python-version: '3.10'
 
     - name: Fetch decisions.yml
       run: curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o decisions.yml

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,10 +19,10 @@ jobs:
             os: 'ubuntu-20.04'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
       env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,6 +14,7 @@ jobs:
         include:
           - python-version: '3.5'
             os: 'ubuntu-20.04'
+            pip-trusted-host: 'pypi.python.org pypi.org files.pythonhosted.org'
           - python-version: '3.6'
             os: 'ubuntu-20.04'
 
@@ -24,6 +25,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+      env:
+        PIP_TRUSTED_HOST: ${{ matrix.pip-trusted-host }}
 
     - name: Install dependencies
       run: |

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -127,7 +127,7 @@ class ClientTest(IntegrationTest):
 
     # test for a regression caused by reading '__code__', which does not exist
     # on Mock objects, nor can it be mocked
-    # see: https://github.com/bugsnag/bugsnag-python/commit/77e11747c293ba715bc764d17b49fb32918c030a#r142130768
+    # see: https://github.com/bugsnag/bugsnag-python/commit/77e11747c293ba715bc764d17b49fb32918c030a#r142130768  # noqa: E501
     def test_delivery_can_be_mocked(self):
         delivery = Mock(spec=Delivery)
 

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ deps=
     flask: flask
     flask: blinker
     tornado: tornado
+    tornado: pytest<8.2
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11


### PR DESCRIPTION
## Goal

Various fixes for CI:
- The setup Python step is failing on Python 3.5, which is fixed with a workaround from https://github.com/actions/setup-python/issues/866#issuecomment-2109784318
- Tornado is incompatible with pytest 8.2, so we no longer allow that version to be installed when running the tornado tests (https://github.com/pytest-dev/pytest/issues/12263)
- The license audit is failing because of changes to its dockerfile, which have been fixed by bumping our python version and running it in a virtual environment
- A linting error in a test snuck through because it was covered up by other failures in CI

I've also bumped all the GH Actions actions versions to the latest releases