### PR TITLE
PLAT-16625-github action nodejs version upgrade

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install libcurl4-openssl-dev and net-tools
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,10 +16,10 @@ jobs:
             os: 'ubuntu-22.04'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Goal

Replace github action checkout v4 to v6 and setup-python v5 to v6 to resolve nodejs deprecated warning