### PR TITLE
Update tests to run against Python 3.13

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: ['ubuntu-latest']
         include:
           - python-version: '3.5'

--- a/features/celery.feature
+++ b/features/celery.feature
@@ -12,7 +12,7 @@ Scenario Outline: Handled exceptions are delivered in Celery <celery-version>
   And the event "severityReason.type" equals "handledException"
   And the event "device.runtimeVersions.celery" matches "<celery-version>\.\d+\.\d+"
 
-  @not-python-3.11 @not-python-3.12
+  @not-python-3.11 @not-python-3.12 @not-python-3.13
   Examples:
     | celery-version |
     |              4 |
@@ -40,7 +40,7 @@ Scenario Outline: Unhandled exceptions are delivered in Celery <celery-version>
   And the event "metaData.extra_data.args" string is empty
   And the event "metaData.extra_data.kwargs" string is empty
 
-  @not-python-3.11 @not-python-3.12
+  @not-python-3.11 @not-python-3.12 @not-python-3.13
   Examples:
     | celery-version |
     |              4 |
@@ -72,7 +72,7 @@ Scenario Outline: Task arguments are added to metadata in Celery <celery-version
   And the event "metaData.extra_data.kwargs.a" equals "100"
   And the event "metaData.extra_data.kwargs.b" equals "200"
 
-  @not-python-3.11 @not-python-3.12
+  @not-python-3.11 @not-python-3.12 @not-python-3.13
   Examples:
     | celery-version |
     |              4 |
@@ -101,7 +101,7 @@ Scenario Outline: Errors in shared tasks are reported in Celery <celery-version>
   And the event "metaData.extra_data.args.1" equals "0"
   And the event "metaData.extra_data.kwargs" string is empty
 
-  @not-python-3.11 @not-python-3.12
+  @not-python-3.11 @not-python-3.12 @not-python-3.13
   Examples:
     | celery-version |
     |              4 |
@@ -116,7 +116,7 @@ Scenario Outline: Successful tasks do not report errors in Celery <celery-versio
   When I execute the command "python bugsnag_celery_test_app/queue_task.py add 1 2 3 4 5 6 7 a=8 b=9" in the service "celery-<celery-version>"
   Then I should receive no errors
 
-  @not-python-3.11 @not-python-3.12
+  @not-python-3.11 @not-python-3.12 @not-python-3.13
   Examples:
     | celery-version |
     |              4 |
@@ -131,7 +131,7 @@ Scenario Outline: Successful shared tasks do not report errors in Celery <celery
   When I execute the command "python bugsnag_celery_test_app/queue_task.py divide 10 2" in the service "celery-<celery-version>"
   Then I should receive no errors
 
-  @not-python-3.11 @not-python-3.12
+  @not-python-3.11 @not-python-3.12 @not-python-3.13
   Examples:
     | celery-version |
     |              4 |

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist=
     py{38,39,310,311,312,313}-django4
     py{38,39,310,311,312,313}-{asynctest,threadtest}
     py{37,38,39,310,311,312,313}-exceptiongroup
-    py{35,312,313}-{lint}
+    py{35,313}-{lint}
 
 [pytest]
 testpaths = tests
@@ -65,7 +65,7 @@ deps=
     exceptiongroup: exceptiongroup
     lint: flake8
     lint: mypy
-    lint: types-pkg_resources
+    lint: types-setuptools
     lint: types-requests
     lint: types-Flask
     lint: types-contextvars

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 envlist=
-    py{35,36,37,38,39,310,311,312}-{test,requests,flask,tornado,wsgi,bottle}
-    py{36,37,38,39,310,311,312}-asgi
+    py{35,36,37,38,39,310,311,312,313}-{test,requests,flask,tornado,wsgi,bottle}
+    py{36,37,38,39,310,311,312,313}-asgi
     py{35,36,37}-django{18,19,110,111}
     py{35,36,37,38,39}-django20
     py{35,36,37,38,39,310}-django{21,22}
-    py{36,37,38,39,310,311,312}-django3
-    py{38,39,310,311,312}-django4
-    py{38,39,310,311,312}-{asynctest,threadtest}
-    py{37,38,39,310,311,312}-exceptiongroup
-    py{35,312}-{lint}
+    py{36,37,38,39,310,311,312,313}-django3
+    py{38,39,310,311,312,313}-django4
+    py{38,39,310,311,312,313}-{asynctest,threadtest}
+    py{37,38,39,310,311,312,313}-exceptiongroup
+    py{35,312,313}-{lint}
 
 [pytest]
 testpaths = tests
@@ -32,6 +32,7 @@ basepython =
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 whitelist_externals=
     {toxinidir}/scripts/lint.sh
 deps=


### PR DESCRIPTION
## Goal

This allows us to ensure we have compatibility with the newest releases of Python, and will simplify the addition of new versions of python to our test matrix when required.