### PR TITLE
Use einfo.tb when traceback is str

### DIFF
--- a/bugsnag/celery/__init__.py
+++ b/bugsnag/celery/__init__.py
@@ -1,3 +1,5 @@
+from types import TracebackType
+
 import celery
 from celery.signals import task_failure
 import bugsnag
@@ -10,6 +12,9 @@ def failure_handler(sender, task_id, exception, args, kwargs, traceback, einfo,
         "args": args,
         "kwargs": kwargs
     }
+
+    if not isinstance(traceback, TracebackType):
+        traceback = einfo.tb
 
     bugsnag.auto_notify(exception, traceback=traceback,
                         context=sender.name,


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
Celery sometimes calls the `failure_handler` with a string for the `traceback` parameter instead of an actual traceback object. This was reported in https://github.com/bugsnag/bugsnag-python/issues/372 (there's a comment on that request from @clr182 which I think has a misunderstanding about what the issue is about). Other users running into the same issue with Celery a long time ago: https://github.com/celery/celery/issues/806 Here's another Celery user with a similar issue more recently, and a similar fix: https://github.com/scoutapp/scout_apm_python/issues/708

## Design

<!-- Why was this approach used? -->
Celery should probably be fixed to supply the traceback object in all cases but I haven't had time to dig into that bug. Even if fixed, the old versions of Celery will be used for some time so a workaround in this library seems reasonable.

## Changeset

<!-- What changed? -->
Changed `failure_handler` to get the traceback object from a different place if the `traceback` supplied to the function is a string.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
Tested manually. I don't see any existing test cases that are setup to handle the celery integration. Please let me know if I missed these.