### PR TITLE
replace utcnow calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD 
+
+### Enhancements
+
+* Remove depricated `datetime.utcnow()` method call from utils class
+  [#394](https://github.com/bugsnag/bugsnag-python/pull/394).
+
 ## v4.7.1 (2024-05-22)
 
 ### Bug fixes

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ deps=
     exceptiongroup: exceptiongroup
     lint: flake8
     lint: mypy
-    lint: types-pkg_resources
+    lint: types-pkg_resources; python_version < '3.12'
     lint: types-requests
     lint: types-Flask
     lint: types-contextvars


### PR DESCRIPTION
## Goal

DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC)

## Changeset

Removed `datetime.utcnow()` call, as I believe it was just used to trigger the exception in the try/catch. Instead I've added `sys.version_info` checking to determine which method to use in the date formatting. 
