### PR TITLE
Added python 3.14 to tests

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,15 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         os: ['ubuntu-latest']
         include:
-# Python 3.5 and 3.6 tests skipped pending PLAT-14414
-#          - python-version: '3.5'
-#            os: 'ubuntu-22.04'
-#            pip-trusted-host: 'pypi.python.org pypi.org files.pythonhosted.org'
-#          - python-version: '3.6'
-#            os: 'ubuntu-22.04'
           - python-version: '3.7'
             os: 'ubuntu-22.04'
 
@@ -28,8 +22,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-      env:
-        PIP_TRUSTED_HOST: ${{ matrix.pip-trusted-host }}
 
     - name: Install dependencies
       run: |
@@ -44,7 +36,6 @@ jobs:
     - name: Upload code coverage data
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_FLAG_NAME: ${{ matrix.test-name }}
         COVERALLS_PARALLEL: true
       run: |
         coverage combine

--- a/features/aws-lambda/handled.feature
+++ b/features/aws-lambda/handled.feature
@@ -1,7 +1,8 @@
+# 3.9 is currently the minimum python version with a lambda runtime
+# 3.14 is not supported by the AWS `sam` CLI at the moment
+@not-python-3.5 @not-python-3.6 @not-python-3.7 @not-python-3.8 @not-python-3.14
 Feature: Handled exceptions in AWS Lambda
 
-# 3.9 is currently the minimum python version with a lambda runtime
-@not-python-3.5 @not-python-3.6 @not-python-3.7 @not-python-3.8
 Scenario: Handled exceptions are delivered in an AWS Lambda app
   Given I run the lambda handler "handled" with the "event.json" event
   When I wait to receive an error
@@ -22,7 +23,6 @@ Scenario: Handled exceptions are delivered in an AWS Lambda app
   And the session payload has a valid sessions array
   And the sessionCount "sessionsStarted" equals 1
 
-@not-python-3.5 @not-python-3.6 @not-python-3.7 @not-python-3.8
 Scenario: Handled exceptions are delivered in an AWS Lambda app when auto_notify is False
   Given I run the lambda handler "handled_no_auto_notify" with the "event.json" event
   When I wait to receive an error

--- a/features/aws-lambda/sessions.feature
+++ b/features/aws-lambda/sessions.feature
@@ -1,6 +1,6 @@
+@not-python-3.5 @not-python-3.6 @not-python-3.7 @not-python-3.8 @not-python-3.14
 Feature: Sessions in AWS Lambda
 
-@not-python-3.5 @not-python-3.6 @not-python-3.7 @not-python-3.8
 Scenario: Manually started sessions are delivered in an AWS Lambda app when auto_capture_sessions is True
   Given I run the lambda handler "manual_session" with the "event.json" event
   When I wait to receive a session
@@ -9,7 +9,6 @@ Scenario: Manually started sessions are delivered in an AWS Lambda app when auto
   And the sessionCount "sessionsStarted" equals 2
   And I should receive no errors
 
-@not-python-3.5 @not-python-3.6 @not-python-3.7 @not-python-3.8
 Scenario: Manually started sessions are delivered in an AWS Lambda app when auto_capture_sessions is False
   Given I run the lambda handler "manual_session_no_auto_capture_sessions" with the "event.json" event
   When I wait to receive a session

--- a/features/aws-lambda/unhandled.feature
+++ b/features/aws-lambda/unhandled.feature
@@ -1,6 +1,6 @@
+@not-python-3.5 @not-python-3.6 @not-python-3.7 @not-python-3.8 @not-python-3.14
 Feature: Unhandled exceptions in AWS Lambda
 
-@not-python-3.5 @not-python-3.6 @not-python-3.7 @not-python-3.8
 Scenario: Unhandled exceptions are delivered in an AWS Lambda app
   Given I run the lambda handler "unhandled" with the "event.json" event
   When I wait to receive an error
@@ -21,7 +21,6 @@ Scenario: Unhandled exceptions are delivered in an AWS Lambda app
   And the session payload has a valid sessions array
   And the sessionCount "sessionsStarted" equals 1
 
-@not-python-3.5 @not-python-3.6 @not-python-3.7 @not-python-3.8
 Scenario: Unhandled exceptions are not delivered in an AWS Lambda app when auto_detect_errors is False
   Given I run the lambda handler "unhandled_no_auto_notify" with the "event.json" event
   When I wait to receive a session

--- a/features/celery.feature
+++ b/features/celery.feature
@@ -12,7 +12,7 @@ Scenario Outline: Handled exceptions are delivered in Celery <celery-version>
   And the event "severityReason.type" equals "handledException"
   And the event "device.runtimeVersions.celery" matches "<celery-version>\.\d+\.\d+"
 
