### PR TITLE
SCA fixes for PLAT-17181

### DIFF
--- a/example/celery+django/requirements.txt
+++ b/example/celery+django/requirements.txt
@@ -8,4 +8,4 @@ markdown==3.4.1
 pytz==2022.5
 redis==4.3.4
 vine==5.0.0
-WebOb==1.8.7
+WebOb==1.8.11

--- a/example/flask/requirements.txt
+++ b/example/flask/requirements.txt
@@ -5,5 +5,5 @@ Flask==1.1.2
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
-WebOb==1.8.6
+WebOb==1.8.11
 Werkzeug==1.0.1


### PR DESCRIPTION
## Summary
 
Updates vulnerable WebOb versions in example application dependencies:
 
- `requirements.txt`: `WebOb` `1.8.7` -> `1.8.11`
- `requirements.txt`: `WebOb` `1.8.6` -> `1.8.11`
 
WebOb `1.8.11` includes the security fix that uses WebOb's RFC 3986-compliant URL joining and ensures `_HTTPMove` subclasses use the sanitized location handling path.
 
## Validation
 
- Resolved both complete requirements files with pip using `--dry-run --ignore-installed`.
- Confirmed `WebOb==1.8.11` is compatible with the existing pinned Celery/Django and Flask dependency sets.
- Ran `git diff --check`.
 
## Security
 
Remediates the WebOb Dependabot alerts associated with PRs #150 and #151.