### PR TITLE
update utcnow to datetime.now(timezone.utc)

### DIFF
--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -42,13 +42,12 @@ except ImportError:
     from bugsnag.utils import ThreadContextVar
     _request_info = ThreadContextVar('bugsnag-request', default=None)  # type: ignore  # noqa: E501
 
-
-try:
+# Define PathLike for compatibility
+if sys.version_info >= (3, 6):
     from os import PathLike
-except ImportError:
-    # PathLike was added in Python 3.6 so fallback to PurePath on Python 3.5 as
-    # all builtin Path objects inherit from PurePath
-    from pathlib import PurePath as PathLike  # type: ignore
+else:
+    from pathlib import PurePath
+    PathLike = Union[str, PurePath]
 
 
 __all__ = ('Configuration', 'RequestConfiguration')

--- a/bugsnag/configuration.py
+++ b/bugsnag/configuration.py
@@ -7,6 +7,7 @@ from typing import List, Any, Tuple, Union, Optional
 import warnings
 import logging
 from threading import Lock
+from pathlib import PurePath
 
 from bugsnag.breadcrumbs import (
     BreadcrumbType,
@@ -46,7 +47,6 @@ except ImportError:
 if sys.version_info >= (3, 6):
     from os import PathLike
 else:
-    from pathlib import PurePath
     PathLike = Union[str, PurePath]
 
 

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -2,7 +2,7 @@ from functools import wraps, partial
 import inspect
 from json import JSONEncoder
 from threading import local as threadlocal
-from typing import AnyStr, Tuple, Optional, Union, cast
+from typing import AnyStr, Tuple, Optional
 import warnings
 import copy
 import logging
@@ -10,12 +10,12 @@ from datetime import datetime, timedelta
 import sys
 from urllib.parse import urlparse, urlunsplit, parse_qs
 
-# PathLike was added in Python 3.6 so fallback to PurePath on Python 3.5 as
-# all builtin Path objects inherit from PurePath
-if sys.version_info >= (3, 6):
+try:
     from os import PathLike
-else:
-    PathLike = cast(type(PurePath), None)  # using cast to avoid mypy error
+except ImportError:
+    # PathLike was added in Python 3.6 so fallback to PurePath on Python 3.5 as
+    # all builtin Path objects inherit from PurePath
+    from pathlib import PurePath as PathLike  # type: ignore
 
 
 MAX_PAYLOAD_LENGTH = 128 * 1024

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -463,17 +463,15 @@ else:
 
 
 def get_package_version(package_name: str) -> Optional[str]:
-    try:
-        from importlib import metadata
-
-        return metadata.version(package_name)  # type: ignore
-    except ImportError:
+    if sys.version_info >= (3, 8):
+        try:
+            from importlib import metadata
+            return metadata.version(package_name)  # type: ignore
+        except metadata.PackageNotFoundError:
+            return None
+    else:
         try:
             import pkg_resources
-        except ImportError:
-            return None
-
-        try:
             return pkg_resources.get_distribution(package_name).version
-        except pkg_resources.DistributionNotFound:
+        except (ImportError, pkg_resources.DistributionNotFound):
             return None

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -9,12 +9,12 @@ import logging
 from datetime import datetime, timedelta
 import sys
 from urllib.parse import urlparse, urlunsplit, parse_qs
+from pathlib import PurePath
 
 # define PathLike as a type alias for compatibility with Python 3.5
 if sys.version_info >= (3, 6):
     from os import PathLike
 else:
-    from pathlib import PurePath
     PathLike = Union[str, PurePath]
 
 MAX_PAYLOAD_LENGTH = 128 * 1024

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -2,7 +2,7 @@ from functools import wraps, partial
 import inspect
 from json import JSONEncoder
 from threading import local as threadlocal
-from typing import AnyStr, Tuple, Optional
+from typing import AnyStr, Tuple, Optional, Union, cast
 import warnings
 import copy
 import logging
@@ -10,13 +10,12 @@ from datetime import datetime, timedelta
 import sys
 from urllib.parse import urlparse, urlunsplit, parse_qs
 
-
-try:
+# PathLike was added in Python 3.6 so fallback to PurePath on Python 3.5 as
+# all builtin Path objects inherit from PurePath
+if sys.version_info >= (3, 6):
     from os import PathLike
-except ImportError:
-    # PathLike was added in Python 3.6 so fallback to PurePath on Python 3.5 as
-    # all builtin Path objects inherit from PurePath
-    from pathlib import PurePath as PathLike  # type: ignore
+else:
+    PathLike = cast(type(PurePath), None)  # using cast to avoid mypy error
 
 
 MAX_PAYLOAD_LENGTH = 128 * 1024

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -422,29 +422,25 @@ def remove_query_from_url(url: AnyStr) -> Optional[AnyStr]:
 # milliseconds precision
 # Python can do this natively from version 3.6, but we need to include a
 # fallback implementation for Python 3.5
-try:
-    # this will raise if 'timespec' isn't supported
-    datetime.now(timezone.utc).isoformat(
-        timespec='milliseconds'  # type: ignore
-    )
 
+if sys.version_info >= (3, 6):
+    # Python 3.6+ has a built-in method for this
     def to_rfc3339(dt: datetime) -> str:
         return dt.isoformat(timespec='milliseconds')  # type: ignore
 
-except Exception:
+else:
+    # Python 3.5 fallback implementation
     def _get_timezone_offset(dt: datetime) -> str:
         if dt.tzinfo is None:
             return ''
 
         utc_offset = dt.tzinfo.utcoffset(dt)
-
         if utc_offset is None:
             return ''
 
         sign = '+'
-
         if utc_offset.days < 0:
-            sign = '-'
+            sign == '-'
             utc_offset = -utc_offset
 
         hours_offset, minutes = divmod(utc_offset, timedelta(hours=1))

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -424,7 +424,7 @@ def remove_query_from_url(url: AnyStr) -> Optional[AnyStr]:
 # fallback implementation for Python 3.5
 try:
     # this will raise if 'timespec' isn't supported
-    datetime.utcnow().isoformat(timespec='milliseconds')  # type: ignore
+    datetime.now(timezone.utc).isoformat(timespec='milliseconds')  # type: ignore
 
     def to_rfc3339(dt: datetime) -> str:
         return dt.isoformat(timespec='milliseconds')  # type: ignore

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -471,7 +471,8 @@ def get_package_version(package_name: str) -> Optional[str]:
             return None
     else:
         try:
-            import pkg_resources # type: ignore
-            return pkg_resources.get_distribution(package_name).version # type: ignore
+            import pkg_resources  # type: ignore
+            return pkg_resources.get_distribution(
+                    package_name).version  # type: ignore
         except (ImportError, pkg_resources.DistributionNotFound):
             return None

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -424,7 +424,9 @@ def remove_query_from_url(url: AnyStr) -> Optional[AnyStr]:
 # fallback implementation for Python 3.5
 try:
     # this will raise if 'timespec' isn't supported
-    datetime.now(timezone.utc).isoformat(timespec='milliseconds')
+    datetime.now(timezone.utc).isoformat(
+        timespec='milliseconds'  # type: ignore
+    )
 
     def to_rfc3339(dt: datetime) -> str:
         return dt.isoformat(timespec='milliseconds')  # type: ignore

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -2,7 +2,7 @@ from functools import wraps, partial
 import inspect
 from json import JSONEncoder
 from threading import local as threadlocal
-from typing import AnyStr, Tuple, Optional
+from typing import AnyStr, Tuple, Optional, Union
 import warnings
 import copy
 import logging
@@ -13,11 +13,13 @@ from urllib.parse import urlparse, urlunsplit, parse_qs
 try:
     from os import PathLike
 except ImportError:
-    # PathLike was added in Python 3.6 so fallback to PurePath on Python 3.5 as
-    # all builtin Path objects inherit from PurePath
-    from pathlib import PurePath as PathLike  # type: ignore
+    # For Python 3.5, define PathLike as none for type check
+    PathLike = None  # type: ignore
 
-
+# Conditionally import PurePath if Pathlike is not available
+if PathLike is None:
+    from pathlib import PurePath  # type: ignore
+    PathLike = Union[str, PurePath]  # Define for compatibility
 MAX_PAYLOAD_LENGTH = 128 * 1024
 MAX_STRING_LENGTH = 1024
 

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -13,13 +13,14 @@ from urllib.parse import urlparse, urlunsplit, parse_qs
 try:
     from os import PathLike
 except ImportError:
-    # For Python 3.5, define PathLike as none for type check
+    # For Py35, define PathLike as none for type check
     PathLike = None  # type: ignore
 
 # Conditionally import PurePath if Pathlike is not available
 if PathLike is None:
     from pathlib import PurePath  # type: ignore
     PathLike = Union[str, PurePath]  # Define for compatibility
+
 MAX_PAYLOAD_LENGTH = 128 * 1024
 MAX_STRING_LENGTH = 1024
 

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -6,7 +6,7 @@ from typing import AnyStr, Tuple, Optional
 import warnings
 import copy
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse, urlunsplit, parse_qs
 
 
@@ -424,7 +424,7 @@ def remove_query_from_url(url: AnyStr) -> Optional[AnyStr]:
 # fallback implementation for Python 3.5
 try:
     # this will raise if 'timespec' isn't supported
-    datetime.now(timezone.utc).isoformat(timespec='milliseconds')  # type: ignore
+    datetime.now(timezone.utc).isoformat(timespec='milliseconds')
 
     def to_rfc3339(dt: datetime) -> str:
         return dt.isoformat(timespec='milliseconds')  # type: ignore

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -471,7 +471,7 @@ def get_package_version(package_name: str) -> Optional[str]:
             return None
     else:
         try:
-            import pkg_resources
-            return pkg_resources.get_distribution(package_name).version
+            import pkg_resources # type: ignore
+            return pkg_resources.get_distribution(package_name).version # type: ignore
         except (ImportError, pkg_resources.DistributionNotFound):
             return None

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -2,7 +2,7 @@ from functools import wraps, partial
 import inspect
 from json import JSONEncoder
 from threading import local as threadlocal
-from typing import AnyStr, Tuple, Optional, Union
+from typing import AnyStr, Tuple, Optional
 import warnings
 import copy
 import logging
@@ -14,8 +14,9 @@ from pathlib import PurePath
 # define PathLike as a type alias for compatibility with Python 3.5
 if sys.version_info >= (3, 6):
     from os import PathLike
+    path_types = (str, PathLike)
 else:
-    PathLike = Union[str, PurePath]
+    path_types = (str, PurePath)
 
 MAX_PAYLOAD_LENGTH = 128 * 1024
 MAX_STRING_LENGTH = 1024
@@ -314,7 +315,7 @@ validate_required_str_setter = partial(_validate_setter, (str,),
 validate_bool_setter = partial(_validate_setter, (bool,))
 validate_iterable_setter = partial(_validate_setter, (list, tuple))
 validate_int_setter = partial(_validate_setter, (int,))
-validate_path_setter = partial(_validate_setter, (str, PathLike))
+validate_path_setter = partial(_validate_setter, path_types)
 
 
 class ThreadContextVar:

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -6,7 +6,8 @@ from typing import AnyStr, Tuple, Optional
 import warnings
 import copy
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
+import sys
 from urllib.parse import urlparse, urlunsplit, parse_qs
 
 

--- a/bugsnag/utils.py
+++ b/bugsnag/utils.py
@@ -10,16 +10,12 @@ from datetime import datetime, timedelta
 import sys
 from urllib.parse import urlparse, urlunsplit, parse_qs
 
-try:
+# define PathLike as a type alias for compatibility with Python 3.5
+if sys.version_info >= (3, 6):
     from os import PathLike
-except ImportError:
-    # For Py35, define PathLike as none for type check
-    PathLike = None  # type: ignore
-
-# Conditionally import PurePath if Pathlike is not available
-if PathLike is None:
-    from pathlib import PurePath  # type: ignore
-    PathLike = Union[str, PurePath]  # Define for compatibility
+else:
+    from pathlib import PurePath
+    PathLike = Union[str, PurePath]
 
 MAX_PAYLOAD_LENGTH = 128 * 1024
 MAX_STRING_LENGTH = 1024

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,6 @@ deps=
     exceptiongroup: exceptiongroup
     lint: flake8
     lint: mypy
-    lint: types-pkg_resources
     lint: types-requests
     lint: types-Flask
     lint: types-contextvars

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,7 @@ deps=
     exceptiongroup: exceptiongroup
     lint: flake8
     lint: mypy
+    py35-lint: types-setuptools # add for py35
     lint: types-requests
     lint: types-Flask
     lint: types-contextvars

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,11 @@ deps=
     flask: blinker
     tornado: tornado
     tornado: pytest<8.2
+    py35: requests==2.22.0
+    py35: pytest==4.6.11
+    py35: flake8==3.7.9
+    py35: mypy==0.770
+    py35: types-setuptools
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC)

## Changeset

Changed utcnow in bugsnag/utils.py to `datetime.now(timezone.utc)`