-  @not-python-3.11 @not-python-3.12 @not-python-3.13
+  @not-python-3.11 @not-python-3.12 @not-python-3.13 @not-python-3.14
   Examples:
     | celery-version |
     |              4 |
@@ -40,7 +40,7 @@ Scenario Outline: Unhandled exceptions are delivered in Celery <celery-version>
   And the event "metaData.extra_data.args" string is empty
   And the event "metaData.extra_data.kwargs" string is empty
 
-  @not-python-3.11 @not-python-3.12 @not-python-3.13
+  @not-python-3.11 @not-python-3.12 @not-python-3.13 @not-python-3.14
   Examples:
     | celery-version |
     |              4 |
@@ -72,7 +72,7 @@ Scenario Outline: Task arguments are added to metadata in Celery <celery-version
   And the event "metaData.extra_data.kwargs.a" equals "100"
   And the event "metaData.extra_data.kwargs.b" equals "200"
 
-  @not-python-3.11 @not-python-3.12 @not-python-3.13
+  @not-python-3.11 @not-python-3.12 @not-python-3.13 @not-python-3.14
   Examples:
     | celery-version |
     |              4 |
@@ -101,7 +101,7 @@ Scenario Outline: Errors in shared tasks are reported in Celery <celery-version>
   And the event "metaData.extra_data.args.1" equals "0"
   And the event "metaData.extra_data.kwargs" string is empty
 
-  @not-python-3.11 @not-python-3.12 @not-python-3.13
+  @not-python-3.11 @not-python-3.12 @not-python-3.13 @not-python-3.14
   Examples:
     | celery-version |
     |              4 |
@@ -116,7 +116,7 @@ Scenario Outline: Successful tasks do not report errors in Celery <celery-versio
   When I execute the command "python bugsnag_celery_test_app/queue_task.py add 1 2 3 4 5 6 7 a=8 b=9" in the service "celery-<celery-version>"
   Then I should receive no errors
 
-  @not-python-3.11 @not-python-3.12 @not-python-3.13
+  @not-python-3.11 @not-python-3.12 @not-python-3.13 @not-python-3.14
   Examples:
     | celery-version |
     |              4 |
@@ -131,7 +131,7 @@ Scenario Outline: Successful shared tasks do not report errors in Celery <celery
   When I execute the command "python bugsnag_celery_test_app/queue_task.py divide 10 2" in the service "celery-<celery-version>"
   Then I should receive no errors
 
-  @not-python-3.11 @not-python-3.12 @not-python-3.13
+  @not-python-3.11 @not-python-3.12 @not-python-3.13 @not-python-3.14
   Examples:
     | celery-version |
     |              4 |

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 envlist=
-    py{35,36,37,38,39,310,311,312,313}-{test,requests,flask,tornado,wsgi,bottle}
-    py{36,37,38,39,310,311,312,313}-asgi
+    py{35,36,37,38,39,310,311,312,313,314}-{test,requests,flask,tornado,wsgi,bottle}
+    py{36,37,38,39,310,311,312,313,314}-asgi
     py{35,36,37}-django{18,19,110,111}
     py{35,36,37,38,39}-django20
     py{35,36,37,38,39,310}-django{21,22}
     py{36,37,38,39,310,311,312,313}-django3
     py{38,39,310,311,312,313}-django4
-    py{38,39,310,311,312,313}-{asynctest,threadtest}
-    py{37,38,39,310,311,312,313}-exceptiongroup
-    py{35,313}-{lint}
+    py{38,39,310,311,312,313,314}-{asynctest,threadtest}
+    py{37,38,39,310,311,312,313,314}-exceptiongroup
+    py{35,313,314}-{lint}
 
 [pytest]
 testpaths = tests
@@ -33,6 +33,7 @@ basepython =
     py311: python3.11
     py312: python3.12
     py313: python3.13
+    py314: python3.14
 whitelist_externals=
     {toxinidir}/scripts/lint.sh
 deps=


### PR DESCRIPTION
## Goal

This PR adds Python 3.14 to the testing matrix. 

## Changeset

- Added Python 3.14 to the testing matrices.
- Removed unused parts of the unit test GitHub workflow(these Python versions are severely out of date and don't work on Ubuntu 22 or higher, and GH doesn't offer older versions of Ubuntu on runners)
- Aggregated version constraints in the AWS Maze tests and added Python 3.14 there. Exclusion of Python 3.14 is temporary and caused by the incompatibility of 3.14 with the AWS `sam` CLI. This exclusion is to be removed when a new version of `sam` supporting Python 3.14 is released
