### PR TITLE
SCA Finding fixed

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -2,6 +2,9 @@ name: Maze Runner
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   maze-runner:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,9 @@ name: Test bugsnag-python against Python versions
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -46,6 +49,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     container: python:3-slim
+    permissions:
+      contents: none
     steps:
     - name: Send request
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 ### Enhancements
 
 * Add support for `level` parameter in `BugsnagHandler` constructor and `Client.log_handler()` method.
+  [#416](https://github.com/bugsnag/bugsnag-python/pull/416)
 
 ## v4.9.0 (2026-04-21)
 

--- a/example/celery+django/celery_django/settings.py
+++ b/example/celery+django/celery_django/settings.py
@@ -20,7 +20,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 't70qw62gdx%ru%w1&f#$so*a$h9-m6h#a1=gji9$5q&)exf$*%'
+SECRET_KEY = os.environ.get(
+    'DJANGO_SECRET_KEY',
+    'django-insecure-testonly-not-a-real-secret-key-replace-me',
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/example/django21/bugsnag_demo/settings.py
+++ b/example/django21/bugsnag_demo/settings.py
@@ -18,7 +18,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '3n3h7r@tpqnwqtt8#avxh_t75k_6zf3x)@6cg!u(&xmz79(26h'
+SECRET_KEY = os.environ.get(
+    'DJANGO_SECRET_KEY',
+    'django-insecure-testonly-not-a-real-secret-key-replace-me',
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/example/django31/todo/settings.py
+++ b/example/django31/todo/settings.py
@@ -22,7 +22,10 @@ BASE_DIR = dirname(dirname(abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '$#yb)ri-v$^#8o1r0x%5$0yy&aqu2yefwo10zm+(=7!t+d^6ft'
+SECRET_KEY = os.environ.get(
+    'DJANGO_SECRET_KEY',
+    'django-insecure-testonly-not-a-real-secret-key-replace-me',
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/tests/fixtures/django30/todo/settings.py
+++ b/tests/fixtures/django30/todo/settings.py
@@ -22,7 +22,7 @@ BASE_DIR = dirname(dirname(abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '$#yb)ri-v$^#8o1r0x%5$0yy&aqu2yefwo10zm+(=7!t+d^6ft'
+SECRET_KEY = 'django-insecure-testonly-not-a-real-secret-key-replace-me'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False

--- a/tests/fixtures/django4/todo/settings.py
+++ b/tests/fixtures/django4/todo/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-z++&i7gx^m*qqq_1(xjqo=7%gg)^&fcq6fa3gen+10(zn5756z'
+SECRET_KEY = 'django-insecure-testonly-not-a-real-secret-key-replace-me'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False

--- a/tests/fixtures/django5/todo/settings.py
+++ b/tests/fixtures/django5/todo/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-z++&i7gx^m*qqq_1(xjqo=7%gg)^&fcq6fa3gen+10(zn5756z'
+SECRET_KEY = 'django-insecure-testonly-not-a-real-secret-key-replace-me'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False

--- a/tests/fixtures/django6/todo/settings.py
+++ b/tests/fixtures/django6/todo/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-z++&i7gx^m*qqq_1(xjqo=7%gg)^&fcq6fa3gen+10(zn5756z'
+SECRET_KEY = 'django-insecure-testonly-not-a-real-secret-key-replace-me'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False


### PR DESCRIPTION
## Fix SAST/secret findings: GitHub Actions permissions and Django SECRET_KEY

Addresses `PLAT-16976`, `PLAT-16740`, and `PLAT-16763`.

### GitHub Actions (`maze-runner.yml`, `python-package.yml`)
- Added `permissions: contents: read` at top level
- Added `permissions: contents: none` on `test-done` job
- Follows least-privilege principle for workflow tokens

### Django `SECRET_KEY` — example files (3 files)
- Replaced hardcoded keys with `os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-testonly')`
- Falls back to a clearly marked insecure test key

### Django `SECRET_KEY` — test fixtures (5 files)
- Replaced random-looking keys with `django-insecure-testonly`
- No env var needed for test fixtures

### Changelog
- Added PR reference for `level` parameter enhancement