### PR TITLE
Pawan/plat 14675 flask lambda

### DIFF
--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, Tuple, Type, Optional, Union, List, Callable
 import types
 import sys
+import warnings
 
 from bugsnag.breadcrumbs import BreadcrumbType, OnBreadcrumbCallback
 from bugsnag.feature_flags import FeatureFlag
@@ -13,16 +14,64 @@ logger = configuration.logger
 ExcInfoType = Tuple[Type, Exception, types.TracebackType]
 
 
-__all__ = ('configure', 'configure_request', 'add_metadata_tab',
-           'clear_request_config', 'notify', 'start_session', 'auto_notify',
-           'auto_notify_exc_info', 'before_notify', 'leave_breadcrumb')
+__all__ = (
+    'configure',
+    'configure_request',
+    'add_metadata_tab',
+    'clear_request_config',
+    'notify',
+    'start_session',
+    'auto_notify',
+    'auto_notify_exc_info',
+    'before_notify',
+    'leave_breadcrumb',
+)
 
 
 def configure(**options):
     """
     Configure the Bugsnag notifier application-wide settings.
     """
-    return configuration.configure(**options)
+    # Synchronize legacy references to point at the live configuration
+    # only `logger` is rebound in this scope
+    global logger
+
+    # Delegate to the module-local configuration instance so we update the
+    # single source of truth without resolving package submodules that may
+    # shadow the attribute name.
+    result = configuration.configure(**options)
+    try:
+        default_client.configuration = configuration
+    except (AttributeError, TypeError, ImportError) as exc:
+        try:
+            configuration.logger.debug(
+                "legacy configuration sync failed: %s", exc
+            )
+        except Exception:
+            warnings.warn(
+                f"legacy configuration sync failed: {exc}", stacklevel=2
+            )
+
+    logger = configuration.logger
+
+    # Also update the `bugsnag` package attributes so other modules that
+    # reference `bugsnag.configuration` / `bugsnag.logger` reflect the
+    # live configuration object (keeps package-level attributes in sync).
+    try:
+        import bugsnag as _pkg
+        setattr(_pkg, 'configuration', configuration)
+        setattr(_pkg, 'logger', configuration.logger)
+    except (ImportError, AttributeError, TypeError) as exc:
+        try:
+            configuration.logger.debug(
+                "legacy package attr sync failed: %s", exc
+            )
+        except Exception:
+            warnings.warn(
+                f"legacy package attr sync failed: {exc}", stacklevel=2
+            )
+
+    return result
 
 
 def configure_request(**options):

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -49,7 +49,7 @@ def configure(**options):
             )
         except Exception:
             warnings.warn(
-                f"legacy configuration sync failed: {exc}", stacklevel=2
+                "legacy configuration sync failed: {}".format(exc), stacklevel=2
             )
 
     logger = configuration.logger
@@ -68,7 +68,7 @@ def configure(**options):
             )
         except Exception:
             warnings.warn(
-                f"legacy package attr sync failed: {exc}", stacklevel=2
+                "legacy package attr sync failed: {}".format(exc), stacklevel=2
             )
 
     return result

--- a/bugsnag/legacy.py
+++ b/bugsnag/legacy.py
@@ -49,7 +49,8 @@ def configure(**options):
             )
         except Exception:
             warnings.warn(
-                "legacy configuration sync failed: {}".format(exc), stacklevel=2
+                "legacy configuration sync failed: {}".format(exc),
+                stacklevel=2
             )
 
     logger = configuration.logger
@@ -68,7 +69,8 @@ def configure(**options):
             )
         except Exception:
             warnings.warn(
-                "legacy package attr sync failed: {}".format(exc), stacklevel=2
+                "legacy package attr sync failed: {}".format(exc),
+                stacklevel=2
             )
 
     return result

--- a/tests/test_legacy_configuration.py
+++ b/tests/test_legacy_configuration.py
@@ -1,0 +1,13 @@
+import bugsnag
+from bugsnag import legacy
+
+
+def test_legacy_configuration_sync():
+    """After calling `bugsnag.configure(...)`, the package and legacy
+    configuration objects should point to the same live objects.
+    This prevents an import-time snapshot from becoming stale.
+    """
+    bugsnag.configure(api_key="test-api-key")
+
+    assert bugsnag.configuration is legacy.configuration
+    assert getattr(bugsnag, "logger", None) is getattr(legacy, "logger", None)

--- a/tox.ini
+++ b/tox.ini
@@ -43,8 +43,9 @@ deps=
     requests: requests
     wsgi: webtest
     asgi: starlette
+    asgi: starlette<0.28
     asgi: requests
-    asgi: httpx
+    asgi: httpx<0.28
     bottle: webtest
     bottle: bottle
     flask: flask


### PR DESCRIPTION
## Goal

Problem: Prevent legacy module/package configuration (import-time snapshot) from becoming stale and diverging from the live Configuration.


## Design

Approach: Defer synchronization to [configure()] and perform call-time, best-effort, non-throwing synchronization of legacy/module/package references.

## Changeset

* [legacy.py]: Call-time sync of [configuration], [default_client.configuration], and [logger]; update [bugsnag] package attrs; remove unused global.
* [test_legacy_configuration.py]: Add regression test asserting [bugsnag.configuration is legacy.configuration] (and that [logger] reflects the live instance).
* [tox.ini]: Pin starlette<0.28 and httpx<0.28 to stabilize ASGI tests.

## Testing

Unit: Added [test_legacy_configuration.py].
Local CI: Ran tox -e py310-asgi, tox -e py313-lint, tox -e py314-lint — all passed locally.
Notes: Lint fix addressed a long line (E501) and an unused global; no test-only shims are included in the changeset.